### PR TITLE
fix: remove instanceof usage for provider

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -562,11 +562,11 @@ export class AlphaRouter
     }
 
     let gasPriceProviderInstance: IGasPriceProvider;
-    if (this.provider instanceof JsonRpcProvider) {
+    if (JsonRpcProvider.isProvider(this.provider)) {
       gasPriceProviderInstance = new OnChainGasPriceProvider(
         chainId,
-        new EIP1559GasPriceProvider(this.provider),
-        new LegacyGasPriceProvider(this.provider)
+        new EIP1559GasPriceProvider(this.provider as JsonRpcProvider),
+        new LegacyGasPriceProvider(this.provider as JsonRpcProvider)
       );
     } else {
       gasPriceProviderInstance = new ETHGasStationInfoProvider(ETH_GAS_STATION_API_URL);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

- **What is the current behavior?** (You can also link to an open issue here)

possible versioning mismatch which causes this check to fail when it shouldn't. instead we should use the `isProvider` check on `JsonRpcProvider`

- **What is the new behavior (if this is a feature change)?**

Use the `JsonRpcProvider` built-in function for checking the type.

- **Other information**: