### PR TITLE
Refactor and create Quoter models

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -63,7 +63,6 @@ import {
   IRouter,
   ISwapToRatio,
   MethodParameters,
-  MixedRoute,
   SwapAndAddConfig,
   SwapAndAddOptions,
   SwapAndAddParameters,
@@ -71,7 +70,6 @@ import {
   SwapRoute,
   SwapToRatioResponse,
   SwapToRatioStatus,
-  V3Route,
 } from '../router';
 
 import { DEFAULT_ROUTING_CONFIG_BY_CHAIN, ETH_GAS_STATION_API_URL } from './config';

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -4,7 +4,6 @@ import DEFAULT_TOKEN_LIST from '@uniswap/default-token-list';
 import { Protocol, SwapRouter, Trade } from '@uniswap/router-sdk';
 import { Currency, Fraction, Token, TradeType } from '@uniswap/sdk-core';
 import { TokenList } from '@uniswap/token-lists';
-import { Pair } from '@uniswap/v2-sdk';
 import { Pool, Position, SqrtPriceMath, TickMath } from '@uniswap/v3-sdk';
 import retry from 'async-retry';
 import JSBI from 'jsbi';
@@ -41,11 +40,7 @@ import {
 import { CachingTokenListProvider, ITokenListProvider } from '../../providers/caching-token-list-provider';
 import { GasPrice, IGasPriceProvider } from '../../providers/gas-price-provider';
 import { ITokenProvider, TokenProvider } from '../../providers/token-provider';
-import {
-  ITokenValidatorProvider,
-  TokenValidationResult,
-  TokenValidatorProvider,
-} from '../../providers/token-validator-provider';
+import { ITokenValidatorProvider, TokenValidatorProvider, } from '../../providers/token-validator-provider';
 import { IV2PoolProvider, V2PoolProvider } from '../../providers/v2/pool-provider';
 import {
   ArbitrumGasData,
@@ -63,7 +58,6 @@ import { ChainId, ID_TO_CHAIN_ID, ID_TO_NETWORK_NAME, V2_SUPPORTED } from '../..
 import { log } from '../../util/log';
 import { buildSwapMethodParameters, buildTrade } from '../../util/methodParameters';
 import { metric, MetricLoggerUnit } from '../../util/metric';
-import { poolToString, routeToString } from '../../util/routes';
 import { UNSUPPORTED_TOKENS } from '../../util/unsupported-tokens';
 import {
   IRouter,
@@ -89,18 +83,12 @@ import {
 } from './entities/route-with-valid-quote';
 import { getBestSwapRoute } from './functions/best-swap-route';
 import { calculateRatioAmountIn } from './functions/calculate-ratio-amount-in';
-import { computeAllMixedRoutes, computeAllV2Routes, computeAllV3Routes } from './functions/compute-all-routes';
-import {
-  CandidatePoolsBySelectionCriteria,
-  getMixedRouteCandidatePools,
-  getV2CandidatePools,
-  getV3CandidatePools,
-  PoolId,
-} from './functions/get-candidate-pools';
+import { CandidatePoolsBySelectionCriteria, PoolId, } from './functions/get-candidate-pools';
 import { IGasModel, IOnChainGasModelFactory, IV2GasModelFactory } from './gas-models/gas-model';
 import { MixedRouteHeuristicGasModelFactory } from './gas-models/mixedRoute/mixed-route-heuristic-gas-model';
 import { V2HeuristicGasModelFactory } from './gas-models/v2/v2-heuristic-gas-model';
 import { V3HeuristicGasModelFactory } from './gas-models/v3/v3-heuristic-gas-model';
+import { GetQuotesResult, MixedQuoter, V2Quoter, V3Quoter } from './quoters';
 
 export type AlphaRouterParams = {
   /**
@@ -322,6 +310,9 @@ export class AlphaRouter
     | IL2GasDataProvider<OptimismGasData>
     | IL2GasDataProvider<ArbitrumGasData>;
   protected simulator?: Simulator;
+  protected v2Quoter: V2Quoter;
+  protected v3Quoter: V3Quoter;
+  protected mixedQuoter: MixedQuoter;
 
   constructor({
     chainId,
@@ -597,6 +588,40 @@ export class AlphaRouter
         new NodeJSCache(new NodeCache({ stdTTL: 30000, useClones: false }))
       );
     }
+
+    // Initialize the Quoters.
+    // Quoters are an abstraction encapsulating the business logic of fetching routes and quotes.
+    this.v2Quoter = new V2Quoter(
+      this.v2SubgraphProvider,
+      this.v2PoolProvider,
+      this.v2QuoteProvider,
+      this.tokenProvider,
+      this.chainId,
+      this.blockedTokenListProvider,
+      this.tokenValidatorProvider
+    );
+
+    this.v3Quoter = new V3Quoter(
+      this.v3SubgraphProvider,
+      this.v3PoolProvider,
+      this.onChainQuoteProvider,
+      this.tokenProvider,
+      this.chainId,
+      this.blockedTokenListProvider,
+      this.tokenValidatorProvider
+    );
+
+    this.mixedQuoter = new MixedQuoter(
+      this.v3SubgraphProvider,
+      this.v3PoolProvider,
+      this.v2SubgraphProvider,
+      this.v2PoolProvider,
+      this.onChainQuoteProvider,
+      this.tokenProvider,
+      this.chainId,
+      this.blockedTokenListProvider,
+      this.tokenValidatorProvider
+    );
   }
 
   public async routeToRatio(
@@ -832,12 +857,13 @@ export class AlphaRouter
 
     const quoteToken = quoteCurrency.wrapped;
 
-    const quotePromises: Promise<{
-      routesWithValidQuotes: RouteWithValidQuote[];
-      candidatePools: CandidatePoolsBySelectionCriteria;
-    }>[] = [];
+    const quotePromises: Promise<GetQuotesResult>[] = [];
 
-    const [v3gasModel, mixedRouteGasModel] = await this.getGasModels(gasPriceWei, amount.currency.wrapped, quoteToken);
+    const [v2GasModel, v3gasModel, mixedRouteGasModel] = await this.getGasModels(
+      gasPriceWei,
+      amount.currency.wrapped,
+      quoteToken
+    );
 
     // Create a Set to sanitize the protocols input, a Set of undefined becomes an empty set,
     // Then create an Array from the values of that Set.
@@ -855,7 +881,7 @@ export class AlphaRouter
     if (v3ProtocolSpecified || noProtocolsSpecified) {
       log.info({ protocols, tradeType }, 'Routing across V3');
       quotePromises.push(
-        this.getV3Quotes(
+        this.v3Quoter.getRoutesThenQuotes(
           tokenIn,
           tokenOut,
           amounts,
@@ -872,13 +898,13 @@ export class AlphaRouter
     if (v2SupportedInChain && (v2ProtocolSpecified || noProtocolsSpecified)) {
       log.info({ protocols, tradeType }, 'Routing across V2');
       quotePromises.push(
-        this.getV2Quotes(
+        this.v2Quoter.getRoutesThenQuotes(
           tokenIn,
           tokenOut,
           amounts,
           percents,
           quoteToken,
-          gasPriceWei,
+          v2GasModel,
           tradeType,
           routingConfig
         )
@@ -891,7 +917,7 @@ export class AlphaRouter
     if (shouldQueryMixedProtocol && mixedProtocolAllowed) {
       log.info({ protocols, tradeType }, 'Routing across MixedRoutes');
       quotePromises.push(
-        this.getMixedRouteQuotes(
+        this.mixedQuoter.getRoutesThenQuotes(
           tokenIn,
           tokenOut,
           amounts,
@@ -919,7 +945,9 @@ export class AlphaRouter
         ...allRoutesWithValidQuotes,
         ...routesWithValidQuotes,
       ];
-      allCandidatePools = [...allCandidatePools, candidatePools];
+      if (candidatePools) {
+        allCandidatePools = [...allCandidatePools, candidatePools];
+      }
     }
 
     if (allRoutesWithValidQuotes.length == 0) {
@@ -1070,8 +1098,19 @@ export class AlphaRouter
     gasPriceWei: BigNumber,
     amountToken: Token,
     quoteToken: Token
-  ): Promise<[IGasModel<V3RouteWithValidQuote>, IGasModel<MixedRouteWithValidQuote>]> {
+  ): Promise<[
+    IGasModel<V2RouteWithValidQuote>,
+    IGasModel<V3RouteWithValidQuote>,
+    IGasModel<MixedRouteWithValidQuote>
+  ]> {
     const beforeGasModel = Date.now();
+
+    const v2GasModelPromise = this.v2GasModelFactory.buildGasModel({
+      chainId: this.chainId,
+      gasPriceWei,
+      poolProvider: this.v2PoolProvider,
+      token: quoteToken,
+    });
 
     const v3GasModelPromise = this.v3GasModelFactory.buildGasModel({
       chainId: this.chainId,
@@ -1092,7 +1131,11 @@ export class AlphaRouter
       v2poolProvider: this.v2PoolProvider,
     });
 
-    const [v3GasModel, mixedRouteGasModel] = await Promise.all([v3GasModelPromise, mixedRouteGasModelPromise]);
+    const [v2GasModel, v3GasModel, mixedRouteGasModel] = await Promise.all([
+      v2GasModelPromise,
+      v3GasModelPromise,
+      mixedRouteGasModelPromise
+    ]);
 
     metric.putMetric(
       'GasModelCreation',
@@ -1100,522 +1143,7 @@ export class AlphaRouter
       MetricLoggerUnit.Milliseconds
     );
 
-    return [v3GasModel, mixedRouteGasModel];
-  }
-
-  private async applyTokenValidatorToPools<T extends Pool | Pair>(
-    pools: T[],
-    isInvalidFn: (
-      token: Currency,
-      tokenValidation: TokenValidationResult | undefined
-    ) => boolean
-  ): Promise<T[]> {
-    if (!this.tokenValidatorProvider) {
-      return pools;
-    }
-
-    log.info(`Running token validator on ${pools.length} pools`);
-
-    const tokens = _.flatMap(pools, (pool) => [pool.token0, pool.token1]);
-
-    const tokenValidationResults =
-      await this.tokenValidatorProvider.validateTokens(tokens);
-
-    const poolsFiltered = _.filter(pools, (pool: T) => {
-      const token0Validation = tokenValidationResults.getValidationByToken(
-        pool.token0
-      );
-      const token1Validation = tokenValidationResults.getValidationByToken(
-        pool.token1
-      );
-
-      const token0Invalid = isInvalidFn(pool.token0, token0Validation);
-      const token1Invalid = isInvalidFn(pool.token1, token1Validation);
-
-      if (token0Invalid || token1Invalid) {
-        log.info(
-          `Dropping pool ${poolToString(pool)} because token is invalid. ${pool.token0.symbol
-          }: ${token0Validation}, ${pool.token1.symbol}: ${token1Validation}`
-        );
-      }
-
-      return !token0Invalid && !token1Invalid;
-    });
-
-    return poolsFiltered;
-  }
-
-  private async getV3Quotes(
-    tokenIn: Token,
-    tokenOut: Token,
-    amounts: CurrencyAmount[],
-    percents: number[],
-    quoteToken: Token,
-    gasModel: IGasModel<V3RouteWithValidQuote>,
-    swapType: TradeType,
-    routingConfig: AlphaRouterConfig
-  ): Promise<{
-    routesWithValidQuotes: V3RouteWithValidQuote[];
-    candidatePools: CandidatePoolsBySelectionCriteria;
-  }> {
-    log.info('Starting to get V3 quotes');
-    // Fetch all the pools that we will consider routing via. There are thousands
-    // of pools, so we filter them to a set of candidate pools that we expect will
-    // result in good prices.
-    const { poolAccessor, candidatePools } = await getV3CandidatePools({
-      tokenIn,
-      tokenOut,
-      tokenProvider: this.tokenProvider,
-      blockedTokenListProvider: this.blockedTokenListProvider,
-      poolProvider: this.v3PoolProvider,
-      routeType: swapType,
-      subgraphProvider: this.v3SubgraphProvider,
-      routingConfig,
-      chainId: this.chainId,
-    });
-    const poolsRaw = poolAccessor.getAllPools();
-
-    // Drop any pools that contain fee on transfer tokens (not supported by v3) or have issues with being transferred.
-    const pools = await this.applyTokenValidatorToPools(
-      poolsRaw,
-      (
-        token: Currency,
-        tokenValidation: TokenValidationResult | undefined
-      ): boolean => {
-        // If there is no available validation result we assume the token is fine.
-        if (!tokenValidation) {
-          return false;
-        }
-
-        // Only filters out *intermediate* pools that involve tokens that we detect
-        // cant be transferred. This prevents us trying to route through tokens that may
-        // not be transferrable, but allows users to still swap those tokens if they
-        // specify.
-        //
-        if (
-          tokenValidation == TokenValidationResult.STF &&
-          (token.equals(tokenIn) || token.equals(tokenOut))
-        ) {
-          return false;
-        }
-
-        return (
-          tokenValidation == TokenValidationResult.FOT ||
-          tokenValidation == TokenValidationResult.STF
-        );
-      }
-    );
-
-    // Given all our candidate pools, compute all the possible ways to route from tokenIn to tokenOut.
-    const { maxSwapsPerPath } = routingConfig;
-    const routes = computeAllV3Routes(
-      tokenIn,
-      tokenOut,
-      pools,
-      maxSwapsPerPath
-    );
-
-    if (routes.length == 0) {
-      return { routesWithValidQuotes: [], candidatePools };
-    }
-
-    // For all our routes, and all the fractional amounts, fetch quotes on-chain.
-    const quoteFn =
-      swapType == TradeType.EXACT_INPUT
-        ? this.onChainQuoteProvider.getQuotesManyExactIn.bind(
-          this.onChainQuoteProvider
-        )
-        : this.onChainQuoteProvider.getQuotesManyExactOut.bind(
-          this.onChainQuoteProvider
-        );
-
-    const beforeQuotes = Date.now();
-    log.info(
-      `Getting quotes for V3 for ${routes.length} routes with ${amounts.length} amounts per route.`
-    );
-
-    const { routesWithQuotes } = await quoteFn<V3Route>(amounts, routes, {
-      blockNumber: routingConfig.blockNumber,
-    });
-
-    metric.putMetric(
-      'V3QuotesLoad',
-      Date.now() - beforeQuotes,
-      MetricLoggerUnit.Milliseconds
-    );
-
-    metric.putMetric(
-      'V3QuotesFetched',
-      _(routesWithQuotes)
-        .map(([, quotes]) => quotes.length)
-        .sum(),
-      MetricLoggerUnit.Count
-    );
-
-    const routesWithValidQuotes = [];
-
-    for (const routeWithQuote of routesWithQuotes) {
-      const [route, quotes] = routeWithQuote;
-
-      for (let i = 0; i < quotes.length; i++) {
-        const percent = percents[i]!;
-        const amountQuote = quotes[i]!;
-        const {
-          quote,
-          amount,
-          sqrtPriceX96AfterList,
-          initializedTicksCrossedList,
-          gasEstimate,
-        } = amountQuote;
-
-        if (
-          !quote ||
-          !sqrtPriceX96AfterList ||
-          !initializedTicksCrossedList ||
-          !gasEstimate
-        ) {
-          log.debug(
-            {
-              route: routeToString(route),
-              amountQuote,
-            },
-            'Dropping a null V3 quote for route.'
-          );
-          continue;
-        }
-
-        const routeWithValidQuote = new V3RouteWithValidQuote({
-          route,
-          rawQuote: quote,
-          amount,
-          percent,
-          sqrtPriceX96AfterList,
-          initializedTicksCrossedList,
-          quoterGasEstimate: gasEstimate,
-          gasModel,
-          quoteToken,
-          tradeType: swapType,
-          v3PoolProvider: this.v3PoolProvider,
-        });
-
-        routesWithValidQuotes.push(routeWithValidQuote);
-      }
-    }
-
-    return { routesWithValidQuotes, candidatePools };
-  }
-
-  private async getV2Quotes(
-    tokenIn: Token,
-    tokenOut: Token,
-    amounts: CurrencyAmount[],
-    percents: number[],
-    quoteToken: Token,
-    gasPriceWei: BigNumber,
-    swapType: TradeType,
-    routingConfig: AlphaRouterConfig
-  ): Promise<{
-    routesWithValidQuotes: V2RouteWithValidQuote[];
-    candidatePools: CandidatePoolsBySelectionCriteria;
-  }> {
-    log.info('Starting to get V2 quotes');
-    // Fetch all the pools that we will consider routing via. There are thousands
-    // of pools, so we filter them to a set of candidate pools that we expect will
-    // result in good prices.
-    const { poolAccessor, candidatePools } = await getV2CandidatePools({
-      tokenIn,
-      tokenOut,
-      tokenProvider: this.tokenProvider,
-      blockedTokenListProvider: this.blockedTokenListProvider,
-      poolProvider: this.v2PoolProvider,
-      routeType: swapType,
-      subgraphProvider: this.v2SubgraphProvider,
-      routingConfig,
-      chainId: this.chainId,
-    });
-    const poolsRaw = poolAccessor.getAllPools();
-
-    // Drop any pools that contain tokens that can not be transferred according to the token validator.
-    const pools = await this.applyTokenValidatorToPools(
-      poolsRaw,
-      (
-        token: Currency,
-        tokenValidation: TokenValidationResult | undefined
-      ): boolean => {
-        // If there is no available validation result we assume the token is fine.
-        if (!tokenValidation) {
-          return false;
-        }
-
-        // Only filters out *intermediate* pools that involve tokens that we detect
-        // cant be transferred. This prevents us trying to route through tokens that may
-        // not be transferrable, but allows users to still swap those tokens if they
-        // specify.
-        if (
-          tokenValidation == TokenValidationResult.STF &&
-          (token.equals(tokenIn) || token.equals(tokenOut))
-        ) {
-          return false;
-        }
-
-        return tokenValidation == TokenValidationResult.STF;
-      }
-    );
-
-    // Given all our candidate pools, compute all the possible ways to route from tokenIn to tokenOut.
-    const { maxSwapsPerPath } = routingConfig;
-    const routes = computeAllV2Routes(
-      tokenIn,
-      tokenOut,
-      pools,
-      maxSwapsPerPath
-    );
-
-    if (routes.length == 0) {
-      return { routesWithValidQuotes: [], candidatePools };
-    }
-
-    // For all our routes, and all the fractional amounts, fetch quotes on-chain.
-    const quoteFn =
-      swapType == TradeType.EXACT_INPUT
-        ? this.v2QuoteProvider.getQuotesManyExactIn.bind(this.v2QuoteProvider)
-        : this.v2QuoteProvider.getQuotesManyExactOut.bind(this.v2QuoteProvider);
-
-    const beforeQuotes = Date.now();
-
-    log.info(
-      `Getting quotes for V2 for ${routes.length} routes with ${amounts.length} amounts per route.`
-    );
-    const { routesWithQuotes } = await quoteFn(amounts, routes);
-
-    const V2gasModel = await this.v2GasModelFactory.buildGasModel({
-      chainId: this.chainId,
-      gasPriceWei,
-      poolProvider: this.v2PoolProvider,
-      token: quoteToken,
-    });
-
-    metric.putMetric(
-      'V2QuotesLoad',
-      Date.now() - beforeQuotes,
-      MetricLoggerUnit.Milliseconds
-    );
-
-    metric.putMetric(
-      'V2QuotesFetched',
-      _(routesWithQuotes)
-        .map(([, quotes]) => quotes.length)
-        .sum(),
-      MetricLoggerUnit.Count
-    );
-
-    const routesWithValidQuotes = [];
-
-    for (const routeWithQuote of routesWithQuotes) {
-      const [route, quotes] = routeWithQuote;
-
-      for (let i = 0; i < quotes.length; i++) {
-        const percent = percents[i]!;
-        const amountQuote = quotes[i]!;
-        const { quote, amount } = amountQuote;
-
-        if (!quote) {
-          log.debug(
-            {
-              route: routeToString(route),
-              amountQuote,
-            },
-            'Dropping a null V2 quote for route.'
-          );
-          continue;
-        }
-
-        const routeWithValidQuote = new V2RouteWithValidQuote({
-          route,
-          rawQuote: quote,
-          amount,
-          percent,
-          gasModel: V2gasModel,
-          quoteToken,
-          tradeType: swapType,
-          v2PoolProvider: this.v2PoolProvider,
-        });
-
-        routesWithValidQuotes.push(routeWithValidQuote);
-      }
-    }
-
-    return { routesWithValidQuotes, candidatePools };
-  }
-
-  private async getMixedRouteQuotes(
-    tokenIn: Token,
-    tokenOut: Token,
-    amounts: CurrencyAmount[],
-    percents: number[],
-    quoteToken: Token,
-    mixedRouteGasModel: IGasModel<MixedRouteWithValidQuote>,
-    swapType: TradeType,
-    routingConfig: AlphaRouterConfig
-  ): Promise<{
-    routesWithValidQuotes: MixedRouteWithValidQuote[];
-    candidatePools: CandidatePoolsBySelectionCriteria;
-  }> {
-    log.info('Starting to get mixed quotes');
-
-    if (swapType != TradeType.EXACT_INPUT) {
-      throw new Error('Mixed route quotes are not supported for EXACT_OUTPUT');
-    }
-
-    const {
-      V2poolAccessor,
-      V3poolAccessor,
-      candidatePools: mixedRouteCandidatePools,
-    } = await getMixedRouteCandidatePools({
-      tokenIn,
-      tokenOut,
-      tokenProvider: this.tokenProvider,
-      blockedTokenListProvider: this.blockedTokenListProvider,
-      v3poolProvider: this.v3PoolProvider,
-      v2poolProvider: this.v2PoolProvider,
-      routeType: swapType,
-      v3subgraphProvider: this.v3SubgraphProvider,
-      v2subgraphProvider: this.v2SubgraphProvider,
-      routingConfig,
-      chainId: this.chainId,
-    });
-
-    const V3poolsRaw = V3poolAccessor.getAllPools();
-    const V2poolsRaw = V2poolAccessor.getAllPools();
-
-    const poolsRaw = [...V3poolsRaw, ...V2poolsRaw];
-
-    const candidatePools = mixedRouteCandidatePools;
-
-    // Drop any pools that contain fee on transfer tokens (not supported by v3) or have issues with being transferred.
-    const pools = await this.applyTokenValidatorToPools(
-      poolsRaw,
-      (
-        token: Currency,
-        tokenValidation: TokenValidationResult | undefined
-      ): boolean => {
-        // If there is no available validation result we assume the token is fine.
-        if (!tokenValidation) {
-          return false;
-        }
-
-        // Only filters out *intermediate* pools that involve tokens that we detect
-        // cant be transferred. This prevents us trying to route through tokens that may
-        // not be transferrable, but allows users to still swap those tokens if they
-        // specify.
-        //
-        if (
-          tokenValidation == TokenValidationResult.STF &&
-          (token.equals(tokenIn) || token.equals(tokenOut))
-        ) {
-          return false;
-        }
-
-        return (
-          tokenValidation == TokenValidationResult.FOT ||
-          tokenValidation == TokenValidationResult.STF
-        );
-      }
-    );
-
-    const { maxSwapsPerPath } = routingConfig;
-
-    const routes = computeAllMixedRoutes(
-      tokenIn,
-      tokenOut,
-      pools,
-      maxSwapsPerPath
-    );
-
-    if (routes.length == 0) {
-      return { routesWithValidQuotes: [], candidatePools };
-    }
-
-    // For all our routes, and all the fractional amounts, fetch quotes on-chain.
-    const quoteFn = this.onChainQuoteProvider.getQuotesManyExactIn.bind(
-      this.onChainQuoteProvider
-    );
-
-    const beforeQuotes = Date.now();
-    log.info(
-      `Getting quotes for mixed for ${routes.length} routes with ${amounts.length} amounts per route.`
-    );
-
-    const { routesWithQuotes } = await quoteFn<MixedRoute>(amounts, routes, {
-      blockNumber: routingConfig.blockNumber,
-    });
-
-    metric.putMetric(
-      'MixedQuotesLoad',
-      Date.now() - beforeQuotes,
-      MetricLoggerUnit.Milliseconds
-    );
-
-    metric.putMetric(
-      'MixedQuotesFetched',
-      _(routesWithQuotes)
-        .map(([, quotes]) => quotes.length)
-        .sum(),
-      MetricLoggerUnit.Count
-    );
-
-    const routesWithValidQuotes = [];
-
-    for (const routeWithQuote of routesWithQuotes) {
-      const [route, quotes] = routeWithQuote;
-
-      for (let i = 0; i < quotes.length; i++) {
-        const percent = percents[i]!;
-        const amountQuote = quotes[i]!;
-        const {
-          quote,
-          amount,
-          sqrtPriceX96AfterList,
-          initializedTicksCrossedList,
-          gasEstimate,
-        } = amountQuote;
-
-        if (
-          !quote ||
-          !sqrtPriceX96AfterList ||
-          !initializedTicksCrossedList ||
-          !gasEstimate
-        ) {
-          log.debug(
-            {
-              route: routeToString(route),
-              amountQuote,
-            },
-            'Dropping a null mixed quote for route.'
-          );
-          continue;
-        }
-
-        const routeWithValidQuote = new MixedRouteWithValidQuote({
-          route,
-          rawQuote: quote,
-          amount,
-          percent,
-          sqrtPriceX96AfterList,
-          initializedTicksCrossedList,
-          quoterGasEstimate: gasEstimate,
-          mixedRouteGasModel,
-          quoteToken,
-          tradeType: swapType,
-          v3PoolProvider: this.v3PoolProvider,
-          v2PoolProvider: this.v2PoolProvider,
-        });
-
-        routesWithValidQuotes.push(routeWithValidQuote);
-      }
-    }
-
-    return { routesWithValidQuotes, candidatePools };
+    return [v2GasModel, v3GasModel, mixedRouteGasModel];
   }
 
   // Note multiplications here can result in a loss of precision in the amounts (e.g. taking 50% of 101)

--- a/src/routers/alpha-router/index.ts
+++ b/src/routers/alpha-router/index.ts
@@ -1,3 +1,4 @@
 export * from './alpha-router';
 export * from './entities';
 export * from './gas-models';
+export * from './quoters';

--- a/src/routers/alpha-router/quoters/index.ts
+++ b/src/routers/alpha-router/quoters/index.ts
@@ -1,0 +1,5 @@
+export * from './model/';
+export * from './quoter';
+export * from './v2-quoter';
+export * from './v3-quoter';
+export * from './mixed-quoter';

--- a/src/routers/alpha-router/quoters/index.ts
+++ b/src/routers/alpha-router/quoters/index.ts
@@ -1,5 +1,5 @@
 export * from './model/';
-export * from './quoter';
+export * from './base-quoter';
 export * from './v2-quoter';
 export * from './v3-quoter';
 export * from './mixed-quoter';

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -1,0 +1,234 @@
+import { Currency, Token, TradeType } from '@uniswap/sdk-core';
+import _ from 'lodash';
+
+import {
+  IOnChainQuoteProvider,
+  ITokenListProvider,
+  ITokenProvider,
+  ITokenValidatorProvider,
+  IV2PoolProvider,
+  IV2SubgraphProvider,
+  IV3PoolProvider,
+  IV3SubgraphProvider,
+  TokenValidationResult
+} from '../../../providers';
+import { ChainId, CurrencyAmount, log, metric, MetricLoggerUnit, routeToString } from '../../../util';
+import { MixedRoute } from '../../router';
+import { AlphaRouterConfig } from '../alpha-router';
+import { MixedRouteWithValidQuote } from '../entities';
+import { computeAllMixedRoutes } from '../functions/compute-all-routes';
+import { CandidatePoolsBySelectionCriteria, getMixedRouteCandidatePools } from '../functions/get-candidate-pools';
+import { IGasModel } from '../gas-models';
+
+import { GetQuotesResult, GetRoutesResult } from './model';
+import { IQuoter } from './quoter';
+
+export class MixedQuoter extends IQuoter<MixedRoute> {
+  protected v3SubgraphProvider: IV3SubgraphProvider;
+  protected v3PoolProvider: IV3PoolProvider;
+  protected v2SubgraphProvider: IV2SubgraphProvider;
+  protected v2PoolProvider: IV2PoolProvider;
+  protected onChainQuoteProvider: IOnChainQuoteProvider;
+
+  constructor(
+    v3SubgraphProvider: IV3SubgraphProvider,
+    v3PoolProvider: IV3PoolProvider,
+    v2SubgraphProvider: IV2SubgraphProvider,
+    v2PoolProvider: IV2PoolProvider,
+    onChainQuoteProvider: IOnChainQuoteProvider,
+    tokenProvider: ITokenProvider,
+    chainId: ChainId,
+    blockedTokenListProvider?: ITokenListProvider,
+    tokenValidatorProvider?: ITokenValidatorProvider
+  ) {
+    super(tokenProvider, chainId, blockedTokenListProvider, tokenValidatorProvider);
+    this.v3SubgraphProvider = v3SubgraphProvider;
+    this.v3PoolProvider = v3PoolProvider;
+    this.v2SubgraphProvider = v2SubgraphProvider;
+    this.v2PoolProvider = v2PoolProvider;
+    this.onChainQuoteProvider = onChainQuoteProvider;
+  }
+
+  protected async getRoutes(
+    tokenIn: Token,
+    tokenOut: Token,
+    tradeType: TradeType,
+    routingConfig: AlphaRouterConfig
+  ): Promise<GetRoutesResult<MixedRoute>> {
+    if (tradeType != TradeType.EXACT_INPUT) {
+      throw new Error('Mixed route quotes are not supported for EXACT_OUTPUT');
+    }
+
+    const {
+      V2poolAccessor,
+      V3poolAccessor,
+      candidatePools: mixedRouteCandidatePools,
+    } = await getMixedRouteCandidatePools({
+      tokenIn,
+      tokenOut,
+      tokenProvider: this.tokenProvider,
+      blockedTokenListProvider: this.blockedTokenListProvider,
+      v3poolProvider: this.v3PoolProvider,
+      v2poolProvider: this.v2PoolProvider,
+      routeType: tradeType,
+      v3subgraphProvider: this.v3SubgraphProvider,
+      v2subgraphProvider: this.v2SubgraphProvider,
+      routingConfig,
+      chainId: this.chainId,
+    });
+
+    const V3poolsRaw = V3poolAccessor.getAllPools();
+    const V2poolsRaw = V2poolAccessor.getAllPools();
+
+    const poolsRaw = [...V3poolsRaw, ...V2poolsRaw];
+
+    const candidatePools = mixedRouteCandidatePools;
+
+    // Drop any pools that contain fee on transfer tokens (not supported by v3) or have issues with being transferred.
+    const pools = await this.applyTokenValidatorToPools(
+      poolsRaw,
+      (
+        token: Currency,
+        tokenValidation: TokenValidationResult | undefined
+      ): boolean => {
+        // If there is no available validation result we assume the token is fine.
+        if (!tokenValidation) {
+          return false;
+        }
+
+        // Only filters out *intermediate* pools that involve tokens that we detect
+        // cant be transferred. This prevents us trying to route through tokens that may
+        // not be transferrable, but allows users to still swap those tokens if they
+        // specify.
+        //
+        if (
+          tokenValidation == TokenValidationResult.STF &&
+          (token.equals(tokenIn) || token.equals(tokenOut))
+        ) {
+          return false;
+        }
+
+        return (
+          tokenValidation == TokenValidationResult.FOT ||
+          tokenValidation == TokenValidationResult.STF
+        );
+      }
+    );
+
+    const { maxSwapsPerPath } = routingConfig;
+
+    const routes = computeAllMixedRoutes(
+      tokenIn,
+      tokenOut,
+      pools,
+      maxSwapsPerPath
+    );
+
+    return {
+      routes,
+      candidatePools
+    };
+  }
+
+  public async getQuotes(
+    routes: MixedRoute[],
+    amounts: CurrencyAmount[],
+    percents: number[],
+    quoteToken: Token,
+    gasModel: IGasModel<MixedRouteWithValidQuote>,
+    tradeType: TradeType,
+    routingConfig: AlphaRouterConfig,
+    candidatePools?: CandidatePoolsBySelectionCriteria
+  ): Promise<GetQuotesResult> {
+    log.info('Starting to get mixed quotes');
+
+    if (routes.length == 0) {
+      return { routesWithValidQuotes: [], candidatePools };
+    }
+
+    // For all our routes, and all the fractional amounts, fetch quotes on-chain.
+    const quoteFn = this.onChainQuoteProvider.getQuotesManyExactIn.bind(
+      this.onChainQuoteProvider
+    );
+
+    const beforeQuotes = Date.now();
+    log.info(
+      `Getting quotes for mixed for ${routes.length} routes with ${amounts.length} amounts per route.`
+    );
+
+    const { routesWithQuotes } = await quoteFn<MixedRoute>(amounts, routes, {
+      blockNumber: routingConfig.blockNumber,
+    });
+
+    metric.putMetric(
+      'MixedQuotesLoad',
+      Date.now() - beforeQuotes,
+      MetricLoggerUnit.Milliseconds
+    );
+
+    metric.putMetric(
+      'MixedQuotesFetched',
+      _(routesWithQuotes)
+        .map(([, quotes]) => quotes.length)
+        .sum(),
+      MetricLoggerUnit.Count
+    );
+
+    const routesWithValidQuotes = [];
+
+    for (const routeWithQuote of routesWithQuotes) {
+      const [route, quotes] = routeWithQuote;
+
+      for (let i = 0; i < quotes.length; i++) {
+        const percent = percents[i]!;
+        const amountQuote = quotes[i]!;
+        const {
+          quote,
+          amount,
+          sqrtPriceX96AfterList,
+          initializedTicksCrossedList,
+          gasEstimate,
+        } = amountQuote;
+
+        if (
+          !quote ||
+          !sqrtPriceX96AfterList ||
+          !initializedTicksCrossedList ||
+          !gasEstimate
+        ) {
+          log.debug(
+            {
+              route: routeToString(route),
+              amountQuote,
+            },
+            'Dropping a null mixed quote for route.'
+          );
+          continue;
+        }
+
+        const routeWithValidQuote = new MixedRouteWithValidQuote({
+          route,
+          rawQuote: quote,
+          amount,
+          percent,
+          sqrtPriceX96AfterList,
+          initializedTicksCrossedList,
+          quoterGasEstimate: gasEstimate,
+          mixedRouteGasModel: gasModel,
+          quoteToken,
+          tradeType,
+          v3PoolProvider: this.v3PoolProvider,
+          v2PoolProvider: this.v2PoolProvider,
+        });
+
+        routesWithValidQuotes.push(routeWithValidQuote);
+      }
+    }
+
+    return {
+      routesWithValidQuotes,
+      candidatePools
+    };
+  }
+
+}

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -20,10 +20,10 @@ import { computeAllMixedRoutes } from '../functions/compute-all-routes';
 import { CandidatePoolsBySelectionCriteria, getMixedRouteCandidatePools } from '../functions/get-candidate-pools';
 import { IGasModel } from '../gas-models';
 
+import { BaseQuoter } from './base-quoter';
 import { GetQuotesResult, GetRoutesResult } from './model';
-import { IQuoter } from './quoter';
 
-export class MixedQuoter extends IQuoter<MixedRoute> {
+export class MixedQuoter extends BaseQuoter<MixedRoute> {
   protected v3SubgraphProvider: IV3SubgraphProvider;
   protected v3PoolProvider: IV3PoolProvider;
   protected v2SubgraphProvider: IV2SubgraphProvider;

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -135,13 +135,15 @@ export class MixedQuoter extends IQuoter<MixedRoute> {
     amounts: CurrencyAmount[],
     percents: number[],
     quoteToken: Token,
-    gasModel: IGasModel<MixedRouteWithValidQuote>,
     tradeType: TradeType,
     routingConfig: AlphaRouterConfig,
-    candidatePools?: CandidatePoolsBySelectionCriteria
+    candidatePools: CandidatePoolsBySelectionCriteria,
+    gasModel?: IGasModel<MixedRouteWithValidQuote>
   ): Promise<GetQuotesResult> {
     log.info('Starting to get mixed quotes');
-
+    if (gasModel === undefined) {
+      throw new Error('GasModel for MixedRouteWithValidQuote is required to getQuotes');
+    }
     if (routes.length == 0) {
       return { routesWithValidQuotes: [], candidatePools };
     }

--- a/src/routers/alpha-router/quoters/model/index.ts
+++ b/src/routers/alpha-router/quoters/model/index.ts
@@ -1,0 +1,1 @@
+export * from './results';

--- a/src/routers/alpha-router/quoters/model/results/get-quotes-result.ts
+++ b/src/routers/alpha-router/quoters/model/results/get-quotes-result.ts
@@ -1,0 +1,7 @@
+import { RouteWithValidQuote } from '../../../entities';
+import { CandidatePoolsBySelectionCriteria } from '../../../functions/get-candidate-pools';
+
+export interface GetQuotesResult {
+  routesWithValidQuotes: RouteWithValidQuote[];
+  candidatePools?: CandidatePoolsBySelectionCriteria;
+}

--- a/src/routers/alpha-router/quoters/model/results/get-quotes-result.ts
+++ b/src/routers/alpha-router/quoters/model/results/get-quotes-result.ts
@@ -3,5 +3,5 @@ import { CandidatePoolsBySelectionCriteria } from '../../../functions/get-candid
 
 export interface GetQuotesResult {
   routesWithValidQuotes: RouteWithValidQuote[];
-  candidatePools?: CandidatePoolsBySelectionCriteria;
+  candidatePools: CandidatePoolsBySelectionCriteria;
 }

--- a/src/routers/alpha-router/quoters/model/results/get-routes-result.ts
+++ b/src/routers/alpha-router/quoters/model/results/get-routes-result.ts
@@ -1,0 +1,7 @@
+import { MixedRoute, V2Route, V3Route } from '../../../../router';
+import { CandidatePoolsBySelectionCriteria } from '../../../functions/get-candidate-pools';
+
+export interface GetRoutesResult<Route extends V2Route | V3Route | MixedRoute> {
+  routes: Route[];
+  candidatePools: CandidatePoolsBySelectionCriteria;
+}

--- a/src/routers/alpha-router/quoters/model/results/index.ts
+++ b/src/routers/alpha-router/quoters/model/results/index.ts
@@ -1,0 +1,2 @@
+export * from './get-routes-result';
+export * from './get-quotes-result';

--- a/src/routers/alpha-router/quoters/quoter.ts
+++ b/src/routers/alpha-router/quoters/quoter.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from '@ethersproject/bignumber';
 import { Currency, Token, TradeType } from '@uniswap/sdk-core';
 import { Pair } from '@uniswap/v2-sdk';
 import { Pool } from '@uniswap/v3-sdk';
@@ -44,10 +45,11 @@ export abstract class IQuoter<Route extends V2Route | V3Route | MixedRoute> {
     amounts: CurrencyAmount[],
     percents: number[],
     quoteToken: Token,
-    gasModel: IGasModel<RouteWithValidQuote>,
     tradeType: TradeType,
     routingConfig: AlphaRouterConfig,
-    candidatePools?: CandidatePoolsBySelectionCriteria
+    candidatePools: CandidatePoolsBySelectionCriteria,
+    gasModel?: IGasModel<RouteWithValidQuote>,
+    gasPriceWei?: BigNumber
   ): Promise<GetQuotesResult>
 
   public async getRoutesThenQuotes(
@@ -56,9 +58,10 @@ export abstract class IQuoter<Route extends V2Route | V3Route | MixedRoute> {
     amounts: CurrencyAmount[],
     percents: number[],
     quoteToken: Token,
-    gasModel: IGasModel<RouteWithValidQuote>,
     tradeType: TradeType,
-    routingConfig: AlphaRouterConfig
+    routingConfig: AlphaRouterConfig,
+    gasModel?: IGasModel<RouteWithValidQuote>,
+    gasPriceWei?: BigNumber
   ): Promise<GetQuotesResult> {
     return this.getRoutes(tokenIn, tokenOut, tradeType, routingConfig)
       .then((routesResult) =>
@@ -67,10 +70,11 @@ export abstract class IQuoter<Route extends V2Route | V3Route | MixedRoute> {
           amounts,
           percents,
           quoteToken,
-          gasModel,
           tradeType,
           routingConfig,
-          routesResult.candidatePools
+          routesResult.candidatePools,
+          gasModel,
+          gasPriceWei
         )
       );
   }

--- a/src/routers/alpha-router/quoters/quoter.ts
+++ b/src/routers/alpha-router/quoters/quoter.ts
@@ -1,0 +1,118 @@
+import { Currency, Token, TradeType } from '@uniswap/sdk-core';
+import { Pair } from '@uniswap/v2-sdk';
+import { Pool } from '@uniswap/v3-sdk';
+import _ from 'lodash';
+
+import { ITokenListProvider, ITokenProvider, ITokenValidatorProvider, TokenValidationResult } from '../../../providers';
+import { ChainId, CurrencyAmount, log, poolToString } from '../../../util';
+import { MixedRoute, V2Route, V3Route } from '../../router';
+import { AlphaRouterConfig } from '../alpha-router';
+import { RouteWithValidQuote } from '../entities/route-with-valid-quote';
+import { CandidatePoolsBySelectionCriteria } from '../functions/get-candidate-pools';
+import { IGasModel } from '../gas-models';
+
+import { GetQuotesResult } from './model/results/get-quotes-result';
+import { GetRoutesResult } from './model/results/get-routes-result';
+
+export abstract class IQuoter<Route extends V2Route | V3Route | MixedRoute> {
+  protected tokenProvider: ITokenProvider;
+  protected chainId: ChainId;
+  protected blockedTokenListProvider?: ITokenListProvider;
+  protected tokenValidatorProvider?: ITokenValidatorProvider;
+
+  constructor(
+    tokenProvider: ITokenProvider,
+    chainId: ChainId,
+    blockedTokenListProvider?: ITokenListProvider,
+    tokenValidatorProvider?: ITokenValidatorProvider
+  ) {
+    this.tokenProvider = tokenProvider;
+    this.chainId = chainId;
+    this.blockedTokenListProvider = blockedTokenListProvider;
+    this.tokenValidatorProvider = tokenValidatorProvider;
+  }
+
+  protected abstract getRoutes(
+    tokenIn: Token,
+    tokenOut: Token,
+    tradeType: TradeType,
+    routingConfig: AlphaRouterConfig
+  ): Promise<GetRoutesResult<Route>>
+
+  abstract getQuotes(
+    routes: Route[],
+    amounts: CurrencyAmount[],
+    percents: number[],
+    quoteToken: Token,
+    gasModel: IGasModel<RouteWithValidQuote>,
+    tradeType: TradeType,
+    routingConfig: AlphaRouterConfig,
+    candidatePools?: CandidatePoolsBySelectionCriteria
+  ): Promise<GetQuotesResult>
+
+  public async getRoutesThenQuotes(
+    tokenIn: Token,
+    tokenOut: Token,
+    amounts: CurrencyAmount[],
+    percents: number[],
+    quoteToken: Token,
+    gasModel: IGasModel<RouteWithValidQuote>,
+    tradeType: TradeType,
+    routingConfig: AlphaRouterConfig
+  ): Promise<GetQuotesResult> {
+    return this.getRoutes(tokenIn, tokenOut, tradeType, routingConfig)
+      .then((routesResult) =>
+        this.getQuotes(
+          routesResult.routes,
+          amounts,
+          percents,
+          quoteToken,
+          gasModel,
+          tradeType,
+          routingConfig,
+          routesResult.candidatePools
+        )
+      );
+  }
+
+  protected async applyTokenValidatorToPools<T extends Pool | Pair>(
+    pools: T[],
+    isInvalidFn: (
+      token: Currency,
+      tokenValidation: TokenValidationResult | undefined
+    ) => boolean
+  ): Promise<T[]> {
+    if (!this.tokenValidatorProvider) {
+      return pools;
+    }
+
+    log.info(`Running token validator on ${pools.length} pools`);
+
+    const tokens = _.flatMap(pools, (pool) => [pool.token0, pool.token1]);
+
+    const tokenValidationResults = await this.tokenValidatorProvider.validateTokens(tokens);
+
+    const poolsFiltered = _.filter(pools, (pool: T) => {
+      const token0Validation = tokenValidationResults.getValidationByToken(
+        pool.token0
+      );
+      const token1Validation = tokenValidationResults.getValidationByToken(
+        pool.token1
+      );
+
+      const token0Invalid = isInvalidFn(pool.token0, token0Validation);
+      const token1Invalid = isInvalidFn(pool.token1, token1Validation);
+
+      if (token0Invalid || token1Invalid) {
+        log.info(
+          `Dropping pool ${poolToString(pool)} because token is invalid. ${pool.token0.symbol
+          }: ${token0Validation}, ${pool.token1.symbol}: ${token1Validation}`
+        );
+      }
+
+      return !token0Invalid && !token1Invalid;
+    });
+
+    return poolsFiltered;
+  }
+}

--- a/src/routers/alpha-router/quoters/quoter.ts
+++ b/src/routers/alpha-router/quoters/quoter.ts
@@ -52,7 +52,7 @@ export abstract class IQuoter<Route extends V2Route | V3Route | MixedRoute> {
     gasPriceWei?: BigNumber
   ): Promise<GetQuotesResult>
 
-  public async getRoutesThenQuotes(
+  public getRoutesThenQuotes(
     tokenIn: Token,
     tokenOut: Token,
     amounts: CurrencyAmount[],

--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -1,0 +1,193 @@
+import { Currency, Token, TradeType } from '@uniswap/sdk-core';
+import _ from 'lodash';
+
+import {
+  ITokenListProvider,
+  ITokenProvider,
+  ITokenValidatorProvider,
+  IV2PoolProvider,
+  IV2QuoteProvider,
+  IV2SubgraphProvider,
+  TokenValidationResult
+} from '../../../providers';
+import { ChainId, CurrencyAmount, log, metric, MetricLoggerUnit, routeToString } from '../../../util';
+import { V2Route } from '../../router';
+import { AlphaRouterConfig } from '../alpha-router';
+import { V2RouteWithValidQuote } from '../entities';
+import { computeAllV2Routes } from '../functions/compute-all-routes';
+import { CandidatePoolsBySelectionCriteria, getV2CandidatePools } from '../functions/get-candidate-pools';
+import { IGasModel } from '../gas-models';
+
+import { GetQuotesResult } from './model/results/get-quotes-result';
+import { GetRoutesResult } from './model/results/get-routes-result';
+import { IQuoter } from './quoter';
+
+export class V2Quoter extends IQuoter<V2Route> {
+  protected v2SubgraphProvider: IV2SubgraphProvider;
+  protected v2PoolProvider: IV2PoolProvider;
+  protected v2QuoteProvider: IV2QuoteProvider;
+
+  constructor(
+    v2SubgraphProvider: IV2SubgraphProvider,
+    v2PoolProvider: IV2PoolProvider,
+    v2QuoteProvider: IV2QuoteProvider,
+    tokenProvider: ITokenProvider,
+    chainId: ChainId,
+    blockedTokenListProvider?: ITokenListProvider,
+    tokenValidatorProvider?: ITokenValidatorProvider
+  ) {
+    super(tokenProvider, chainId, blockedTokenListProvider, tokenValidatorProvider);
+    this.v2SubgraphProvider = v2SubgraphProvider;
+    this.v2PoolProvider = v2PoolProvider;
+    this.v2QuoteProvider = v2QuoteProvider;
+  }
+
+  protected async getRoutes(
+    tokenIn: Token,
+    tokenOut: Token,
+    tradeType: TradeType,
+    routingConfig: AlphaRouterConfig
+  ): Promise<GetRoutesResult<V2Route>> {
+    // Fetch all the pools that we will consider routing via. There are thousands
+    // of pools, so we filter them to a set of candidate pools that we expect will
+    // result in good prices.
+    const { poolAccessor, candidatePools } = await getV2CandidatePools({
+      tokenIn,
+      tokenOut,
+      tokenProvider: this.tokenProvider,
+      blockedTokenListProvider: this.blockedTokenListProvider,
+      poolProvider: this.v2PoolProvider,
+      routeType: tradeType,
+      subgraphProvider: this.v2SubgraphProvider,
+      routingConfig,
+      chainId: this.chainId,
+    });
+    const poolsRaw = poolAccessor.getAllPools();
+
+    // Drop any pools that contain tokens that can not be transferred according to the token validator.
+    const pools = await this.applyTokenValidatorToPools(
+      poolsRaw,
+      (
+        token: Currency,
+        tokenValidation: TokenValidationResult | undefined
+      ): boolean => {
+        // If there is no available validation result we assume the token is fine.
+        if (!tokenValidation) {
+          return false;
+        }
+
+        // Only filters out *intermediate* pools that involve tokens that we detect
+        // cant be transferred. This prevents us trying to route through tokens that may
+        // not be transferrable, but allows users to still swap those tokens if they
+        // specify.
+        if (
+          tokenValidation == TokenValidationResult.STF &&
+          (token.equals(tokenIn) || token.equals(tokenOut))
+        ) {
+          return false;
+        }
+
+        return tokenValidation == TokenValidationResult.STF;
+      }
+    );
+
+    // Given all our candidate pools, compute all the possible ways to route from tokenIn to tokenOut.
+    const { maxSwapsPerPath } = routingConfig;
+    const routes = computeAllV2Routes(
+      tokenIn,
+      tokenOut,
+      pools,
+      maxSwapsPerPath
+    );
+
+    return {
+      routes,
+      candidatePools,
+    };
+  }
+
+  public async getQuotes(
+    routes: V2Route[],
+    amounts: CurrencyAmount[],
+    percents: number[],
+    quoteToken: Token,
+    gasModel: IGasModel<V2RouteWithValidQuote>,
+    tradeType: TradeType,
+    _routingConfig: AlphaRouterConfig,
+    candidatePools?: CandidatePoolsBySelectionCriteria
+  ): Promise<GetQuotesResult> {
+    log.info('Starting to get V2 quotes');
+
+    if (routes.length == 0) {
+      return { routesWithValidQuotes: [], candidatePools };
+    }
+
+    // For all our routes, and all the fractional amounts, fetch quotes on-chain.
+    const quoteFn =
+      tradeType == TradeType.EXACT_INPUT
+        ? this.v2QuoteProvider.getQuotesManyExactIn.bind(this.v2QuoteProvider)
+        : this.v2QuoteProvider.getQuotesManyExactOut.bind(this.v2QuoteProvider);
+
+    const beforeQuotes = Date.now();
+
+    log.info(
+      `Getting quotes for V2 for ${routes.length} routes with ${amounts.length} amounts per route.`
+    );
+    const { routesWithQuotes } = await quoteFn(amounts, routes);
+
+    metric.putMetric(
+      'V2QuotesLoad',
+      Date.now() - beforeQuotes,
+      MetricLoggerUnit.Milliseconds
+    );
+
+    metric.putMetric(
+      'V2QuotesFetched',
+      _(routesWithQuotes)
+        .map(([, quotes]) => quotes.length)
+        .sum(),
+      MetricLoggerUnit.Count
+    );
+
+    const routesWithValidQuotes = [];
+
+    for (const routeWithQuote of routesWithQuotes) {
+      const [route, quotes] = routeWithQuote;
+
+      for (let i = 0; i < quotes.length; i++) {
+        const percent = percents[i]!;
+        const amountQuote = quotes[i]!;
+        const { quote, amount } = amountQuote;
+
+        if (!quote) {
+          log.debug(
+            {
+              route: routeToString(route),
+              amountQuote,
+            },
+            'Dropping a null V2 quote for route.'
+          );
+          continue;
+        }
+
+        const routeWithValidQuote = new V2RouteWithValidQuote({
+          route,
+          rawQuote: quote,
+          amount,
+          percent,
+          gasModel: gasModel,
+          quoteToken,
+          tradeType,
+          v2PoolProvider: this.v2PoolProvider,
+        });
+
+        routesWithValidQuotes.push(routeWithValidQuote);
+      }
+    }
+
+    return {
+      routesWithValidQuotes,
+      candidatePools
+    };
+  }
+}

--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -19,11 +19,11 @@ import { computeAllV2Routes } from '../functions/compute-all-routes';
 import { CandidatePoolsBySelectionCriteria, getV2CandidatePools } from '../functions/get-candidate-pools';
 import { IGasModel, IV2GasModelFactory } from '../gas-models';
 
+import { BaseQuoter } from './base-quoter';
 import { GetQuotesResult } from './model/results/get-quotes-result';
 import { GetRoutesResult } from './model/results/get-routes-result';
-import { IQuoter } from './quoter';
 
-export class V2Quoter extends IQuoter<V2Route> {
+export class V2Quoter extends BaseQuoter<V2Route> {
   protected v2SubgraphProvider: IV2SubgraphProvider;
   protected v2PoolProvider: IV2PoolProvider;
   protected v2QuoteProvider: IV2QuoteProvider;

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -18,11 +18,11 @@ import { computeAllV3Routes } from '../functions/compute-all-routes';
 import { CandidatePoolsBySelectionCriteria, getV3CandidatePools } from '../functions/get-candidate-pools';
 import { IGasModel } from '../gas-models';
 
+import { BaseQuoter } from './base-quoter';
 import { GetQuotesResult } from './model/results/get-quotes-result';
 import { GetRoutesResult } from './model/results/get-routes-result';
-import { IQuoter } from './quoter';
 
-export class V3Quoter extends IQuoter<V3Route> {
+export class V3Quoter extends BaseQuoter<V3Route> {
   protected v3SubgraphProvider: IV3SubgraphProvider;
   protected v3PoolProvider: IV3PoolProvider;
   protected onChainQuoteProvider: IOnChainQuoteProvider;

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -1,0 +1,217 @@
+import { Currency, Token, TradeType } from '@uniswap/sdk-core';
+import _ from 'lodash';
+
+import {
+  IOnChainQuoteProvider,
+  ITokenListProvider,
+  ITokenProvider,
+  ITokenValidatorProvider,
+  IV3PoolProvider,
+  IV3SubgraphProvider,
+  TokenValidationResult
+} from '../../../providers';
+import { ChainId, CurrencyAmount, log, metric, MetricLoggerUnit, routeToString } from '../../../util';
+import { V3Route } from '../../router';
+import { AlphaRouterConfig } from '../alpha-router';
+import { V3RouteWithValidQuote } from '../entities';
+import { computeAllV3Routes } from '../functions/compute-all-routes';
+import { CandidatePoolsBySelectionCriteria, getV3CandidatePools } from '../functions/get-candidate-pools';
+import { IGasModel } from '../gas-models';
+
+import { GetQuotesResult } from './model/results/get-quotes-result';
+import { GetRoutesResult } from './model/results/get-routes-result';
+import { IQuoter } from './quoter';
+
+export class V3Quoter extends IQuoter<V3Route> {
+  protected v3SubgraphProvider: IV3SubgraphProvider;
+  protected v3PoolProvider: IV3PoolProvider;
+  protected onChainQuoteProvider: IOnChainQuoteProvider;
+
+  constructor(
+    v3SubgraphProvider: IV3SubgraphProvider,
+    v3PoolProvider: IV3PoolProvider,
+    onChainQuoteProvider: IOnChainQuoteProvider,
+    tokenProvider: ITokenProvider,
+    chainId: ChainId,
+    blockedTokenListProvider?: ITokenListProvider,
+    tokenValidatorProvider?: ITokenValidatorProvider
+  ) {
+    super(tokenProvider, chainId, blockedTokenListProvider, tokenValidatorProvider);
+    this.v3SubgraphProvider = v3SubgraphProvider;
+    this.v3PoolProvider = v3PoolProvider;
+    this.onChainQuoteProvider = onChainQuoteProvider;
+  }
+
+  protected async getRoutes(
+    tokenIn: Token,
+    tokenOut: Token,
+    tradeType: TradeType,
+    routingConfig: AlphaRouterConfig
+  ): Promise<GetRoutesResult<V3Route>> {
+    // Fetch all the pools that we will consider routing via. There are thousands
+    // of pools, so we filter them to a set of candidate pools that we expect will
+    // result in good prices.
+    const { poolAccessor, candidatePools } = await getV3CandidatePools({
+      tokenIn,
+      tokenOut,
+      tokenProvider: this.tokenProvider,
+      blockedTokenListProvider: this.blockedTokenListProvider,
+      poolProvider: this.v3PoolProvider,
+      routeType: tradeType,
+      subgraphProvider: this.v3SubgraphProvider,
+      routingConfig,
+      chainId: this.chainId,
+    });
+    const poolsRaw = poolAccessor.getAllPools();
+
+    // Drop any pools that contain fee on transfer tokens (not supported by v3) or have issues with being transferred.
+    const pools = await this.applyTokenValidatorToPools(
+      poolsRaw,
+      (
+        token: Currency,
+        tokenValidation: TokenValidationResult | undefined
+      ): boolean => {
+        // If there is no available validation result we assume the token is fine.
+        if (!tokenValidation) {
+          return false;
+        }
+
+        // Only filters out *intermediate* pools that involve tokens that we detect
+        // cant be transferred. This prevents us trying to route through tokens that may
+        // not be transferrable, but allows users to still swap those tokens if they
+        // specify.
+        //
+        if (
+          tokenValidation == TokenValidationResult.STF &&
+          (token.equals(tokenIn) || token.equals(tokenOut))
+        ) {
+          return false;
+        }
+
+        return (
+          tokenValidation == TokenValidationResult.FOT ||
+          tokenValidation == TokenValidationResult.STF
+        );
+      }
+    );
+
+    // Given all our candidate pools, compute all the possible ways to route from tokenIn to tokenOut.
+    const { maxSwapsPerPath } = routingConfig;
+    const routes = computeAllV3Routes(
+      tokenIn,
+      tokenOut,
+      pools,
+      maxSwapsPerPath
+    );
+
+    return {
+      routes,
+      candidatePools,
+    };
+  }
+
+  public async getQuotes(
+    routes: V3Route[],
+    amounts: CurrencyAmount[],
+    percents: number[],
+    quoteToken: Token,
+    gasModel: IGasModel<V3RouteWithValidQuote>,
+    tradeType: TradeType,
+    routingConfig: AlphaRouterConfig,
+    candidatePools?: CandidatePoolsBySelectionCriteria,
+  ): Promise<GetQuotesResult> {
+    log.info('Starting to get V3 quotes');
+
+    if (routes.length == 0) {
+      return { routesWithValidQuotes: [], candidatePools };
+    }
+
+    // For all our routes, and all the fractional amounts, fetch quotes on-chain.
+    const quoteFn =
+      tradeType == TradeType.EXACT_INPUT
+        ? this.onChainQuoteProvider.getQuotesManyExactIn.bind(
+          this.onChainQuoteProvider
+        )
+        : this.onChainQuoteProvider.getQuotesManyExactOut.bind(
+          this.onChainQuoteProvider
+        );
+
+    const beforeQuotes = Date.now();
+    log.info(
+      `Getting quotes for V3 for ${routes.length} routes with ${amounts.length} amounts per route.`
+    );
+
+    const { routesWithQuotes } = await quoteFn<V3Route>(amounts, routes, {
+      blockNumber: routingConfig.blockNumber,
+    });
+
+    metric.putMetric(
+      'V3QuotesLoad',
+      Date.now() - beforeQuotes,
+      MetricLoggerUnit.Milliseconds
+    );
+
+    metric.putMetric(
+      'V3QuotesFetched',
+      _(routesWithQuotes)
+        .map(([, quotes]) => quotes.length)
+        .sum(),
+      MetricLoggerUnit.Count
+    );
+
+    const routesWithValidQuotes = [];
+
+    for (const routeWithQuote of routesWithQuotes) {
+      const [route, quotes] = routeWithQuote;
+
+      for (let i = 0; i < quotes.length; i++) {
+        const percent = percents[i]!;
+        const amountQuote = quotes[i]!;
+        const {
+          quote,
+          amount,
+          sqrtPriceX96AfterList,
+          initializedTicksCrossedList,
+          gasEstimate,
+        } = amountQuote;
+
+        if (
+          !quote ||
+          !sqrtPriceX96AfterList ||
+          !initializedTicksCrossedList ||
+          !gasEstimate
+        ) {
+          log.debug(
+            {
+              route: routeToString(route),
+              amountQuote,
+            },
+            'Dropping a null V3 quote for route.'
+          );
+          continue;
+        }
+
+        const routeWithValidQuote = new V3RouteWithValidQuote({
+          route,
+          rawQuote: quote,
+          amount,
+          percent,
+          sqrtPriceX96AfterList,
+          initializedTicksCrossedList,
+          quoterGasEstimate: gasEstimate,
+          gasModel,
+          quoteToken,
+          tradeType,
+          v3PoolProvider: this.v3PoolProvider,
+        });
+
+        routesWithValidQuotes.push(routeWithValidQuote);
+      }
+    }
+
+    return {
+      routesWithValidQuotes,
+      candidatePools
+    };
+  }
+}

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -115,12 +115,16 @@ export class V3Quoter extends IQuoter<V3Route> {
     amounts: CurrencyAmount[],
     percents: number[],
     quoteToken: Token,
-    gasModel: IGasModel<V3RouteWithValidQuote>,
     tradeType: TradeType,
     routingConfig: AlphaRouterConfig,
-    candidatePools?: CandidatePoolsBySelectionCriteria,
+    candidatePools: CandidatePoolsBySelectionCriteria,
+    gasModel?: IGasModel<V3RouteWithValidQuote>
   ): Promise<GetQuotesResult> {
     log.info('Starting to get V3 quotes');
+
+    if (gasModel === undefined) {
+      throw new Error('GasModel for V3RouteWithValidQuote is required to getQuotes');
+    }
 
     if (routes.length == 0) {
       return { routesWithValidQuotes: [], candidatePools };


### PR DESCRIPTION
- Create Quoters and encapsulate business logic
- remove unecessary imports
- build v2 gasmodel inside the quoter

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a refactor of code, it encapsulates the logic of fetching routes and quoting per protocol into their own classes with a shared interface

- **What is the current behavior?** (You can also link to an open issue here)
Currently all the quoting logic is inside AlphaRouter, it is a little hard to read the code since it is not encapsulated

- **What is the new behavior (if this is a feature change)?**
New abstraction, interface and encapsulation. It makes the code more readable and easier to work with

- **Other information**:
Tests are currently being delegated to the tests in AlphaRouter test suite. Pulling the respective tests from there will take some time and I would prefer to do that in a different branch. Given that no new business logic is introduced we can rest assured that the current test coverage is not bad nor worse, but it serves as evidence of the need to create more abstractions with their respective test suites.