### PR TITLE
Add explicit dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,14 @@
     "node": ">=10"
   },
   "dependencies": {
+    "@ethersproject/abi": "^5.6.0",
+    "@ethersproject/bignumber": "^5.6.2",
+    "@ethersproject/logger": "^5.6.0",
+    "@ethersproject/providers": "^5.4.0",
+    "@ethersproject/units": "^5.6.0",
     "@uniswap/default-token-list": "^2.0.0",
     "@uniswap/router-sdk": "^1.3.0",
+    "@uniswap/sdk-core": "^3.0.1",
     "@uniswap/swap-router-contracts": "^1.3.0",
     "@uniswap/token-lists": "^1.0.0-beta.25",
     "@uniswap/v2-sdk": "^3.0.1",
@@ -51,7 +57,6 @@
     "stats-lite": "^2.2.0"
   },
   "devDependencies": {
-    "@ethersproject/providers": "^5.4.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@oclif/command": "^1.8.0",


### PR DESCRIPTION
# Issue

- `@ethersproject/abi@^5.6.0` dependency is used in the package without being defined as an explicit dependency in `package.json`
- `@ethersproject/bignumber@^5.6.2` dependency is used in the package without being defined as an explicit dependency in `package.json`
- `@ethersproject/logger@^5.6.0` dependency is used in the package without being defined as an explicit dependency in `package.json`
- `@ethersproject/providers@^5.4.0` dependency is used in the package without being defined as an explicit dependency in `package.json`
- `@ethersproject/units@^5.6.0` dependency is used in the package without being defined as an explicit dependency in `package.json`
- `@uniswap/sdk-core@^3.0.1` dependency is used in the package without being defined as an explicit dependency in `package.json`

This impacts developers using this package as dependency resolvers (such as `npm` or `yarn`) won't automatically install missing dependencies, or will install it with incorrect (and thus perhaps incompatible) versions

# Fix

- This PR adds the missing dependencies to `package.json` without impacting the current state of `yarn.lock`