### PR TITLE
feat -> feat Add protocol flag to SOR version of SDK routes

### DIFF
--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { BaseProvider } from '@ethersproject/providers';
-import { encodeMixedRouteToPath } from '@uniswap/router-sdk';
+import { encodeMixedRouteToPath, Protocol } from '@uniswap/router-sdk';
 import { encodeRouteToPath } from '@uniswap/v3-sdk';
 import retry, { Options as RetryOptions } from 'async-retry';
 import _ from 'lodash';
@@ -346,7 +346,9 @@ export class OnChainQuoteProvider<TRoute extends V3Route | MixedRoute>
     routesWithQuotes: RouteWithQuotes<TRoute>[];
     blockNumber: BigNumber;
   }> {
-    const isMixedRoutes = routes.every((route) => route instanceof MixedRoute);
+    const isMixedRoutes = routes.every(
+      (route) => route.protocol === Protocol.MIXED
+    );
 
     this.validateRoutes(routes, functionName, isMixedRoutes);
 
@@ -365,7 +367,7 @@ export class OnChainQuoteProvider<TRoute extends V3Route | MixedRoute>
     const inputs: [string, string][] = _(routes)
       .flatMap((route) => {
         const encodedRoute =
-          route instanceof V3Route
+          route.protocol === Protocol.V3
             ? encodeRouteToPath(
                 route,
                 functionName == 'quoteExactOutput' // For exactOut must be true to ensure the routes are reversed.

--- a/src/routers/router.ts
+++ b/src/routers/router.ts
@@ -2,6 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 import {
   CondensedAddLiquidityOptions,
   MixedRouteSDK,
+  Protocol,
   Trade,
 } from '@uniswap/router-sdk';
 import {
@@ -23,9 +24,15 @@ import { CurrencyAmount } from '../util/amounts';
 
 import { RouteWithValidQuote } from './alpha-router';
 
-export class V3Route extends V3RouteRaw<Token, Token> {}
-export class V2Route extends V2RouteRaw<Token, Token> {}
-export class MixedRoute extends MixedRouteSDK<Token, Token> {}
+export class V3Route extends V3RouteRaw<Token, Token> {
+  protocol: Protocol.V3 = Protocol.V3;
+}
+export class V2Route extends V2RouteRaw<Token, Token> {
+  protocol: Protocol.V2 = Protocol.V2;
+}
+export class MixedRoute extends MixedRouteSDK<Token, Token> {
+  protocol: Protocol.MIXED = Protocol.MIXED;
+}
 
 export type SwapRoute = {
   /**

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -13,13 +13,13 @@ export const routeToString = (
 ): string => {
   const routeStr = [];
   const tokens =
-    route instanceof V3Route
+    route.protocol === Protocol.V3
       ? route.tokenPath
       : // MixedRoute and V2Route have path
         route.path;
   const tokenPath = _.map(tokens, (token) => `${token.symbol}`);
   const pools =
-    route instanceof V3Route || route instanceof MixedRoute
+    route.protocol === Protocol.V3 || route.protocol === Protocol.MIXED
       ? route.pools
       : route.pairs;
   const poolFeePath = _.map(pools, (pool) => {


### PR DESCRIPTION
Few notes:
- Sara initially suggested that we use the wrapped `IRoute` instead of the SDK routes in SOR to get access to the `protocol` key and the abstracted `pools` and `path` keys.
- I tried that out, importing the `IRoute` classes and wrapping it around the new SDK routes that we create, but it added a lot of complexity to the code that I didn't really think was worth it. Namely, in computing routes and the tests.
- So since the initial goal was to remove the `instanceOf` checks against `V3Route` and `MixedRoute`, I added a protocol key to each class in SOR that we can use to differentiate with.

However I think there's merit in porting over the SOR to use the `IRoutes` entirely from router-sdk, but it's a change that I think can happen after launch