### PR TITLE
fix: tree-shake mnemonist

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,14 @@
             "message": "Please import from '@ethersproject/module' directly to support tree-shaking."
           }
         ]
+      },
+      {
+        "paths": [
+          {
+            "name": "mnemonist",
+            "message": "Please import from 'mnemonist/module' directly to support tree-shaking."
+          }
+        ]
       }
     ]
   }

--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -5,7 +5,6 @@ import JSBI from 'jsbi';
 import _ from 'lodash';
 import FixedReverseHeap from 'mnemonist/fixed-reverse-heap';
 import Queue from 'mnemonist/queue';
-
 import { ChainId, HAS_L1_FEE } from '../../../util';
 import { CurrencyAmount } from '../../../util/amounts';
 import { log } from '../../../util/log';
@@ -13,7 +12,6 @@ import { metric, MetricLoggerUnit } from '../../../util/metric';
 import { routeAmountsToString, routeToString } from '../../../util/routes';
 import { AlphaRouterConfig } from '../alpha-router';
 import { IGasModel, L1ToL2GasCosts, usdGasTokensByChain } from '../gas-models';
-
 import {
   RouteWithValidQuote,
   V3RouteWithValidQuote,

--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -3,7 +3,9 @@ import { Protocol } from '@uniswap/router-sdk';
 import { TradeType } from '@uniswap/sdk-core';
 import JSBI from 'jsbi';
 import _ from 'lodash';
-import { FixedReverseHeap, Queue } from 'mnemonist';
+import FixedReverseHeap from 'mnemonist/fixed-reverse-heap';
+import Queue from 'mnemonist/queue';
+
 import { ChainId, HAS_L1_FEE } from '../../../util';
 import { CurrencyAmount } from '../../../util/amounts';
 import { log } from '../../../util/log';
@@ -11,6 +13,7 @@ import { metric, MetricLoggerUnit } from '../../../util/metric';
 import { routeAmountsToString, routeToString } from '../../../util/routes';
 import { AlphaRouterConfig } from '../alpha-router';
 import { IGasModel, L1ToL2GasCosts, usdGasTokensByChain } from '../gas-models';
+
 import {
   RouteWithValidQuote,
   V3RouteWithValidQuote,


### PR DESCRIPTION
Import modules for mnemonist to avoid importing the entire library. This should offer significant size savings (~15kb gzipped).