### PR TITLE
Resolve `eth_feeHistory` -> `blockCount` argument problem

### DIFF
--- a/src/providers/eip-1559-gas-price-provider.ts
+++ b/src/providers/eip-1559-gas-price-provider.ts
@@ -42,7 +42,7 @@ export class EIP1559GasPriceProvider extends IGasPriceProvider {
 
   public async getGasPrice(): Promise<GasPrice> {
     const feeHistoryRaw = (await this.provider.send('eth_feeHistory', [
-      this.blocksToConsider,
+      '0x' + this.blocksToConsider.toString(16),
       'latest',
       [this.priorityFeePercentile],
     ])) as RawFeeHistoryResponse;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
https://github.com/Uniswap/smart-order-router/issues/68

The issue is that the first argument to `eth_feeHistory` (`blockCount`) must be a hex-encoded integer. In the code it is just a `number`. Regardless, it appears to work for most nodes; it however fails in Hardhat (specifically mainnet fork mode). In these cases it will fail with the following error:
`Errors encountered in param 0: Invalid value 4 supplied to : QUANTITY`
in the `getGasPrice()` call.

- **What is the new behavior (if this is a feature change)?**
Works across all nodes due to correctly formatting argument. 

- **Other information**:
-