### PR TITLE
fix error: failed to resolve entry for package @uniswap/smart-order-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
-  "module": "build/module/index.js",
+  "module": "build/main/src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/Uniswap/smart-order-router.git"


### PR DESCRIPTION
The following PR fixes the error I encountered when using to use smart-order-router with my ViteJS application.

Simply speaking the 'build/module' path does not exist as per tsconfig.json configuration therefore has to be changed to 'build/main'.

![image](https://user-images.githubusercontent.com/25374117/168874937-4d63d23e-4894-4693-9284-e6a16e8a211f.png)
![image](https://user-images.githubusercontent.com/25374117/168874996-92a9f2d9-e5e5-4032-9eef-b33b9ca71b50.png)