### PR TITLE
Update eip-1559-gas-price-provider.ts

### DIFF
--- a/src/providers/eip-1559-gas-price-provider.ts
+++ b/src/providers/eip-1559-gas-price-provider.ts
@@ -33,7 +33,7 @@ export class EIP1559GasPriceProvider extends IGasPriceProvider {
 
   public async getGasPrice(): Promise<GasPrice> {
     const feeHistoryRaw = (await this.provider.send('eth_feeHistory', [
-      this.blocksToConsider.toString(),
+      this.blocksToConsider,
       'latest',
       [this.priorityFeePercentile],
     ])) as RawFeeHistoryResponse;


### PR DESCRIPTION
this.blocksToConsider needs to be an int, not quoted string in the eth_feeHistory RPC call - I get a {"code": -32602, "message": "Invalid method parameter(s)."} without this

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
32602 - Invalid method parameter(s)

- **What is the new behavior (if this is a feature change)?**
Works as expected

- **Other information**:
JSON_RPC_PROVIDER is Alchemy, Node.js v16.9.1