### PR TITLE
Fix exception when gasToken has less decimals

### DIFF
--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -467,7 +467,6 @@ export async function getBestSwapRouteBy(
   // For each gas estimate, normalize decimals to that of the chosen usd token.
   const estimatedGasUsedUSDs = _(bestSwap)
     .map((routeWithValidQuote) => {
-      // TODO: will error if gasToken has decimals greater than usdToken
       const decimalsDiff =
         usdTokenDecimals - routeWithValidQuote.gasCostInUSD.currency.decimals;
 
@@ -498,7 +497,10 @@ export async function getBestSwapRouteBy(
         usdToken,
         JSBI.multiply(
           gasCostL1USD.quotient,
-          JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(decimalsDiff))
+          JSBI.multiply(
+            JSBI.BigInt(decimalDiff >= 0 ? 1 : -1),
+            JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(Math.abs(decimalsDiff)))
+          )
         )
       )
     );


### PR DESCRIPTION
Addresses aforementioned todo

- **What kind of change does this PR introduce?** 
Bugfix

- **What is the current behavior?**
Getting a quote on goerli throws with 'Exponent must be positive'

- **What is the new behavior (if this is a feature change)?**
Works now
