### PR TITLE
Update Optimism Graph link

### DIFF
--- a/src/providers/v3/subgraph-provider.ts
+++ b/src/providers/v3/subgraph-provider.ts
@@ -50,7 +50,7 @@ const SUBGRAPH_URL_BY_CHAIN: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]:
     'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-rinkeby',
   [ChainId.OPTIMISM]:
-    'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-optmism-regen',
+    'https://api.thegraph.com/subgraphs/name/ianlapham/optimism-post-regenesis',
   [ChainId.ARBITRUM_ONE]:
     'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-minimal',
   [ChainId.POLYGON]:


### PR DESCRIPTION
Found this to be the proper Optimism graph link. info site uses this one, I'll be honest couldn't get it to build in my computer, but the link should be updated to the new one.
same link to the one just merged in uniswap/interface that I authored.