### PR TITLE
Raghava/add check for user balance before simulating tx

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -171,7 +171,6 @@ export class FallbackTenderlySimulator implements ISimulator {
         );
         return swapRouteWithGasEstimate;
       } catch (err) {
-        console.log(err, "HUH")
         log.info({ err: err }, 'Error calling eth estimate gas!');
         return { ...swapRoute, simulationError: true };
       }
@@ -185,7 +184,6 @@ export class FallbackTenderlySimulator implements ISimulator {
       );
     } catch (err) {
       log.info({ err: err }, 'Failed to simulate via Tenderly!');
-      console.log("bruh")
       // set error flag to true
       return { ...swapRoute, simulationError: true };
     }
@@ -277,6 +275,7 @@ export class TenderlySimulator implements ISimulator {
       this.tenderlyUser,
       this.tenderlyProject
     );
+    swapRoute.simulationAttempted = true
     const resp = (await axios.post<TenderlyResponse>(url, body, opts)).data;
 
     // Validate tenderly response body
@@ -287,12 +286,11 @@ export class TenderlySimulator implements ISimulator {
       resp.simulation_results[1].transaction.error_message
     ) {
       const msg = `Failed to Simulate Via Tenderly!: ${resp.simulation_results[1].transaction.error_message}`;
-      console.log("WTF", msg)
       log.info(
         { err: resp.simulation_results[1].transaction.error_message },
         msg
       );
-      return { ...swapRoute, simulationError: true };
+      return { ...swapRoute, simulationAttempted: true, simulationError: true };
     }
 
     log.info(

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -171,6 +171,7 @@ export class FallbackTenderlySimulator implements ISimulator {
         );
         return swapRouteWithGasEstimate;
       } catch (err) {
+        console.log(err, "HUH")
         log.info({ err: err }, 'Error calling eth estimate gas!');
         return { ...swapRoute, simulationError: true };
       }
@@ -184,6 +185,7 @@ export class FallbackTenderlySimulator implements ISimulator {
       );
     } catch (err) {
       log.info({ err: err }, 'Failed to simulate via Tenderly!');
+      console.log("bruh")
       // set error flag to true
       return { ...swapRoute, simulationError: true };
     }
@@ -285,6 +287,7 @@ export class TenderlySimulator implements ISimulator {
       resp.simulation_results[1].transaction.error_message
     ) {
       const msg = `Failed to Simulate Via Tenderly!: ${resp.simulation_results[1].transaction.error_message}`;
+      console.log("WTF", msg)
       log.info(
         { err: resp.simulation_results[1].transaction.error_message },
         msg

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -290,7 +290,7 @@ export class TenderlySimulator implements ISimulator {
         { err: resp.simulation_results[1].transaction.error_message },
         msg
       );
-      return { ...swapRoute, simulationAttempted: true, simulationError: true };
+      return { ...swapRoute, simulationError: true };
     }
 
     log.info(

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1141,7 +1141,7 @@ export class AlphaRouter
           Date.now() - beforeSimulate,
           MetricLoggerUnit.Milliseconds
         );
-        return { ...swapRouteWithSimulation, simulationAttempted: true };
+        return swapRouteWithSimulation;
       }
     }
 

