### PR TITLE
fixed swapOptions missing in CLI

### DIFF
--- a/cli/commands/quote-to-ratio.ts
+++ b/cli/commands/quote-to-ratio.ts
@@ -8,6 +8,7 @@ import {
   parseAmount,
   SwapToRatioResponse,
   SwapToRatioStatus,
+  SwapType,
 } from '../../src';
 import { BaseCommand } from '../base-command';
 
@@ -118,6 +119,7 @@ export class QuoteToRatio extends BaseCommand {
           recipient: '0x0000000000000000000000000000000000000001',
         },
         swapOptions: {
+          type: SwapType.SWAP_ROUTER_02,
           deadline: 100,
           recipient,
           slippageTolerance: new Percent(5, 10_000),


### PR DESCRIPTION
I was trying to run the CLI but was running into the following error while calling `./bin/cli`

```
(node:361995) TSError Plugin: @uniswap/smart-order-router: ⨯ Unable to compile TypeScript:
cli/commands/quote-to-ratio.ts:120:9 - error TS2741: Property 'type' is missing in type '{ deadline: number; recipient: string; slippageTolerance: Percent; }' but required in type 'SwapOptionsSwapRouter02'.

120         swapOptions: {
            ~~~~~~~~~~~

  src/routers/router.ts:139:3
    139   type: SwapType.SWAP_ROUTER_02;
          ~~~~
    'type' is declared here.
```


It looks like the call signature for the swapOption args is a bit different.
This fixed that particular bug, but there's a series of other mismatched constructor issues reported when calling `./bin/cli`

Please let me know if I'm missing something.
