### PR TITLE
Allow more granularity when selection topN for second hops

### DIFF
--- a/cli/base-command.ts
+++ b/cli/base-command.ts
@@ -63,6 +63,10 @@ export abstract class BaseCommand extends Command {
       required: false,
       default: 2,
     }),
+    topNSecondHopForTokenAddressRaw: flags.string({
+      required: false,
+      default: '',
+    }),
     topNWithEachBaseToken: flags.integer({
       required: false,
       default: 2,

--- a/cli/commands/quote.ts
+++ b/cli/commands/quote.ts
@@ -74,9 +74,6 @@ export class Quote extends BaseCommand {
     const topNSecondHopForTokenAddress = new Map();
     topNSecondHopForTokenAddressRaw.split(',').forEach((entry) => {
       if (entry != '') {
-        log.error('parsed stuff');
-        log.error(topNSecondHopForTokenAddressRaw);
-        log.error(entry);
         const entryParts = entry.split('|');
         if (entryParts.length != 2) {
           throw new Error(

--- a/cli/commands/quote.ts
+++ b/cli/commands/quote.ts
@@ -65,15 +65,26 @@ export class Quote extends BaseCommand {
       simulate,
     } = flags;
 
+    const chainId = ID_TO_CHAIN_ID(chainIdNumb);
+
+    const log = this.logger;
+    const tokenProvider = this.tokenProvider;
+    const router = this.router;
+
     const topNSecondHopForTokenAddress = new Map();
     topNSecondHopForTokenAddressRaw.split(',').forEach((entry) => {
-      const entryParts = entry.split('|');
-      if (entryParts.length != 2) {
-        throw new Error(
-          'flag --topNSecondHopForTokenAddressRaw must be in format tokenAddress|topN,...');
+      if (entry != '') {
+        log.error('parsed stuff');
+        log.error(topNSecondHopForTokenAddressRaw);
+        log.error(entry);
+        const entryParts = entry.split('|');
+        if (entryParts.length != 2) {
+          throw new Error(
+            'flag --topNSecondHopForTokenAddressRaw must be in format tokenAddress|topN,...');
+        }
+        const topNForTokenAddress: number = +entryParts[1]!;
+        topNSecondHopForTokenAddress.set(entryParts[0], topNForTokenAddress);
       }
-      const topNForTokenAddress: number = +entryParts[1]!;
-      topNSecondHopForTokenAddress.set(entryParts[0], topNForTokenAddress);
     });
 
     if ((exactIn && exactOut) || (!exactIn && !exactOut)) {
@@ -92,12 +103,6 @@ export class Quote extends BaseCommand {
         );
       }
     }
-
-    const chainId = ID_TO_CHAIN_ID(chainIdNumb);
-
-    const log = this.logger;
-    const tokenProvider = this.tokenProvider;
-    const router = this.router;
 
     // if the tokenIn str is 'ETH' or 'MATIC' or in NATIVE_NAMES_BY_ID
     const tokenIn: Currency = NATIVE_NAMES_BY_ID[chainId]!.includes(tokenInStr)

--- a/cli/commands/quote.ts
+++ b/cli/commands/quote.ts
@@ -65,12 +65,6 @@ export class Quote extends BaseCommand {
       simulate,
     } = flags;
 
-    const chainId = ID_TO_CHAIN_ID(chainIdNumb);
-
-    const log = this.logger;
-    const tokenProvider = this.tokenProvider;
-    const router = this.router;
-
     const topNSecondHopForTokenAddress = new Map();
     topNSecondHopForTokenAddressRaw.split(',').forEach((entry) => {
       if (entry != '') {
@@ -79,7 +73,7 @@ export class Quote extends BaseCommand {
           throw new Error(
             'flag --topNSecondHopForTokenAddressRaw must be in format tokenAddress|topN,...');
         }
-        const topNForTokenAddress: number = +entryParts[1]!;
+        const topNForTokenAddress: number = Number(entryParts[1]!);
         topNSecondHopForTokenAddress.set(entryParts[0], topNForTokenAddress);
       }
     });
@@ -100,6 +94,12 @@ export class Quote extends BaseCommand {
         );
       }
     }
+
+    const chainId = ID_TO_CHAIN_ID(chainIdNumb);
+
+    const log = this.logger;
+    const tokenProvider = this.tokenProvider;
+    const router = this.router;
 
     // if the tokenIn str is 'ETH' or 'MATIC' or in NATIVE_NAMES_BY_ID
     const tokenIn: Currency = NATIVE_NAMES_BY_ID[chainId]!.includes(tokenInStr)

--- a/cli/commands/quote.ts
+++ b/cli/commands/quote.ts
@@ -5,7 +5,7 @@ import { Currency, Percent, TradeType } from '@uniswap/sdk-core';
 import dotenv from 'dotenv';
 import _ from 'lodash';
 
-import { ID_TO_CHAIN_ID, nativeOnChain, parseAmount, SwapRoute, SwapType, } from '../../src';
+import { ID_TO_CHAIN_ID, MapWithLowerCaseKey, nativeOnChain, parseAmount, SwapRoute, SwapType, } from '../../src';
 import { NATIVE_NAMES_BY_ID, TO_PROTOCOL } from '../../src/util';
 import { BaseCommand } from '../base-command';
 
@@ -65,7 +65,7 @@ export class Quote extends BaseCommand {
       simulate,
     } = flags;
 
-    const topNSecondHopForTokenAddress = new Map();
+    const topNSecondHopForTokenAddress = new MapWithLowerCaseKey();
     topNSecondHopForTokenAddressRaw.split(',').forEach((entry) => {
       if (entry != '') {
         const entryParts = entry.split('|');
@@ -74,7 +74,7 @@ export class Quote extends BaseCommand {
             'flag --topNSecondHopForTokenAddressRaw must be in format tokenAddress|topN,...');
         }
         const topNForTokenAddress: number = Number(entryParts[1]!);
-        topNSecondHopForTokenAddress.set(entryParts[0], topNForTokenAddress);
+        topNSecondHopForTokenAddress.set(entryParts[0]!, topNForTokenAddress);
       }
     });
 

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -195,6 +195,12 @@ export type AlphaRouterParams = {
   routeCachingProvider?: IRouteCachingProvider;
 };
 
+export class MapWithLowerCaseKey<V> extends Map<string, V> {
+  override set(key: string, value: V): this {
+    return super.set(key.toLowerCase(), value);
+  }
+}
+
 /**
  * Determines the pools that the algorithm will consider when finding the optimal swap.
  *
@@ -231,7 +237,7 @@ export type ProtocolPoolSelection = {
    * and there's a mapping USDT => 4, but no mapping for DAI
    * it would find the top 4 pools that involve USDT, and find the topNSecondHop pools that involve DAI
    */
-  topNSecondHopForTokenAddress?: Map<string, number>;
+  topNSecondHopForTokenAddress?: MapWithLowerCaseKey<number>;
   /**
    * The top N pools for token in and token out that involve a token from a list of
    * hardcoded 'base tokens'. These are standard tokens such as WETH, USDC, DAI, etc.

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -220,9 +220,18 @@ export type ProtocolPoolSelection = {
   /**
    * Given the topNTokenInOut pools, gets the top N pools that involve the other token.
    * E.g. for a WETH -> USDC swap, if topNTokenInOut found WETH -> DAI and WETH -> USDT,
-   * a value of 2 would find the top 2 pools that involve DAI or USDT.
+   * a value of 2 would find the top 2 pools that involve DAI and top 2 pools that involve USDT.
    */
   topNSecondHop: number;
+  /**
+   * Given the topNTokenInOut pools and a token address,
+   * gets the top N pools that involve the other token.
+   * If token address is not on the list, we default to topNSecondHop.
+   * E.g. for a WETH -> USDC swap, if topNTokenInOut found WETH -> DAI and WETH -> USDT,
+   * and there's a mapping USDT => 4, but no mapping for DAI
+   * it would find the top 4 pools that involve USDT, and find the topNSecondHop pools that involve DAI
+   */
+  topNSecondHopForTokenAddress?: Map<string, number>;
   /**
    * The top N pools for token in and token out that involve a token from a list of
    * hardcoded 'base tokens'. These are standard tokens such as WETH, USDC, DAI, etc.

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -199,6 +199,7 @@ export async function getV3CandidatePools({
       topNDirectSwaps,
       topNTokenInOut,
       topNSecondHop,
+      topNSecondHopForTokenAddress,
       topNWithEachBaseToken,
       topNWithBaseToken,
     },
@@ -446,7 +447,7 @@ export async function getV3CandidatePools({
               subgraphPool.token1.id == secondHopId)
           );
         })
-        .slice(0, topNSecondHop)
+        .slice(0, topNSecondHopForTokenAddress?.get(secondHopId) ?? topNSecondHop)
         .value();
     })
     .uniqBy((pool) => pool.id)
@@ -469,7 +470,7 @@ export async function getV3CandidatePools({
               subgraphPool.token1.id == secondHopId)
           );
         })
-        .slice(0, topNSecondHop)
+        .slice(0, topNSecondHopForTokenAddress?.get(secondHopId) ?? topNSecondHop)
         .value();
     })
     .uniqBy((pool) => pool.id)


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature
- **What is the current behavior?** (You can also link to an open issue here)
Currently we indiscriminately select the topN for all second hops
- **What is the new behavior (if this is a feature change)?**
This feature allows us to specify more granularity for second hops given a token address
- **Other information**:
