### PR TITLE
Add ARB and OP to their respective chains for use in the PoolProviders

### DIFF
--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -221,6 +221,13 @@ export const DAI_OPTIMISM = new Token(
   'DAI',
   'Dai Stablecoin'
 );
+export const OP_OPTIMISM = new Token(
+  ChainId.OPTIMISM,
+  '0x4200000000000000000000000000000000000042',
+  18,
+  'OP',
+  'Optimism'
+);
 
 export const USDC_OPTIMISM_GOERLI = new Token(
   ChainId.OPTIMISM_GOERLI,
@@ -307,6 +314,14 @@ export const DAI_ARBITRUM = new Token(
   18,
   'DAI',
   'Dai Stablecoin'
+);
+
+export const ARB_ARBITRUM = new Token(
+  ChainId.ARBITRUM_ONE,
+  '0x912CE59144191C1204E64559FE8253a0e49E6548',
+  18,
+  'ARB',
+  'Arbitrum'
 );
 
 // export const DAI_ARBITRUM_RINKEBY = new Token(
@@ -609,7 +624,8 @@ export class TokenProvider implements ITokenProvider {
   constructor(
     private chainId: ChainId,
     protected multicall2Provider: IMulticallProvider
-  ) {}
+  ) {
+  }
 
   public async getTokens(
     _addresses: string[],

--- a/src/providers/v3/static-subgraph-provider.ts
+++ b/src/providers/v3/static-subgraph-provider.ts
@@ -8,6 +8,7 @@ import { unparseFeeAmount } from '../../util/amounts';
 import { ChainId, WRAPPED_NATIVE_CURRENCY } from '../../util/chains';
 import { log } from '../../util/log';
 import {
+  ARB_ARBITRUM,
   BTC_BSC,
   BUSD_BSC,
   CELO,
@@ -33,6 +34,7 @@ import {
   DAI_RINKEBY_2,
   DAI_ROPSTEN,
   ETH_BSC,
+  OP_OPTIMISM,
   UNI_ARBITRUM_RINKEBY,
   USDC_ARBITRUM,
   USDC_ARBITRUM_GOERLI,
@@ -122,6 +124,7 @@ const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
     DAI_OPTIMISM,
     USDT_OPTIMISM,
     WBTC_OPTIMISM,
+    OP_OPTIMISM,
   ],
   [ChainId.ARBITRUM_ONE]: [
     WRAPPED_NATIVE_CURRENCY[ChainId.ARBITRUM_ONE]!,
@@ -129,6 +132,7 @@ const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
     DAI_ARBITRUM,
     USDC_ARBITRUM,
     USDT_ARBITRUM,
+    ARB_ARBITRUM,
   ],
   [ChainId.ARBITRUM_RINKEBY]: [
     WRAPPED_NATIVE_CURRENCY[ChainId.ARBITRUM_RINKEBY]!,
@@ -205,7 +209,8 @@ export class StaticV3SubgraphProvider implements IV3SubgraphProvider {
   constructor(
     private chainId: ChainId,
     private poolProvider: IV3PoolProvider
-  ) {}
+  ) {
+  }
 
   public async getPools(
     tokenIn?: Token,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently pairs against OP and ARB are not being used in the PoolProvider because there's no subgraph on those chains and we aren't matching against these tokens

- **What is the new behavior (if this is a feature change)?**
Tokens are now added and we will look for pairs using OP or ARB

- **Other information**:
