### PR TITLE
fix: move prettier-plugin-organize-imports and sinon to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "1.45.1",
+  "version": "1.45.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "1.45.0",
+      "version": "1.45.2",
       "license": "GPL",
       "dependencies": {
         "@bitauth/libauth": "^1.17.1",
@@ -39,8 +39,6 @@
         "lodash": "^4.17.21",
         "mnemonist": "^0.38.3",
         "node-cache": "^5.1.2",
-        "prettier-plugin-organize-imports": "^2.1.0",
-        "sinon": "^11.1.2",
         "stats-lite": "^2.2.0",
         "tslib": "^1.14.1"
       },
@@ -63,6 +61,8 @@
         "npm-run-all": "^4.1.5",
         "open-cli": "^6.0.1",
         "prettier": "^2.1.1",
+        "prettier-plugin-organize-imports": "^2.1.0",
+        "sinon": "^11.1.2",
         "standard-version": "^9.0.0",
         "ts-jest": "^27.0.4",
         "ts-node": "^9.0.0",
@@ -2348,6 +2348,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
       "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -2357,7 +2358,8 @@
     "node_modules/@sinonjs/text-encoding": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "node_modules/@solidity-parser/parser": {
       "version": "0.11.1",
@@ -9989,7 +9991,8 @@
     "node_modules/just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
     },
     "node_modules/keccak": {
       "version": "3.0.1",
@@ -10237,7 +10240,8 @@
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -11373,6 +11377,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
       "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/fake-timers": "^7.0.4",
@@ -12133,6 +12138,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -12140,7 +12146,8 @@
     "node_modules/path-to-regexp/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -12281,6 +12288,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -12292,6 +12300,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.2.0.tgz",
       "integrity": "sha512-2WM3moc/cAPCCsSneYhaL4+mMws0Bypbxz+98wuRyaA7GMokhOECVkQCG7l2hcH+9/4d5NsgZs9yktfwDy4r7A==",
+      "dev": true,
       "peerDependencies": {
         "prettier": ">=2.0",
         "typescript": ">=2.9"
@@ -12929,6 +12938,7 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
       "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": "^7.1.2",
@@ -12946,6 +12956,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -16317,7 +16328,6 @@
       "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
       "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
       "requires": {
-        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.3.3",
         "@oclif/parser": "^3.8.3",
         "@oclif/plugin-help": "^3",
@@ -16639,6 +16649,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
       "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -16648,7 +16659,8 @@
     "@sinonjs/text-encoding": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "@solidity-parser/parser": {
       "version": "0.11.1",
@@ -22493,7 +22505,8 @@
     "just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
     },
     "keccak": {
       "version": "3.0.1",
@@ -22691,7 +22704,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -23582,6 +23596,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
       "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/fake-timers": "^7.0.4",
@@ -24159,6 +24174,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
       "requires": {
         "isarray": "0.0.1"
       },
@@ -24166,7 +24182,8 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         }
       }
     },
@@ -24262,12 +24279,14 @@
     "prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ=="
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "dev": true
     },
     "prettier-plugin-organize-imports": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.2.0.tgz",
       "integrity": "sha512-2WM3moc/cAPCCsSneYhaL4+mMws0Bypbxz+98wuRyaA7GMokhOECVkQCG7l2hcH+9/4d5NsgZs9yktfwDy4r7A==",
+      "dev": true,
       "requires": {}
     },
     "pretty-format": {
@@ -24736,6 +24755,7 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
       "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": "^7.1.2",
@@ -24748,7 +24768,8 @@
         "diff": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -105,3 +105,4 @@
     "commands": "./cli/commands"
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "lodash": "^4.17.21",
     "mnemonist": "^0.38.3",
     "node-cache": "^5.1.2",
-    "prettier-plugin-organize-imports": "^2.1.0",
-    "sinon": "^11.1.2",
     "stats-lite": "^2.2.0",
     "tslib": "^1.14.1"
   },
@@ -83,6 +81,8 @@
     "npm-run-all": "^4.1.5",
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
+    "prettier-plugin-organize-imports": "^2.1.0",
+    "sinon": "^11.1.2",
     "standard-version": "^9.0.0",
     "ts-jest": "^27.0.4",
     "ts-node": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "1.45.1",
+  "version": "1.45.2",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** bug fix

- **What is the current behavior?** `prettier-plugin-organize-imports` is automatically added to every project with a dependency on `smart-order-router`

- **What is the new behavior (if this is a feature change)?** moved to dev dependency
- 
- **Other information**:
