### PR TITLE
Remove reserveETH from query and all types

### DIFF
--- a/src/providers/v2/subgraph-provider.ts
+++ b/src/providers/v2/subgraph-provider.ts
@@ -32,7 +32,6 @@ type RawV2SubgraphPool = {
     id: string;
   };
   totalSupply: string;
-  reserveETH: string;
   trackedReserveETH: string;
   reserveUSD: string;
 };
@@ -98,7 +97,6 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
           token0 { id, symbol }
           token1 { id, symbol }
           totalSupply
-          reserveETH
           trackedReserveETH
           reserveUSD
         }


### PR DESCRIPTION
We don't use the returned value `reserveETH` from our v2 subgraph query so hoping that removing this piece of data returned will shorten the request time.