### PR TITLE
Support KTON token, make KTON swappable

### DIFF
--- a/src/providers/caching-token-provider.ts
+++ b/src/providers/caching-token-provider.ts
@@ -53,6 +53,13 @@ export const CACHE_SEED_TOKENS: {
       'RING',
       'RING'
     ),
+    KTON: new Token(
+      ChainId.MAINNET,
+      '0x9F284E1337A815fe77D2Ff4aE46544645B20c5ff',
+      18,
+      'KTON',
+      'KTON'
+    ),
   },
   [ChainId.RINKEBY]: {
     WETH: WRAPPED_NATIVE_CURRENCY[ChainId.RINKEBY]!,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    KTON token stores its symbol as bytes32, therefore can not be fetched on-chain using token providers.

- **What is the current behavior?** (You can also link to an open issue here)
  #47 
- **What is the new behavior (if this is a feature change)?**
 
- **Other information**:
local test
```shell
~ ./bin/cli quote --tokenIn 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 --tokenOut 0x9F284E1337A815fe77D2Ff4aE46544645B20c5ff --amount 1000 --exactIn --recipient 0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B --protocols v2,v3
Best Route:
[V2] 100.00% = WETH -- [0x2D97755d2d18a77eF9EAD977DD0c3cA7C840D5FC] --> KTON
        Raw Quote Exact In:
                3425.21
        Gas Adjusted Quote In:
                3424.40

Gas Used Quote Token: 0.807968
Gas Used USD: 25.393718
Calldata: 0x5ae401dc000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e4472b43f300000000000000000000000000000000000000000000003635c9adc5dea000000000000000000000000000000000000000000000000000b996a0b2f50241cb8c0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000ab5801a7d398351b8be11c439e05c5b3259aec9b0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000009f284e1337a815fe77d2ff4ae46544645b20c5ff00000000000000000000000000000000000000000000000000000000
Value: 0x00

  blockNumber: "14542792"
  estimatedGasUsed: "115000"
  gasPriceWei: "67628575193"
Total ticks crossed: 1

```