### PR TITLE
Add peer dependency to fix JSBI issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,9 @@
     "typechain": "^5.0.0",
     "typescript": "^4.2.2"
   },
+  "peerDependencies": {
+    "jsbi": "3.2.5"
+  },
   "files": [
     "build/main",
     "build/module",


### PR DESCRIPTION
Fixes the issues users are having in #58 - the issue occurs if they have v4 not v3 of JSBI. Given JSBI is not a direct dependency of this repo, I'm adding the version that we use as a peer dependency.