### PR TITLE
Fix nativePool selection for mixed routes

### DIFF
--- a/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
@@ -2,6 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { partitionMixedRouteByProtocol } from '@uniswap/router-sdk';
 import { Pair } from '@uniswap/v2-sdk';
 import { Pool } from '@uniswap/v3-sdk';
+import JSBI from 'jsbi';
 import _ from 'lodash';
 
 import { WRAPPED_NATIVE_CURRENCY } from '../../../..';
@@ -148,10 +149,13 @@ export class MixedRouteHeuristicGasModelFactory extends IOnChainGasModelFactory 
         };
       }
 
-      /// we will use nativeV2Pool for fallback if nativeV3 does not exist
+      /// we will use nativeV2Pool for fallback if nativeV3 does not exist or has 0 liquidity
       /// can use ! here because we return above if v3Pool and v2Pool are null
       const nativePool =
-        !nativeV3Pool && nativeV2Pool ? nativeV2Pool : nativeV3Pool!;
+        (!nativeV3Pool || JSBI.equal(nativeV3Pool.liquidity, JSBI.BigInt(0))) &&
+        nativeV2Pool
+          ? nativeV2Pool
+          : nativeV3Pool!;
 
       const token0 = nativePool.token0.address == nativeCurrency.address;
 


### PR DESCRIPTION
Sometimes mixed routes will estimate 0 for `gasInTermsOfQuoteToken` because while the V3Pool does exist, it has 0 liquidity and thus the resulting gas cost in terms of quote token is 0, causing the AutoRouter to incorrectly choose the mixed route over more viable V2 or V3 ones.

There's still the issue of mixed routes preferring the V3 pool in all other cases compared to the V2 pool, but it's difficult to determine which pool is "better" at runtime.

The following quote on main should select a Mixed route with 0 as the `Gas Used Quote Token: XX`, but on this branch should be well defined.
```
./bin/cli quote --tokenIn c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 --tokenOut 0xe57402125e1fae01abb1d30d1efbec68a7ee5bd1 --amount 0.07 --exactIn --recipient 0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B --protocols v2,v3,mixed
```