### PR TITLE
chore: update providers import from @ethersproject

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@bitauth/libauth": "^1.17.1",
     "@ethersproject/bignumber": "^5.1.1",
+    "@ethersproject/providers": "5.5.3",
     "@oclif/command": "^1.8.0",
     "@oclif/errors": "^1.3.5",
     "@types/async-retry": "^1.4.2",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -10,7 +10,8 @@ import {
   SqrtPriceMath,
   TickMath,
 } from '@uniswap/v3-sdk';
-import { BigNumber, providers } from 'ethers';
+import * as providers from '@ethersproject/providers'
+import { BigNumber } from 'ethers';
 import JSBI from 'jsbi';
 import _ from 'lodash';
 import NodeCache from 'node-cache';

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1,3 +1,4 @@
+import * as providers from '@ethersproject/providers';
 import DEFAULT_TOKEN_LIST from '@uniswap/default-token-list';
 import { Protocol, SwapRouter, Trade } from '@uniswap/router-sdk';
 import { Currency, Fraction, Token, TradeType } from '@uniswap/sdk-core';
@@ -10,7 +11,6 @@ import {
   SqrtPriceMath,
   TickMath,
 } from '@uniswap/v3-sdk';
-import * as providers from '@ethersproject/providers'
 import { BigNumber } from 'ethers';
 import JSBI from 'jsbi';
 import _ from 'lodash';


### PR DESCRIPTION
- This PR updates the imports for types on `AlphaRouterParams`

- currently, `providers` is imported from ethers

- in this change, we import `providers` from `'@ethersproject/providers'`

- Currenlty in other applications that use the SOR package, dependencies need to be built to create a local SOR. However, some bundles like widgets can not directly import from `ethers`, so updating this dependency would allow for both to work together 