--- a/src/routers/router.ts
+++ b/src/routers/router.ts
@@ -84,6 +84,10 @@ export type SwapRoute = {
    * Flag that is true if and only if simulation is requested and simulation fails
    */
   simulationError?: boolean;
+  /**
+   * Flag that is true if and only if simulation is requested and also attempted
+   */
+  simulationAttempted?: boolean;
 };
 
 export type SwapToRatioRoute = SwapRoute & {

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -30,7 +30,7 @@ import {
   NodeJSCache,
   OnChainQuoteProvider,
   parseAmount,
-  SUPPORTED_CHAINS,
+  //SUPPORTED_CHAINS,
   UniswapMulticallProvider,
   UNI_GÖRLI,
   UNI_MAINNET,
@@ -871,6 +871,7 @@ describe('alpha router integration', () => {
             // declaring these to reduce confusion
             const tokenIn = USDC_MAINNET;
             const tokenOut = USDT_MAINNET;
+            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
             const amount =
               tradeType == TradeType.EXACT_INPUT
                 ? parseAmount('100', tokenIn)
@@ -884,7 +885,7 @@ describe('alpha router integration', () => {
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(tokenIn) },
+                simulate: { fromAddress: WHALES(inputToken) },
               },
               {
                 ...ROUTING_CONFIG,
@@ -919,6 +920,7 @@ describe('alpha router integration', () => {
             // Trade of this size almost always results in splits.
             const tokenIn = USDC_MAINNET;
             const tokenOut = Ether.onChain(1) as Currency;
+            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
             const amount =
               tradeType == TradeType.EXACT_INPUT
                 ? parseAmount('1000000', tokenIn)
@@ -932,7 +934,7 @@ describe('alpha router integration', () => {
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(tokenIn) },
+                simulate: { fromAddress: WHALES(inputToken) },
               },
               {
                 ...ROUTING_CONFIG,
@@ -975,6 +977,7 @@ describe('alpha router integration', () => {
             /// Fails for v3 for some reason, ProviderGasError
             const tokenIn = Ether.onChain(1) as Currency;
             const tokenOut = UNI_MAINNET;
+            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
             const amount =
               tradeType == TradeType.EXACT_INPUT
                 ? parseAmount('10', tokenIn)
@@ -988,7 +991,7 @@ describe('alpha router integration', () => {
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(tokenIn) },
+                simulate: { fromAddress: WHALES(inputToken) },
               },
               {
                 ...ROUTING_CONFIG,
@@ -1017,6 +1020,7 @@ describe('alpha router integration', () => {
           it(`weth -> erc20`, async () => {
             const tokenIn = WETH9[1];
             const tokenOut = DAI_MAINNET;
+            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
             const amount =
               tradeType == TradeType.EXACT_INPUT
                 ? parseAmount('100', tokenIn)
@@ -1030,7 +1034,7 @@ describe('alpha router integration', () => {
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(tokenIn) },
+                simulate: { fromAddress: WHALES(inputToken) },
               },
               {
                 ...ROUTING_CONFIG,
@@ -1072,6 +1076,7 @@ describe('alpha router integration', () => {
           it(`erc20 -> weth`, async () => {
             const tokenIn = USDC_MAINNET;
             const tokenOut = WETH9[1];
+            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
             const amount =
               tradeType == TradeType.EXACT_INPUT
                 ? parseAmount('100', tokenIn)
@@ -1085,7 +1090,7 @@ describe('alpha router integration', () => {
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(tokenIn) },
+                simulate: { fromAddress: WHALES(inputToken) },
               },
               {
                 ...ROUTING_CONFIG,
@@ -1127,6 +1132,7 @@ describe('alpha router integration', () => {
           it('erc20 -> erc20 v3 only', async () => {
             const tokenIn = USDC_MAINNET;
             const tokenOut = USDT_MAINNET;
+            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
             const amount =
               tradeType == TradeType.EXACT_INPUT
                 ? parseAmount('100', tokenIn)
@@ -1140,7 +1146,7 @@ describe('alpha router integration', () => {
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(tokenIn) },
+                simulate: { fromAddress: WHALES(inputToken) },
               },
               {
                 ...ROUTING_CONFIG,
@@ -1182,6 +1188,7 @@ describe('alpha router integration', () => {
           it('erc20 -> erc20 v2 only', async () => {
             const tokenIn = USDC_MAINNET;
             const tokenOut = USDT_MAINNET;
+            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
             const amount =
               tradeType == TradeType.EXACT_INPUT
                 ? parseAmount('100', tokenIn)
@@ -1195,7 +1202,7 @@ describe('alpha router integration', () => {
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(tokenIn) },
+                simulate: { fromAddress: WHALES(inputToken) },
               },
               {
                 ...ROUTING_CONFIG,
@@ -1238,6 +1245,7 @@ describe('alpha router integration', () => {
           it('erc20 -> erc20 forceCrossProtocol', async () => {
             const tokenIn = USDC_MAINNET;
             const tokenOut = USDT_MAINNET;
+            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
             const amount =
               tradeType == TradeType.EXACT_INPUT
                 ? parseAmount('100', tokenIn)
@@ -1251,7 +1259,7 @@ describe('alpha router integration', () => {
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(tokenIn) },
+                simulate: { fromAddress: WHALES(inputToken) },
               },
               {
                 ...ROUTING_CONFIG,
@@ -1608,7 +1616,7 @@ describe('quote for other networks', () => {
 
   // TODO: Find valid pools/tokens on optimistic kovan and polygon mumbai. We skip those tests for now.
   for (const chain of _.filter(
-    SUPPORTED_CHAINS,
+    [ChainId.MAINNET],
     (c) =>
       c != ChainId.RINKEBY &&
       c != ChainId.ROPSTEN &&

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -30,7 +30,7 @@ import {
   NodeJSCache,
   OnChainQuoteProvider,
   parseAmount,
-  //SUPPORTED_CHAINS,
+  SUPPORTED_CHAINS,
   UniswapMulticallProvider,
   UNI_GÖRLI,
   UNI_MAINNET,
@@ -1501,7 +1501,7 @@ describe('quote for other networks', () => {
 
   // TODO: Find valid pools/tokens on optimistic kovan and polygon mumbai. We skip those tests for now.
   for (const chain of _.filter(
-    [ChainId.MAINNET],
+    SUPPORTED_CHAINS,
     (c) =>
       c != ChainId.RINKEBY &&
       c != ChainId.ROPSTEN &&

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -895,7 +895,7 @@ describe('alpha router integration', () => {
             expect(swap).toBeDefined();
             expect(swap).not.toBeNull();
 
-            const { quote, quoteGasAdjusted, methodParameters } = swap!;
+            const { quote, quoteGasAdjusted, methodParameters, simulationError, simulationAttempted } = swap!;
 
             await validateSwapRoute(
               quote,
@@ -904,6 +904,10 @@ describe('alpha router integration', () => {
               100,
               10
             );
+
+            // simulation should 1: run, and 2: not fail
+            expect(simulationAttempted).toBeTruthy();
+            expect(simulationError).toBeUndefined();
 
             await validateExecuteSwap(
               quote,
@@ -949,6 +953,7 @@ describe('alpha router integration', () => {
               methodParameters,
               estimatedGasUsed,
               simulationError,
+              simulationAttempted,
               estimatedGasUsedQuoteToken,
             } = swap!;
 
@@ -958,7 +963,8 @@ describe('alpha router integration', () => {
                 .equalTo(estimatedGasUsedQuoteToken)
             );
 
-            // Expect tenderly simulation to be successful
+            // simulation should 1: run, and 2: not fail
+            expect(simulationAttempted).toBeTruthy();
             expect(simulationError).toBeUndefined();
 
             await validateExecuteSwap(
@@ -1005,6 +1011,7 @@ describe('alpha router integration', () => {
               quote,
               quoteGasAdjusted,
               simulationError,
+              simulationAttempted,
               estimatedGasUsedQuoteToken,
             } = swap!;
             expect(
@@ -1013,233 +1020,9 @@ describe('alpha router integration', () => {
                 .equalTo(estimatedGasUsedQuoteToken)
             );
 
-            // Expect tenderly simulation to be successful
+            // simulation should 1: run, and 2: not fail
+            expect(simulationAttempted).toBeTruthy();
             expect(simulationError).toBeUndefined();
-          });
-
-          it(`weth -> erc20`, async () => {
-            const tokenIn = WETH9[1];
-            const tokenOut = DAI_MAINNET;
-            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
-            const amount =
-              tradeType == TradeType.EXACT_INPUT
-                ? parseAmount('100', tokenIn)
-                : parseAmount('100', tokenOut);
-
-            const swap = await alphaRouter.route(
-              amount,
-              getQuoteToken(tokenIn, tokenOut, tradeType),
-              tradeType,
-              {
-                recipient: alice._address,
-                slippageTolerance: SLIPPAGE,
-                deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(inputToken) },
-              },
-              {
-                ...ROUTING_CONFIG,
-              }
-            );
-            expect(swap).toBeDefined();
-            expect(swap).not.toBeNull();
-
-            const {
-              quote,
-              quoteGasAdjusted,
-              methodParameters,
-              estimatedGasUsed,
-              simulationError,
-              estimatedGasUsedQuoteToken,
-            } = swap!;
-
-            expect(
-              quoteGasAdjusted
-                .subtract(quote)
-                .equalTo(estimatedGasUsedQuoteToken)
-            );
-
-            // Expect tenderly simulation to be successful
-            expect(simulationError).toBeUndefined();
-
-            await validateExecuteSwap(
-              quote,
-              tokenIn,
-              tokenOut,
-              methodParameters,
-              tradeType,
-              100,
-              100,
-              estimatedGasUsed
-            );
-          });
-
-          it(`erc20 -> weth`, async () => {
-            const tokenIn = USDC_MAINNET;
-            const tokenOut = WETH9[1];
-            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
-            const amount =
-              tradeType == TradeType.EXACT_INPUT
-                ? parseAmount('100', tokenIn)
-                : parseAmount('100', tokenOut);
-
-            const swap = await alphaRouter.route(
-              amount,
-              getQuoteToken(tokenIn, tokenOut, tradeType),
-              tradeType,
-              {
-                recipient: alice._address,
-                slippageTolerance: SLIPPAGE,
-                deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(inputToken) },
-              },
-              {
-                ...ROUTING_CONFIG,
-              }
-            );
-            expect(swap).toBeDefined();
-            expect(swap).not.toBeNull();
-
-            const {
-              quote,
-              quoteGasAdjusted,
-              methodParameters,
-              estimatedGasUsed,
-              simulationError,
-              estimatedGasUsedQuoteToken,
-            } = swap!;
-
-            expect(
-              quoteGasAdjusted
-                .subtract(quote)
-                .equalTo(estimatedGasUsedQuoteToken)
-            );
-
-            // Expect tenderly simulation to be successful
-            expect(simulationError).toBeUndefined();
-
-            await validateExecuteSwap(
-              quote,
-              tokenIn,
-              tokenOut,
-              methodParameters,
-              tradeType,
-              100,
-              100,
-              estimatedGasUsed
-            );
-          });
-
-          it('erc20 -> erc20 v3 only', async () => {
-            const tokenIn = USDC_MAINNET;
-            const tokenOut = USDT_MAINNET;
-            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
-            const amount =
-              tradeType == TradeType.EXACT_INPUT
-                ? parseAmount('100', tokenIn)
-                : parseAmount('100', tokenOut);
-
-            const swap = await alphaRouter.route(
-              amount,
-              getQuoteToken(tokenIn, tokenOut, tradeType),
-              tradeType,
-              {
-                recipient: alice._address,
-                slippageTolerance: SLIPPAGE,
-                deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(inputToken) },
-              },
-              {
-                ...ROUTING_CONFIG,
-                protocols: [Protocol.V3],
-              }
-            );
-            expect(swap).toBeDefined();
-            expect(swap).not.toBeNull();
-
-            const {
-              quote,
-              quoteGasAdjusted,
-              methodParameters,
-              estimatedGasUsed,
-              simulationError,
-              estimatedGasUsedQuoteToken,
-            } = swap!;
-            expect(
-              quoteGasAdjusted
-                .subtract(quote)
-                .equalTo(estimatedGasUsedQuoteToken)
-            );
-
-            // Expect tenderly simulation to be successful
-            expect(simulationError).toBeUndefined();
-
-            await validateExecuteSwap(
-              quote,
-              tokenIn,
-              tokenOut,
-              methodParameters,
-              tradeType,
-              100,
-              100,
-              estimatedGasUsed
-            );
-          });
-
-          it('erc20 -> erc20 v2 only', async () => {
-            const tokenIn = USDC_MAINNET;
-            const tokenOut = USDT_MAINNET;
-            const inputToken = TradeType.EXACT_INPUT ? tokenIn : tokenOut
-            const amount =
-              tradeType == TradeType.EXACT_INPUT
-                ? parseAmount('100', tokenIn)
-                : parseAmount('100', tokenOut);
-
-            const swap = await alphaRouter.route(
-              amount,
-              getQuoteToken(tokenIn, tokenOut, tradeType),
-              tradeType,
-              {
-                recipient: alice._address,
-                slippageTolerance: SLIPPAGE,
-                deadline: parseDeadline(360),
-                simulate: { fromAddress: WHALES(inputToken) },
-              },
-              {
-                ...ROUTING_CONFIG,
-                protocols: [Protocol.V2],
-              }
-            );
-            expect(swap).toBeDefined();
-            expect(swap).not.toBeNull();
-
-            const {
-              quote,
-              quoteGasAdjusted,
-              methodParameters,
-              estimatedGasUsed,
-              simulationError,
-              estimatedGasUsedQuoteToken,
-            } = swap!;
-
-            expect(
-              quoteGasAdjusted
-                .subtract(quote)
-                .equalTo(estimatedGasUsedQuoteToken)
-            );
-
-            // Expect tenderly simulation to be successful
-            expect(simulationError).toBeUndefined();
-
-            await validateExecuteSwap(
-              quote,
-              tokenIn,
-              tokenOut,
-              methodParameters,
-              tradeType,
-              100,
-              100,
-              estimatedGasUsed
-            );
           });
 
           it('erc20 -> erc20 forceCrossProtocol', async () => {
@@ -1275,6 +1058,7 @@ describe('alpha router integration', () => {
               methodParameters,
               estimatedGasUsed,
               simulationError,
+              simulationAttempted,
               estimatedGasUsedQuoteToken,
             } = swap!;
 
@@ -1284,7 +1068,8 @@ describe('alpha router integration', () => {
                 .equalTo(estimatedGasUsedQuoteToken)
             );
 
-            // Expect tenderly simulation to be successful
+            // simulation should 1: run, and 2: not fail
+            expect(simulationAttempted).toBeTruthy();
             expect(simulationError).toBeUndefined();
 
             await validateExecuteSwap(
@@ -1633,7 +1418,7 @@ describe('quote for other networks', () => {
 
       describe(`${ID_TO_NETWORK_NAME(chain)} ${tradeType} 2xx`, function () {
         // Help with test flakiness by retrying.
-        jest.retryTimes(1);
+        jest.retryTimes(2);
 
         const wrappedNative = WNATIVE_ON(chain);
 

--- a/test/test-util/whales.ts
+++ b/test/test-util/whales.ts
@@ -32,6 +32,7 @@ export const WHALES = (token:Currency):string => {
         case WNATIVE_ON(ChainId.POLYGON):
             return '0x369582d2010b6ed950b571f4101e3bb9b554876f'
         case USDC_MAINNET:
+            return '0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1'
         case UNI_MAINNET:
         case DAI_MAINNET:
         case USDT_MAINNET:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds check before simulating transactions from addresses that don't have sufficient balance. This prevents us from simulating when we already know the transaction would fail on chain.

- **What is the current behavior?** (You can also link to an open issue here)
https://uniswaplabs.atlassian.net/browse/TRD-159

- **What is the new behavior (if this is a feature change)?**
Simulates as normal if user has sufficient token balance, otherwise returns flag `simulationAttempted = false`

- **Other information**:
Will also help with integrating tenderly with web for gas estimates
