### PR TITLE
Take the TopN for each second hop

### DIFF
--- a/cli/base-command.ts
+++ b/cli/base-command.ts
@@ -17,8 +17,8 @@ import {
   CachingTokenListProvider,
   CachingTokenProviderWithFallback,
   CachingV3PoolProvider,
-  ChainId,
   CHAIN_IDS_LIST,
+  ChainId,
   EIP1559GasPriceProvider,
   EthEstimateGasSimulator,
   FallbackTenderlySimulator,
@@ -61,7 +61,7 @@ export abstract class BaseCommand extends Command {
     }),
     topNSecondHop: flags.integer({
       required: false,
-      default: 0,
+      default: 2,
     }),
     topNWithEachBaseToken: flags.integer({
       required: false,
@@ -125,8 +125,8 @@ export abstract class BaseCommand extends Command {
     return this._log
       ? this._log
       : bunyan.createLogger({
-          name: 'Default Logger',
-        });
+        name: 'Default Logger',
+      });
   }
 
   get router() {
@@ -196,19 +196,19 @@ export abstract class BaseCommand extends Command {
       streams: debugJSON
         ? undefined
         : [
-            {
-              level: logLevel,
-              type: 'stream',
-              stream: bunyanDebugStream({
-                basepath: __dirname,
-                forceColor: false,
-                showDate: false,
-                showPid: false,
-                showLoggerName: false,
-                showLevel: !!debug,
-              }),
-            },
-          ],
+          {
+            level: logLevel,
+            type: 'stream',
+            stream: bunyanDebugStream({
+              basepath: __dirname,
+              forceColor: false,
+              showDate: false,
+              showPid: false,
+              showLoggerName: false,
+              showLevel: !!debug,
+            }),
+          },
+        ],
     });
 
     if (debug || debugJSON) {

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -3,11 +3,7 @@ import { Token, TradeType } from '@uniswap/sdk-core';
 import { FeeAmount } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
-import {
-  ITokenListProvider,
-  IV2SubgraphProvider,
-  V2SubgraphPool,
-} from '../../../providers';
+import { ITokenListProvider, IV2SubgraphProvider, V2SubgraphPool, } from '../../../providers';
 import {
   CELO,
   CELO_ALFAJORES,
@@ -57,18 +53,9 @@ import {
   WMATIC_POLYGON_MUMBAI,
   WXDAI_GNOSIS,
 } from '../../../providers/token-provider';
-import {
-  IV2PoolProvider,
-  V2PoolAccessor,
-} from '../../../providers/v2/pool-provider';
-import {
-  IV3PoolProvider,
-  V3PoolAccessor,
-} from '../../../providers/v3/pool-provider';
-import {
-  IV3SubgraphProvider,
-  V3SubgraphPool,
-} from '../../../providers/v3/subgraph-provider';
+import { IV2PoolProvider, V2PoolAccessor, } from '../../../providers/v2/pool-provider';
+import { IV3PoolProvider, V3PoolAccessor, } from '../../../providers/v3/pool-provider';
+import { IV3SubgraphProvider, V3SubgraphPool, } from '../../../providers/v3/subgraph-provider';
 import { ChainId, WRAPPED_NATIVE_CURRENCY } from '../../../util';
 import { parseFeeAmount, unparseFeeAmount } from '../../../util/amounts';
 import { log } from '../../../util/log';
@@ -330,7 +317,7 @@ export async function getV3CandidatePools({
       return (
         !poolAddressesSoFar.has(subgraphPool.id) &&
         ((subgraphPool.token0.id == tokenInAddress &&
-          subgraphPool.token1.id == tokenOutAddress) ||
+            subgraphPool.token1.id == tokenOutAddress) ||
           (subgraphPool.token1.id == tokenInAddress &&
             subgraphPool.token0.id == tokenOutAddress))
       );
@@ -463,8 +450,6 @@ export async function getV3CandidatePools({
         .value();
     })
     .uniqBy((pool) => pool.id)
-    .sortBy((tokenListPool) => -tokenListPool.tvlUSD)
-    .slice(0, topNSecondHop)
     .value();
 
   addToAddressSet(topByTVLUsingTokenInSecondHops);
@@ -488,8 +473,6 @@ export async function getV3CandidatePools({
         .value();
     })
     .uniqBy((pool) => pool.id)
-    .sortBy((tokenListPool) => -tokenListPool.tvlUSD)
-    .slice(0, topNSecondHop)
     .value();
 
   addToAddressSet(topByTVLUsingTokenOutSecondHops);
@@ -854,8 +837,6 @@ export async function getV2CandidatePools({
         .value();
     })
     .uniqBy((pool) => pool.id)
-    .sortBy((tokenListPool) => -tokenListPool.reserve)
-    .slice(0, topNSecondHop)
     .value();
 
   addToAddressSet(topByTVLUsingTokenInSecondHops);
@@ -879,8 +860,6 @@ export async function getV2CandidatePools({
         .value();
     })
     .uniqBy((pool) => pool.id)
-    .sortBy((tokenListPool) => -tokenListPool.reserve)
-    .slice(0, topNSecondHop)
     .value();
 
   addToAddressSet(topByTVLUsingTokenOutSecondHops);
@@ -1033,19 +1012,19 @@ export async function getMixedRouteCandidatePools({
    *
    * This way we can reduce calls to our provider since it's possible to generate a lot of mixed routes
    */
-  /// We only really care about pools involving the tokenIn or tokenOut explictly,
-  /// since there's no way a long tail token in V2 would be routed through as an intermediary
+    /// We only really care about pools involving the tokenIn or tokenOut explictly,
+    /// since there's no way a long tail token in V2 would be routed through as an intermediary
   const V2topByTVLPoolIds = new Set(
-    [
-      ...V2candidatePools.selections.topByTVLUsingTokenIn,
-      ...V2candidatePools.selections.topByBaseWithTokenIn,
-      /// tokenOut:
-      ...V2candidatePools.selections.topByTVLUsingTokenOut,
-      ...V2candidatePools.selections.topByBaseWithTokenOut,
-      /// Direct swap:
-      ...V2candidatePools.selections.topByDirectSwapPool,
-    ].map((poolId) => poolId.id)
-  );
+      [
+        ...V2candidatePools.selections.topByTVLUsingTokenIn,
+        ...V2candidatePools.selections.topByBaseWithTokenIn,
+        /// tokenOut:
+        ...V2candidatePools.selections.topByTVLUsingTokenOut,
+        ...V2candidatePools.selections.topByBaseWithTokenOut,
+        /// Direct swap:
+        ...V2candidatePools.selections.topByDirectSwapPool,
+      ].map((poolId) => poolId.id)
+    );
 
   const V2topByTVLSortedPools = _(V2subgraphPools)
     .filter((pool) => V2topByTVLPoolIds.has(pool.id))


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a bug fix.

- **What is the current behavior?** (You can also link to an open issue here)
We were previously only taking the TopN pools of *all* second hop tokens, which could end up being all pools for the same second hop token, It would return an incomplete exploration of the second hops.

- **What is the new behavior (if this is a feature change)?**
With this change we will now take the topN pools for each second hop, it will potentially result in more routes to be explored, but it will explore all routes that require a second hop.

- **Other information**:
Routing Configuration might need to be adjusted based on this change
