### PR TITLE
adding v2 and v3 filtering

### DIFF
--- a/src/providers/v2/subgraph-provider.ts
+++ b/src/providers/v2/subgraph-provider.ts
@@ -9,11 +9,9 @@ import { ChainId } from '../../util/chains';
 export interface V2SubgraphPool {
   id: string;
   token0: {
-    symbol: string;
     id: string;
   };
   token1: {
-    symbol: string;
     id: string;
   };
   totalSupply: number;
@@ -179,17 +177,16 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
     );
 
     log.info(`Got ${pools.length} pools from the subgraph.`);
-
-    const poolsSanitized: V2SubgraphPool[] = _.map(pools, (pool) => {
+    // filter pools that have liquidity less than threshold
+    const threshold = 0.1
+    const poolsSanitized: V2SubgraphPool[] = pools.filter((pool) => parseFloat(pool.reserveETH) > threshold).map((pool) => {
       return {
         ...pool,
         id: pool.id.toLowerCase(),
         token0: {
-          ...pool.token0,
           id: pool.token0.id.toLowerCase(),
         },
         token1: {
-          ...pool.token1,
           id: pool.token1.id.toLowerCase(),
         },
         totalSupply: parseFloat(pool.totalSupply),

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -119,7 +119,7 @@ export async function getCandidatePools({
   }
 
   const subgraphPoolsSorted = _(filteredPools)
-    .sortBy((tokenListPool) => -tokenListPool.totalValueLockedUSDFloat)
+    .sortBy((tokenListPool) => -tokenListPool.tvlUSD)
     .value();
 
   log.info(`After filtering blocked tokens went from ${allPools.length} to ${subgraphPoolsSorted.length}.`)
@@ -145,11 +145,11 @@ export async function getCandidatePools({
               subgraphPool.token0.id == tokenInAddress)
           );
         })
-        .sortBy((tokenListPool) => -tokenListPool.totalValueLockedUSDFloat)
+        .sortBy((tokenListPool) => -tokenListPool.tvlUSD)
         .slice(0, topNWithEachBaseToken)
         .value();
     })
-    .sortBy((tokenListPool) => -tokenListPool.totalValueLockedUSDFloat)
+    .sortBy((tokenListPool) => -tokenListPool.tvlUSD)
     .slice(0, topNWithBaseToken)
     .value();
 
@@ -165,11 +165,11 @@ export async function getCandidatePools({
               subgraphPool.token0.id == tokenOutAddress)
           );
         })
-        .sortBy((tokenListPool) => -tokenListPool.totalValueLockedUSDFloat)
+        .sortBy((tokenListPool) => -tokenListPool.tvlUSD)
         .slice(0, topNWithEachBaseToken)
         .value();
     })
-    .sortBy((tokenListPool) => -tokenListPool.totalValueLockedUSDFloat)
+    .sortBy((tokenListPool) => -tokenListPool.tvlUSD)
     .slice(0, topNWithBaseToken)
     .value();
 
@@ -215,10 +215,10 @@ export async function getCandidatePools({
           );
         } else {
           return (
-            (subgraphPool.token0.symbol == wethAddress &&
-              subgraphPool.token1.symbol == tokenIn.symbol) ||
-            (subgraphPool.token1.symbol == wethAddress &&
-              subgraphPool.token0.symbol == tokenIn.symbol)
+            (subgraphPool.token0.id == wethAddress &&
+              subgraphPool.token1.id == tokenInAddress) ||
+            (subgraphPool.token1.id == wethAddress &&
+              subgraphPool.token0.id == tokenInAddress)
           );
         }
       })
@@ -282,7 +282,7 @@ export async function getCandidatePools({
         .value();
     })
     .uniqBy((pool) => pool.id)
-    .sortBy((tokenListPool) => -tokenListPool.totalValueLockedUSDFloat)
+    .sortBy((tokenListPool) => -tokenListPool.tvlUSD)
     .slice(0, topNSecondHop)
     .value();
 
@@ -307,7 +307,7 @@ export async function getCandidatePools({
         .value();
     })
     .uniqBy((pool) => pool.id)
-    .sortBy((tokenListPool) => -tokenListPool.totalValueLockedUSDFloat)
+    .sortBy((tokenListPool) => -tokenListPool.tvlUSD)
     .slice(0, topNSecondHop)
     .value();
 
@@ -368,10 +368,10 @@ export async function getCandidatePools({
 
     if (!tokenA || !tokenB) {
       log.info(
-        `Dropping candidate pool for ${subgraphPool.token0.symbol}/${
-          subgraphPool.token1.symbol
+        `Dropping candidate pool for ${subgraphPool.token0.id}/${
+          subgraphPool.token1.id
         }/${fee} because ${
-          tokenA ? subgraphPool.token1.symbol : subgraphPool.token0.symbol
+          tokenA ? subgraphPool.token1.id : subgraphPool.token0.id
         } not found by token provider`
       );
       return undefined;


### PR DESCRIPTION
- reducing pool data size for v2 and v3 by filtering out low liquidity pools
- old behavior: returned raw data from subgraph
- new behavior: cleans up param names and excludes relatively illiquid pools from being cached
