### PR TITLE
fix: split tsconfig to reduce package size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [2.5.25](https://github.com/Uniswap/smart-order-router/compare/v2.5.24...v2.5.25) (2022-03-29)
 
-
 ### Bug Fixes
 
-* retain ethers as dep for factories ([#84](https://github.com/Uniswap/smart-order-router/issues/84)) ([a24b0b2](https://github.com/Uniswap/smart-order-router/commit/a24b0b2d6116fef9a7796cb5e090e8d0f2c956b0))
+- retain ethers as dep for factories ([#84](https://github.com/Uniswap/smart-order-router/issues/84)) ([a24b0b2](https://github.com/Uniswap/smart-order-router/commit/a24b0b2d6116fef9a7796cb5e090e8d0f2c956b0))
 
 ### [2.5.24](https://github.com/Uniswap/smart-order-router/compare/v2.5.23...v2.5.24) (2022-03-28)
 

--- a/bin/cli
+++ b/bin/cli
@@ -1,16 +1,12 @@
 #!/usr/bin/env node
 
-const fs = require("fs");
 const path = require("path");
-const project = path.join(__dirname, "../tsconfig.json");
-const dev = fs.existsSync(project);
+const project = path.join(__dirname, "../tsconfig.oclif.json");
 
-if (dev) {
-  require("ts-node").register({
-    project,
-    compilerOptions: { preserveSymlinks: true },
-  });
-}
+require("ts-node").register({
+  project,
+  compilerOptions: { preserveSymlinks: true },
+});
 
 require('@oclif/command').run()
   .catch(require('@oclif/errors/handle'))

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "typescript": "^4.2.2"
   },
   "files": [
-    "build/main",
-    "build/module",
+    "build/main/src",
+    "build/module/src",
     "!**/*.spec.*",
     "!**/*.json",
     "CHANGELOG.md",

--- a/src/providers/swap-router-provider.ts
+++ b/src/providers/swap-router-provider.ts
@@ -1,6 +1,6 @@
 import { ApprovalTypes } from '@uniswap/router-sdk';
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core';
-import { SwapRouter02__factory } from '../types/other';
+import { SwapRouter02__factory } from '../types/other/factories/SwapRouter02__factory';
 import { log } from '../util';
 import { IMulticallProvider } from './multicall-provider';
 

--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -1,6 +1,6 @@
 import { Token } from '@uniswap/sdk-core';
 import _ from 'lodash';
-import { IERC20Metadata__factory } from '../types/v3';
+import { IERC20Metadata__factory } from '../types/v3/factories/IERC20Metadata__factory';
 import { ChainId, log } from '../util';
 import { IMulticallProvider } from './multicall-provider';
 import { ProviderConfig } from './provider';

--- a/src/providers/v2/pool-provider.ts
+++ b/src/providers/v2/pool-provider.ts
@@ -3,7 +3,7 @@ import { Token } from '@uniswap/sdk-core';
 import { Pair } from '@uniswap/v2-sdk';
 import retry, { Options as RetryOptions } from 'async-retry';
 import _ from 'lodash';
-import { IUniswapV2Pair__factory } from '../../types/v2';
+import { IUniswapV2Pair__factory } from '../../types/v2/factories/IUniswapV2Pair__factory';
 import { ChainId, CurrencyAmount } from '../../util';
 import { log } from '../../util/log';
 import { poolToString } from '../../util/routes';

--- a/src/providers/v3/pool-provider.ts
+++ b/src/providers/v3/pool-provider.ts
@@ -3,7 +3,7 @@ import { Token } from '@uniswap/sdk-core';
 import { computePoolAddress, FeeAmount, Pool } from '@uniswap/v3-sdk';
 import retry, { Options as RetryOptions } from 'async-retry';
 import _ from 'lodash';
-import { IUniswapV3PoolState__factory } from '../../types/v3';
+import { IUniswapV3PoolState__factory } from '../../types/v3/factories/IUniswapV3PoolState__factory';
 import { ChainId } from '../../util';
 import { V3_CORE_FACTORY_ADDRESS } from '../../util/addresses';
 import { log } from '../../util/log';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,7 @@
     // "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
 
     "lib": ["es2017", "dom"],
-    "types": ["node", "jest"],
+    "types": ["node", "jest"]
   },
   "include": ["src/index.ts"],
   "compileOnSave": false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,9 +39,7 @@
 
     "lib": ["es2017", "dom"],
     "types": ["node", "jest"],
-    "typeRoots": ["node_modules/@types", "src/types"]
   },
-  "include": ["src/**/*.ts", "cli/**/*.ts"],
-  "exclude": ["node_modules/**"],
+  "include": ["src/index.ts"],
   "compileOnSave": false
 }

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -4,6 +4,5 @@
     "target": "es2018",
     "outDir": "build/module",
     "module": "esnext"
-  },
-  "exclude": ["node_modules/**"]
+  }
 }

--- a/tsconfig.oclif.json
+++ b/tsconfig.oclif.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "include": ["cli/**/*.ts"]
+}


### PR DESCRIPTION
Reduces the exported package size from 3.7M to 1.4M

- Imports types explicitly to allow for tree-shaking, instead of from barrel files
  - _Reduces package size from 3.7M to 1.5M_
- Splits the cli tsconfig to avoid including those files in the exported package (cli is now dev-only)
  - Updates the cli file to always use ts-node
  - _Reduces package size from 1.5M to 1.4M_