### PR TITLE
Add reserveUSD to graphql query for v2 subgraph

### DIFF
--- a/src/providers/v2/static-subgraph-provider.ts
+++ b/src/providers/v2/static-subgraph-provider.ts
@@ -119,6 +119,7 @@ export class StaticV2SubgraphProvider implements IV2SubgraphProvider {
           },
           supply: 100,
           reserve: 100,
+          reserveUSD: 100,
         };
       })
       .compact()

--- a/src/providers/v2/subgraph-provider.ts
+++ b/src/providers/v2/subgraph-provider.ts
@@ -18,6 +18,7 @@ export interface V2SubgraphPool {
   };
   supply: number;
   reserve: number;
+  reserveUSD: number;
 }
 
 type RawV2SubgraphPool = {
@@ -33,6 +34,7 @@ type RawV2SubgraphPool = {
   totalSupply: string;
   reserveETH: string;
   trackedReserveETH: string;
+  reserveUSD: string;
 };
 
 const SUBGRAPH_URL_BY_CHAIN: { [chainId in ChainId]?: string } = {
@@ -98,6 +100,7 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
           totalSupply
           reserveETH
           trackedReserveETH
+          reserveUSD
         }
       }
     `;
@@ -219,6 +222,7 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
           },
           supply: parseFloat(pool.totalSupply),
           reserve: parseFloat(pool.trackedReserveETH),
+          reserveUSD: parseFloat(pool.reserveUSD),
         };
       });
 

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -718,6 +718,7 @@ export async function getV2CandidatePools({
         },
         supply: 10000, // Not used. Set to arbitrary number.
         reserve: 10000, // Not used. Set to arbitrary number.
+        reserveUSD: 10000, // Not used. Set to arbitrary number.
       },
     ];
   }

--- a/test/test-util/mock-data.ts
+++ b/test/test-util/mock-data.ts
@@ -210,6 +210,7 @@ export const pairToV2SubgraphPool = (
     },
     reserve: 1000,
     supply: 100,
+    reserveUSD: 100,
   };
 };
 


### PR DESCRIPTION
Getting the `reserveUSD` data point returned from the V2 subgraph will allow us to add heuristics for mixed Route selection. Namely, we can compare this USD value to the `tvlUSD` value returned for v3 pools.

Going to land this and update routing-api to begin saving the new information into cloudflare.