### PR TITLE
Changes to CachedRoutes and CachedRoute in preparation for usage in routing-api

### DIFF
--- a/src/providers/caching/route/model/cached-route.ts
+++ b/src/providers/caching/route/model/cached-route.ts
@@ -2,6 +2,11 @@ import { Protocol } from '@uniswap/router-sdk';
 
 import { MixedRoute, V2Route, V3Route } from '../../../../routers';
 
+interface CachedRouteParams<Route extends V3Route | V2Route | MixedRoute> {
+  route: Route;
+  percent: number;
+}
+
 /**
  * Class defining the route to cache
  *
@@ -12,10 +17,11 @@ export class CachedRoute<Route extends V3Route | V2Route | MixedRoute> {
   public readonly route: Route;
   public readonly percent: number;
 
-  constructor(
-    route: Route,
-    percent: number,
-  ) {
+  /**
+   * @param route
+   * @param percent
+   */
+  constructor({ route, percent }: CachedRouteParams<Route>) {
     this.route = route;
     this.percent = percent;
   }

--- a/src/providers/caching/route/model/cached-routes.ts
+++ b/src/providers/caching/route/model/cached-routes.ts
@@ -7,6 +7,17 @@ import { ChainId } from '../../../../util';
 
 import { CachedRoute } from './cached-route';
 
+interface CachedRoutesParams {
+  routes: CachedRoute<V3Route | V2Route | MixedRoute>[];
+  chainId: ChainId;
+  tokenIn: Token;
+  tokenOut: Token;
+  protocolsCovered: Protocol[];
+  blockNumber: number;
+  tradeType: TradeType;
+  blocksToLive?: number;
+}
+
 /**
  * Class defining the route to cache
  *
@@ -22,16 +33,29 @@ export class CachedRoutes {
   public readonly blockNumber: number;
   public readonly tradeType: TradeType;
 
-  public blocksToLive = 0;
+  public blocksToLive: number;
 
-  private constructor(
-    routes: CachedRoute<V3Route | V2Route | MixedRoute>[],
-    chainId: ChainId,
-    tokenIn: Token,
-    tokenOut: Token,
-    protocolsCovered: Protocol[],
-    blockNumber: number,
-    tradeType: TradeType,
+  /**
+   * @param routes
+   * @param chainId
+   * @param tokenIn
+   * @param tokenOut
+   * @param protocolsCovered
+   * @param blockNumber
+   * @param tradeType
+   * @param blocksToLive
+   */
+  constructor(
+    {
+      routes,
+      chainId,
+      tokenIn,
+      tokenOut,
+      protocolsCovered,
+      blockNumber,
+      tradeType,
+      blocksToLive = 0
+    }: CachedRoutesParams
   ) {
     this.routes = routes;
     this.chainId = chainId;
@@ -40,6 +64,7 @@ export class CachedRoutes {
     this.protocolsCovered = protocolsCovered;
     this.blockNumber = blockNumber;
     this.tradeType = tradeType;
+    this.blocksToLive = blocksToLive;
   }
 
   /**
@@ -67,10 +92,18 @@ export class CachedRoutes {
     if (routes.length == 0) return undefined;
 
     const cachedRoutes = _.map(routes, (route: RouteWithValidQuote) =>
-      new CachedRoute(route.route, route.percent)
+      new CachedRoute({ route: route.route, percent: route.percent })
     );
 
-    return new CachedRoutes(cachedRoutes, chainId, tokenIn, tokenOut, protocolsCovered, blockNumber, tradeType);
+    return new CachedRoutes({
+      routes: cachedRoutes,
+      chainId: chainId,
+      tokenIn: tokenIn,
+      tokenOut: tokenOut,
+      protocolsCovered: protocolsCovered,
+      blockNumber: blockNumber,
+      tradeType: tradeType
+    });
   }
 
   /**

--- a/test/unit/providers/caching/route/model/cached-route.test.ts
+++ b/test/unit/providers/caching/route/model/cached-route.test.ts
@@ -6,7 +6,7 @@ import { USDC_DAI, USDC_DAI_MEDIUM } from '../../../../../test-util/mock-data';
 describe('CachedRoute', () => {
   it('creates an instance given a route object and percent', () => {
     const v3Route = new V3Route([USDC_DAI_MEDIUM], USDC_MAINNET, DAI_MAINNET);
-    const cachedRoute = new CachedRoute(v3Route, 100);
+    const cachedRoute = new CachedRoute({ route: v3Route, percent: 100 });
 
     expect(cachedRoute).toBeInstanceOf(CachedRoute<V3Route>);
   });
@@ -14,21 +14,21 @@ describe('CachedRoute', () => {
   describe('protocol obtained from route', () => {
     it('is correctly V3 when using V3Route', () => {
       const route = new V3Route([USDC_DAI_MEDIUM], USDC_MAINNET, DAI_MAINNET);
-      const cachedRoute = new CachedRoute(route, 100);
+      const cachedRoute = new CachedRoute({ route: route, percent: 100 });
 
       expect(cachedRoute.protocol).toEqual(Protocol.V3);
     });
 
     it('is correctly V2 when using V2Route', () => {
       const route = new V2Route([USDC_DAI], USDC_MAINNET, DAI_MAINNET);
-      const cachedRoute = new CachedRoute(route, 100);
+      const cachedRoute = new CachedRoute({ route: route, percent: 100 });
 
       expect(cachedRoute.protocol).toEqual(Protocol.V2);
     });
 
     it('is correctly MIXED when using MixedRoute', () => {
       const route = new MixedRoute([USDC_DAI_MEDIUM], USDC_MAINNET, DAI_MAINNET);
-      const cachedRoute = new CachedRoute(route, 100);
+      const cachedRoute = new CachedRoute({ route: route, percent: 100 });
 
       expect(cachedRoute.protocol).toEqual(Protocol.MIXED);
     });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix
- **What is the current behavior?** (You can also link to an open issue here)
Currently the constructor of CachedRoutes is private and it is not using named arguments.
- **What is the new behavior (if this is a feature change)?**
making the constructor public is necessary for the marshalling step in routing-api and the named arguments are mostly for readability.
- **Other information**:
we likely have to update version 3.8.1, 3.9.1 and 3.10.1
