### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "sinon": "^11.1.2",
     "standard-version": "^9.0.0",
     "ts-jest": "^27.0.4",
-    "ts-node": "^9.0.0",
+    "ts-node": "^10.8.1",
     "typechain": "^5.0.0",
     "typescript": "^4.2.2"
   },


### PR DESCRIPTION
changed ts-node version to 10.8.1

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
CLI was broken due to the ts-node version.

- **What is the current behavior?** (You can also link to an open issue here)
By updating the ts-node, the issue was fixed.

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
Log : 
./bin/cli quote --tokenIn 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 --tokenOut 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984 --amount 1000 --exactIn --recipient 0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B --protocols v2,v3
(node:322343) Error Plugin: @uniswap/smart-order-router: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
module: @oclif/config@1.18.3
task: toCached
plugin: @uniswap/smart-order-router
root: /root/Projects/v3-test-deploy/smart-order-router
See more details with DEBUG=*
(Use `node --trace-warnings ...` to show where the warning was created)
(node:322343) Error Plugin: @uniswap/smart-order-router: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
module: @oclif/config@1.18.3
task: toCached
plugin: @uniswap/smart-order-router
root: /root/Projects/v3-test-deploy/smart-order-router
See more details with DEBUG=*
 ›   Error: command quote not found
