### PR TITLE
feat: add network context to logs

### DIFF
--- a/cli/base-command.ts
+++ b/cli/base-command.ts
@@ -21,6 +21,7 @@ import {
   GasPrice,
   ID_TO_CHAIN_ID,
   ID_TO_PROVIDER,
+  ID_TO_NETWORK_NAME,
   IRouter,
   ISwapToRatio,
   ITokenProvider,
@@ -207,11 +208,14 @@ export abstract class BaseCommand extends Command {
       setGlobalLogger(this.logger);
     }
 
-    const metricLogger: MetricLogger = new MetricLogger();
-    setGlobalMetric(metricLogger);
-
     const chainId = ID_TO_CHAIN_ID(chainIdNumb);
     const chainProvider = ID_TO_PROVIDER(chainId);
+
+    const metricLogger: MetricLogger = new MetricLogger({ 
+      chainId: chainIdNumb, 
+      networkName: ID_TO_NETWORK_NAME(chainId) 
+    });
+    setGlobalMetric(metricLogger);
 
     const provider = new JsonRpcProvider(chainProvider, chainId);
     this._blockNumber = await provider.getBlockNumber();

--- a/src/routers/alpha-router/functions/compute-all-routes.ts
+++ b/src/routers/alpha-router/functions/compute-all-routes.ts
@@ -1,6 +1,7 @@
 import { Token } from '@uniswap/sdk-core';
 import { Pair } from '@uniswap/v2-sdk';
 import { Pool } from '@uniswap/v3-sdk';
+
 import { log } from '../../../util/log';
 import { routeToString } from '../../../util/routes';
 import { MixedRoute, V2Route, V3Route } from '../../router';

--- a/src/routers/legacy-router/legacy-router.ts
+++ b/src/routers/legacy-router/legacy-router.ts
@@ -4,8 +4,8 @@ import { SwapRouter, Trade } from '@uniswap/router-sdk';
 import { Currency, Token, TradeType } from '@uniswap/sdk-core';
 import { FeeAmount, MethodParameters, Pool, Route } from '@uniswap/v3-sdk';
 import _ from 'lodash';
-import { IOnChainQuoteProvider, RouteWithQuotes } from '../../providers';
 
+import { IOnChainQuoteProvider, RouteWithQuotes } from '../../providers';
 import { IMulticallProvider } from '../../providers/multicall-provider';
 import {
   DAI_MAINNET,

--- a/src/util/metric.ts
+++ b/src/util/metric.ts
@@ -1,4 +1,6 @@
-import { log, setGlobalLogger } from './log';
+import Logger from 'bunyan';
+
+import { log } from './log';
 
 export enum MetricLoggerUnit {
   Seconds = 'Seconds',
@@ -31,21 +33,24 @@ export enum MetricLoggerUnit {
 }
 
 export abstract class IMetric {
-  abstract putDimensions(dimensions: Record<string, string>): void;
   abstract putMetric(key: string, value: number, unit?: MetricLoggerUnit): void;
 }
 
-export class MetricLogger extends IMetric {
-  constructor() {
-    super();
-  }
+interface MetricContext {
+  chainId: number;
+  networkName: string;
+}
 
-  public putDimensions(dimensions: Record<string, string>): void {
-    setGlobalLogger(log.child(dimensions));
+export class MetricLogger extends IMetric {
+  private log: Logger;
+
+  constructor(context?: MetricContext) {
+    super();
+    this.log = log.child(context || {});
   }
 
   public putMetric(key: string, value: number, unit?: MetricLoggerUnit): void {
-    log.info(
+    this.log.info(
       { key, value, unit },
       `[Metric]: ${key}: ${value} | ${unit ? unit : ''}`
     );

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -4,9 +4,10 @@ import { Pair } from '@uniswap/v2-sdk';
 import { Pool } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
-import { CurrencyAmount } from '.';
 import { RouteWithValidQuote } from '../routers/alpha-router';
 import { MixedRoute, V2Route, V3Route } from '../routers/router';
+
+import { CurrencyAmount } from '.';
 
 export const routeToString = (
   route: V3Route | V2Route | MixedRoute


### PR DESCRIPTION
This commit adds an optional context object to MetricsLogger which can be used
to add network id and network name to all logs. This may help alerting services
differentiate and bucket errors by network

Example log after this change
```
{"name":"Uniswap Smart Order Router",
"hostname":"toda-XPS-15-9510",
"pid":157780,
"chainId":1,
"networkName":"mainnet",
"level":30,
"key":"FindBestSwapRoute",
"value":13,
"unit":"Milliseconds",
"msg":"[Metric]: FindBestSwapRoute: 13 | Milliseconds",
"time":"2022-08-17T19:40:45.340Z",
"v":0}
```
