### PR TITLE
feat->feat Refactor on chain quote provider

### DIFF
--- a/cli/base-command.ts
+++ b/cli/base-command.ts
@@ -36,7 +36,6 @@ import {
   TokenProvider,
   UniswapMulticallProvider,
   V3PoolProvider,
-  V3Route,
   V3RouteWithValidQuote,
 } from '../src';
 import { LegacyGasPriceProvider } from '../src/providers/legacy-gas-price-provider';
@@ -254,7 +253,7 @@ export abstract class BaseCommand extends Command {
         chainId,
         multicall2Provider,
         poolProvider: new V3PoolProvider(chainId, multicall2Provider),
-        quoteProvider: new OnChainQuoteProvider<V3Route>(
+        quoteProvider: new OnChainQuoteProvider(
           chainId,
           provider,
           multicall2Provider

--- a/cli/commands/quote.ts
+++ b/cli/commands/quote.ts
@@ -33,7 +33,7 @@ export class Quote extends BaseCommand {
     exactOut: flags.boolean({ required: false }),
     protocols: flags.string({ required: false }),
     forceCrossProtocol: flags.boolean({ required: false, default: false }),
-    disableMixedRoutesConsideration: flags.boolean({
+    forceMixedRoutes: flags.boolean({
       required: false,
       default: false,
     }),
@@ -63,7 +63,7 @@ export class Quote extends BaseCommand {
       chainId: chainIdNumb,
       protocols: protocolsStr,
       forceCrossProtocol,
-      disableMixedRoutesConsideration,
+      forceMixedRoutes,
     } = flags;
 
     if ((exactIn && exactOut) || (!exactIn && !exactOut)) {
@@ -135,7 +135,7 @@ export class Quote extends BaseCommand {
           distributionPercent,
           protocols,
           forceCrossProtocol,
-          disableMixedRoutesConsideration,
+          forceMixedRoutes,
         }
       );
     } else {
@@ -168,7 +168,7 @@ export class Quote extends BaseCommand {
           distributionPercent,
           protocols,
           forceCrossProtocol,
-          disableMixedRoutesConsideration,
+          forceMixedRoutes,
         }
       );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2794,9 +2794,10 @@
       }
     },
     "node_modules/@uniswap/router-sdk": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/router-sdk/-/router-sdk-1.3.0.tgz",
-      "integrity": "sha512-T6kXQFXrAkIHfCCmhyW+0xgUyuFVepL9rlwG9+MjnfVtmGIBssbMzyFKGk5HGQYlk6WQrm630W1j87kdfXpZ/Q==",
+      "version": "1.0.5",
+      "resolved": "file:../router-sdk/uniswap-router-sdk-v1.0.5.tgz",
+      "integrity": "sha512-PTXPZPh8A9Jbuh9E0nhlTZRoR/M0JY3HPSP0uT/oe0yGZAun1b42ziySZciian6DAUmgo80VREqoGqDMmGFfXQ==",
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.5.0",
         "@uniswap/sdk-core": "^3.0.1",

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -356,7 +356,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
       routes.some((route) => route instanceof MixedRoute) ||
       routes.some((route) => route instanceof V2Route);
 
-    /// Validate that there are no incorrect routes / funcitonName combinations
+    /// Validate that there are no incorrect routes / function combinations
     this.validateRoutes(routes, functionName, usesMixedRouteQuoter);
 
     let multicallChunk = this.batchParams.multicallChunk;
@@ -988,7 +988,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
   }
 
   /**
-   * Throw an error for incorrect routes / funcitonName combinations
+   * Throw an error for incorrect routes / function combinations
    * @param routes Any combination of V3, V2, and Mixed routes.
    * @param functionName
    * @param usesMixedRouteQuoter Boolean indicating whether the mixedRouteQuoter needs to be used (for pure V2 and Mixed routes)

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -126,7 +126,7 @@ type QuoteBatchState = QuoteBatchSuccess | QuoteBatchFailed | QuoteBatchPending;
 export interface IOnChainQuoteProvider {
   /**
    * For every route, gets an exactIn quotes for every amount provided.
-   * @notice While passing in V2Routes is supported, we recommend using the V2QuoteProvider to compute off chain quotes for V2 whenever possible
+   * @notice While passing in exactIn V2Routes is supported, we recommend using the V2QuoteProvider to compute off chain quotes for V2 whenever possible
    *
    * @param amountIns The amounts to get quotes for.
    * @param routes The routes to get quotes for.

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -26,7 +26,7 @@ import { UniswapMulticallProvider } from './multicall-uniswap-provider';
 import { ProviderConfig } from './provider';
 
 /**
- * An on chain quote for a V3 or MixedRoute swap.
+ * An on chain quote for a swap.
  */
 export type AmountQuote = {
   amount: CurrencyAmount;
@@ -118,10 +118,10 @@ type QuoteBatchPending = {
 type QuoteBatchState = QuoteBatchSuccess | QuoteBatchFailed | QuoteBatchPending;
 
 /**
- * Provider for getting on chain quotes using either V3 pools or V2 pairs.
+ * Provider for getting on chain quotes using routes containing V3 pools or V2 pools.
  *
  * @export
- * @interface IV3QuoteProvider
+ * @interface IOnChainQuoteProvider
  */
 export interface IOnChainQuoteProvider {
   /**

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -967,7 +967,7 @@ export class AlphaRouter
         );
       }
       /// If protocolsSet is not empty, and we specify mixedRoutes, consider them if the chain has v2 liq
-      /// and tradeType === EXACT_INPUT, OR if we forceMixedRoutes
+      /// and tradeType === EXACT_INPUT
       if (
         protocolsSet.has(Protocol.MIXED) &&
         V2_SUPPORTED.includes(this.chainId) &&

--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -39,6 +39,7 @@ export async function getBestSwapRoute(
 
   const { forceMixedRoutes } = routingConfig;
 
+  /// Like with forceCrossProtocol, we apply that logic here when determining the bestSwapRoute
   if (forceMixedRoutes) {
     log.info(
       {

--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -37,6 +37,23 @@ export async function getBestSwapRoute(
 } | null> {
   const now = Date.now();
 
+  const { forceMixedRoutes } = routingConfig;
+
+  if (forceMixedRoutes) {
+    log.info(
+      {
+        forceMixedRoutes: forceMixedRoutes,
+      },
+      'Forcing mixed routes by filtering out other route types'
+    );
+    routesWithValidQuotes = _.filter(routesWithValidQuotes, (quotes) => {
+      return quotes.protocol === Protocol.MIXED;
+    });
+    if (!routesWithValidQuotes) {
+      return null;
+    }
+  }
+
   // Build a map of percentage of the input to list of valid quotes.
   // Quotes can be null for a variety of reasons (not enough liquidity etc), so we drop them here too.
   const percentToQuotes: { [percent: number]: RouteWithValidQuote[] } = {};

--- a/src/routers/legacy-router/legacy-router.ts
+++ b/src/routers/legacy-router/legacy-router.ts
@@ -30,7 +30,7 @@ export type LegacyRouterParams = {
   chainId: ChainId;
   multicall2Provider: IMulticallProvider;
   poolProvider: IV3PoolProvider;
-  quoteProvider: IOnChainQuoteProvider<V3Route>;
+  quoteProvider: IOnChainQuoteProvider;
   tokenProvider: ITokenProvider;
 };
 
@@ -50,7 +50,7 @@ export class LegacyRouter implements IRouter<LegacyRoutingConfig> {
   protected chainId: ChainId;
   protected multicall2Provider: IMulticallProvider;
   protected poolProvider: IV3PoolProvider;
-  protected quoteProvider: IOnChainQuoteProvider<V3Route>;
+  protected quoteProvider: IOnChainQuoteProvider;
   protected tokenProvider: ITokenProvider;
 
   constructor({
@@ -203,9 +203,13 @@ export class LegacyRouter implements IRouter<LegacyRoutingConfig> {
     routingConfig?: LegacyRoutingConfig
   ): Promise<V3RouteWithValidQuote | null> {
     const { routesWithQuotes: quotesRaw } =
-      await this.quoteProvider.getQuotesManyExactIn([amountIn], routes, {
-        blockNumber: routingConfig?.blockNumber,
-      });
+      await this.quoteProvider.getQuotesManyExactIn<V3Route>(
+        [amountIn],
+        routes,
+        {
+          blockNumber: routingConfig?.blockNumber,
+        }
+      );
 
     const quotes100Percent = _.map(
       quotesRaw,
@@ -231,9 +235,13 @@ export class LegacyRouter implements IRouter<LegacyRoutingConfig> {
     routingConfig?: LegacyRoutingConfig
   ): Promise<V3RouteWithValidQuote | null> {
     const { routesWithQuotes: quotesRaw } =
-      await this.quoteProvider.getQuotesManyExactOut([amountOut], routes, {
-        blockNumber: routingConfig?.blockNumber,
-      });
+      await this.quoteProvider.getQuotesManyExactOut<V3Route>(
+        [amountOut],
+        routes,
+        {
+          blockNumber: routingConfig?.blockNumber,
+        }
+      );
     const bestQuote = await this.getBestQuote(
       routes,
       quotesRaw,

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -935,7 +935,7 @@ describe('alpha router integration', () => {
   });
 });
 
-describe.only('quote for other networks', () => {
+describe('quote for other networks', () => {
   const TEST_ERC20_1: { [chainId in ChainId]: Token } = {
     [ChainId.MAINNET]: USDC_ON(1),
     [ChainId.ROPSTEN]: USDC_ON(ChainId.ROPSTEN),

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -33,12 +33,10 @@ import {
   USDC_MAINNET,
   USDC_ON,
   USDT_MAINNET,
-  V3_CORE_FACTORY_ADDRESSES,
   WBTC_GNOSIS,
   WBTC_MOONBEAM,
   WETH9,
   WNATIVE_ON,
-  WRAPPED_NATIVE_CURRENCY,
 } from '../../../../src';
 
 import 'jest-environment-hardhat';
@@ -53,8 +51,6 @@ import { StaticGasPriceProvider } from '../../../../src/providers/static-gas-pri
 import { DEFAULT_ROUTING_CONFIG_BY_CHAIN } from '../../../../src/routers/alpha-router/config';
 import { getBalanceAndApprove } from '../../../test-util/getBalanceAndApprove';
 
-import MixedRouteQuoterV1_ABI from '../../../../src/abis/MixedRouteQuoterV1.json';
-const V2_FACTORY = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f';
 const SWAP_ROUTER_V2 = '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45';
 const SLIPPAGE = new Percent(5, 100); // 5% or 10_000?
 
@@ -271,19 +267,6 @@ describe('alpha router integration', () => {
     alice = hardhat.providers[0]!.getSigner();
     const aliceAddress = await alice.getAddress();
     expect(aliceAddress).toBe(alice._address);
-
-    const MixedRouteQuoterV1Factory =
-      await hardhat.hre.ethers.getContractFactoryFromArtifact(
-        MixedRouteQuoterV1_ABI,
-        alice
-      );
-    const MixedRouteQuoterV1 = await MixedRouteQuoterV1Factory.deploy(
-      V3_CORE_FACTORY_ADDRESSES[ChainId.MAINNET],
-      V2_FACTORY,
-      WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET].address // TODO: change to be chain dependent
-    );
-
-    const MixedRouteQuoterV1Address = MixedRouteQuoterV1.address;
 
     await hardhat.fund(
       alice._address,
@@ -922,7 +905,7 @@ describe('alpha router integration', () => {
             },
             {
               ...ROUTING_CONFIG,
-              protocols: [],
+              protocols: [Protocol.V2, Protocol.V3, Protocol.MIXED],
               forceMixedRoutes: true,
             }
           );

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -22,10 +22,8 @@ import {
   DAI_ON,
   ID_TO_NETWORK_NAME,
   ID_TO_PROVIDER,
-  MixedRoute,
   nativeOnChain,
   NATIVE_CURRENCY,
-  OnChainQuoteProvider,
   parseAmount,
   SUPPORTED_CHAINS,
   UniswapMulticallProvider,
@@ -344,30 +342,6 @@ describe('alpha router integration', () => {
       chainId: ChainId.MAINNET,
       provider: hardhat.providers[0]!,
       multicall2Provider,
-      mixedRouteQuoteProvider: new OnChainQuoteProvider<MixedRoute>(
-        ChainId.MAINNET,
-        hardhat.provider,
-        multicall2Provider,
-        /// Different config than v3
-        {
-          retries: 2,
-          minTimeout: 100,
-          maxTimeout: 1000,
-        },
-        {
-          multicallChunk: 180,
-          gasLimitPerCall: 705_000,
-          quoteMinSuccessRate: 0.15,
-        },
-        {
-          gasLimitOverride: 2_000_000,
-          multicallChunk: 75,
-        },
-        undefined,
-        undefined,
-        true,
-        MixedRouteQuoterV1Address
-      ),
     });
   });
 
@@ -926,9 +900,7 @@ describe('alpha router integration', () => {
       expect(aliceBONDBalance).toEqual(parseAmount('10000', BOND_MAINNET));
     });
 
-    describe(`${
-      tradeType === TradeType.EXACT_INPUT ? 'exactInput' : 'exactOutput'
-    } mixedPath routes`, () => {
+    describe(`exactIn mixedPath routes`, () => {
       describe('+ simulate swap', () => {
         it('BOND -> APE', async () => {
           const tokenIn = BOND_MAINNET;
@@ -950,7 +922,8 @@ describe('alpha router integration', () => {
             },
             {
               ...ROUTING_CONFIG,
-              protocols: [Protocol.V3, Protocol.V2],
+              protocols: [],
+              forceMixedRoutes: true,
             }
           );
 

--- a/test/unit/routers/alpha-router/alpha-router.test.ts
+++ b/test/unit/routers/alpha-router/alpha-router.test.ts
@@ -1823,6 +1823,19 @@ describe.only('alpha router', () => {
       expect(swap!.blockNumber.eq(mockBlockBN)).toBeTruthy();
     });
 
+    test('is null with mixed only', async () => {
+      const swap = await alphaRouter.route(
+        CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[1], 10000),
+        USDC,
+        TradeType.EXACT_OUTPUT,
+        undefined,
+        { ...ROUTING_CONFIG, protocols: [Protocol.MIXED] }
+      );
+      expect(swap).toBeNull();
+
+      sinon.assert.notCalled(mockOnChainQuoteProvider.getQuotesManyExactOut);
+    });
+
     test('succeeds to route and generates calldata on v3 only', async () => {
       const swapParams = {
         deadline: Math.floor(Date.now() / 1000) + 1000000,

--- a/test/unit/routers/alpha-router/alpha-router.test.ts
+++ b/test/unit/routers/alpha-router/alpha-router.test.ts
@@ -1067,6 +1067,10 @@ describe.only('alpha router', () => {
       ).toBeTruthy();
 
       expect(
+        mockOnChainQuoteProvider.getQuotesManyExactOut.notCalled
+      ).toBeTruthy();
+
+      expect(
         swap!.quote.currency.equals(WRAPPED_NATIVE_CURRENCY[1])
       ).toBeTruthy();
       expect(
@@ -1285,6 +1289,10 @@ describe.only('alpha router', () => {
           V2poolProvider: sinon.match.any,
           token: WRAPPED_NATIVE_CURRENCY[1],
         })
+      ).toBeTruthy();
+
+      expect(
+        mockOnChainQuoteProvider.getQuotesManyExactOut.notCalled
       ).toBeTruthy();
 
       expect(


### PR DESCRIPTION
Feature branch for implementing:
- Using one instance of `OnChainQuoteProvider` for V3, MixedRoute, and V2 quotes.
- Removing the `disableMixedRoutesConsideration` flag and adjusting the logic for protocol queries
- Adding `forceMixedRoutes`
- Adding various tests for `getMixedRouteQuotes()` in alpha-router

TODO:
- need to test that we can call the onChainQuoteProvider and get on chain quotes for V2 exactIn routes 
