### PR TITLE
Band-aid fix to resolve validator issues causing active error on interface

### DIFF
--- a/src/providers/token-validator-provider.ts
+++ b/src/providers/token-validator-provider.ts
@@ -18,7 +18,7 @@ export interface TokenValidationResults {
 
 const TOKEN_VALIDATOR_ADDRESS = '0xb5ee1690b7dcc7859771148d0889be838fe108e0';
 const AMOUNT_TO_FLASH_BORROW = '1000';
-const GAS_LIMIT_PER_VALIDATE = 300_000;
+const GAS_LIMIT_PER_VALIDATE = 600_000;
 
 /**
  * Provider for getting token data.

--- a/src/providers/token-validator-provider.ts
+++ b/src/providers/token-validator-provider.ts
@@ -18,7 +18,7 @@ export interface TokenValidationResults {
 
 const TOKEN_VALIDATOR_ADDRESS = '0xb5ee1690b7dcc7859771148d0889be838fe108e0';
 const AMOUNT_TO_FLASH_BORROW = '1000';
-const GAS_LIMIT_PER_VALIDATE = 600_000;
+const GAS_LIMIT_PER_VALIDATE = 400_000;
 
 /**
  * Provider for getting token data.


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 
Band-aid fix to the gas limit for verification of a pool swap, to allow shinja (a FOT token) to be successfully validated as a potential hop. 

- **What is the current behavior?** (You can also link to an open issue here)
#66 causes the entire pool to be discarded instead of just the pair impacted

- **What is the new behavior (if this is a feature change)?**
Uses 400k gas instead of 300k to validate the swap.

- **Other information**:
This is an emergency fix to resolve the issue being had by multiple tokens. A proper fix to the validation logic will be required.