### PR TITLE
Added param for page size for v2 subgraph provider

### DIFF
--- a/src/providers/v2/subgraph-provider.ts
+++ b/src/providers/v2/subgraph-provider.ts
@@ -68,7 +68,8 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
     private chainId: ChainId,
     private retries = 2,
     private timeout = 360000,
-    private rollback = true
+    private rollback = true,
+    private pageSize = PAGE_SIZE
   ) {
     const subgraphUrl = SUBGRAPH_URL_BY_CHAIN[this.chainId];
     if (!subgraphUrl) {
@@ -106,7 +107,7 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
     let pools: RawV2SubgraphPool[] = [];
 
     log.info(
-      `Getting V2 pools from the subgraph with page size ${PAGE_SIZE}${
+      `Getting V2 pools from the subgraph with page size ${this.pageSize}${
         providerConfig?.blockNumber
           ? ` as of block ${providerConfig?.blockNumber}`
           : ''
@@ -128,7 +129,7 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
                 const poolsResult = await this.client.request<{
                   pairs: RawV2SubgraphPool[];
                 }>(query2, {
-                  pageSize: PAGE_SIZE,
+                  pageSize: this.pageSize,
                   id: lastId,
                 });
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Feature to set pageSize for v2SubgraphProvider

- **What is the current behavior?** Uses pageSize = 1000

- **What is the new behavior (if this is a feature change)?**. Uses whatever pageSize is passed, 1000 by default

- **Other information**: This is to try to work around this issue: https://github.com/Uniswap/v2-subgraph/issues/78 

By reducing page size we may be able to get the subgraph query to work more reliably
