### PR TITLE
Include V3 pools from subgraph where there is a small quantity of ETH locked up

### DIFF
--- a/src/providers/v3/subgraph-provider.ts
+++ b/src/providers/v3/subgraph-provider.ts
@@ -203,7 +203,11 @@ export class V3SubgraphProvider implements IV3SubgraphProvider {
     );
 
     const poolsSanitized = pools
-      .filter((pool) => parseInt(pool.liquidity) > 0)
+      .filter(
+        (pool) =>
+          parseInt(pool.liquidity) > 0 ||
+          parseFloat(pool.totalValueLockedETH) > 0.01
+      )
       .map((pool) => {
         const { totalValueLockedETH, totalValueLockedUSD, ...rest } = pool;
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a patch for an issue reported by the research team. Longer term fix is in the Subgraph, but due to resourcing unlikely to get fixed any time soon.

The research team reported that [this pool](https://info.uniswap.org/#/pools/0xd9961ea871a52456a5ad4bccb981d40ed7fdb813) is not showing up in the interface. 

I took a quick look and found it is being [filtered out of the V3 Subgraph query](https://github.com/Uniswap/smart-order-router/blob/main/src/providers/v3/subgraph-provider.ts#L206) because the subgraph says its liquidity == 0. 

Its liquidity is actually not 0 as [can be seen here](https://etherscan.io/address/0xd9961ea871a52456a5ad4bccb981d40ed7fdb813#readContract#F5), so there is an issue with how the Subgraph is computing the liquidity number for some pools.

The subgraph _does_ correctly report the pools TVL in ETH however, so this is a metric we use on for deciding whether to include the pool.

- **What is the current behavior?** (You can also link to an open issue here)
- Currently we only include pools where the subgraph says liquidity > 0, now we will also include pools if TVL in ETH > 0.01 

- **What is the new behavior (if this is a feature change)?**
- Pools with TVL > 0.01 will also be included

- **Other information**:
