### PR TITLE
Keep track of original amount used to create CachedRoute

### DIFF
--- a/src/providers/caching/route/model/cached-routes.ts
+++ b/src/providers/caching/route/model/cached-routes.ts
@@ -15,6 +15,7 @@ interface CachedRoutesParams {
   protocolsCovered: Protocol[];
   blockNumber: number;
   tradeType: TradeType;
+  originalAmount: string;
   blocksToLive?: number;
 }
 
@@ -32,6 +33,7 @@ export class CachedRoutes {
   public readonly protocolsCovered: Protocol[];
   public readonly blockNumber: number;
   public readonly tradeType: TradeType;
+  public readonly originalAmount: string;
 
   public blocksToLive: number;
 
@@ -43,6 +45,7 @@ export class CachedRoutes {
    * @param protocolsCovered
    * @param blockNumber
    * @param tradeType
+   * @param originalAmount
    * @param blocksToLive
    */
   constructor(
@@ -54,6 +57,7 @@ export class CachedRoutes {
       protocolsCovered,
       blockNumber,
       tradeType,
+      originalAmount,
       blocksToLive = 0
     }: CachedRoutesParams
   ) {
@@ -64,6 +68,7 @@ export class CachedRoutes {
     this.protocolsCovered = protocolsCovered;
     this.blockNumber = blockNumber;
     this.tradeType = tradeType;
+    this.originalAmount = originalAmount;
     this.blocksToLive = blocksToLive;
   }
 
@@ -79,6 +84,7 @@ export class CachedRoutes {
    * @param protocolsCovered
    * @param blockNumber
    * @param tradeType
+   * @param originalAmount
    */
   public static fromRoutesWithValidQuotes(
     routes: RouteWithValidQuote[],
@@ -88,6 +94,7 @@ export class CachedRoutes {
     protocolsCovered: Protocol[],
     blockNumber: number,
     tradeType: TradeType,
+    originalAmount: string,
   ): CachedRoutes | undefined {
     if (routes.length == 0) return undefined;
 
@@ -97,12 +104,13 @@ export class CachedRoutes {
 
     return new CachedRoutes({
       routes: cachedRoutes,
-      chainId: chainId,
-      tokenIn: tokenIn,
-      tokenOut: tokenOut,
-      protocolsCovered: protocolsCovered,
-      blockNumber: blockNumber,
-      tradeType: tradeType
+      chainId,
+      tokenIn,
+      tokenOut,
+      protocolsCovered,
+      blockNumber,
+      tradeType,
+      originalAmount
     });
   }
 

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1018,6 +1018,7 @@ export class AlphaRouter
             routesFromChain: swapRouteFromChain.routes.toString(),
             routesFromCache: swapRouteFromCache.routes.toString(),
             amount: amount.toExact(),
+            originalAmount: cachedRoutes?.originalAmount,
             pair: this.tokenPairSymbolTradeTypeChainId(tokenIn, tokenOut, tradeType)
           },
           `Comparing quotes between Chain and Cache for ${this.tokenPairSymbolTradeTypeChainId(
@@ -1051,7 +1052,8 @@ export class AlphaRouter
         tokenOut,
         protocols.sort(), // sort it for consistency in the order of the protocols.
         await blockNumber,
-        tradeType
+        tradeType,
+        amount.toExact()
       );
 
       if (routesToCache) {

--- a/test/unit/providers/caching/route/model/cached-routes.test.ts
+++ b/test/unit/providers/caching/route/model/cached-routes.test.ts
@@ -21,7 +21,8 @@ describe('CachedRoutes', () => {
         DAI,
         [Protocol.V2, Protocol.V3, Protocol.MIXED],
         blockNumber,
-        TradeType.EXACT_INPUT
+        TradeType.EXACT_INPUT,
+        '1.1'
       );
 
       expect(cachedRoutes).toBeInstanceOf(CachedRoutes);
@@ -35,7 +36,8 @@ describe('CachedRoutes', () => {
         DAI,
         [Protocol.V2, Protocol.V3, Protocol.MIXED],
         blockNumber,
-        TradeType.EXACT_INPUT
+        TradeType.EXACT_INPUT,
+        '1.1'
       );
 
       expect(cachedRoutes).toBeUndefined();
@@ -53,7 +55,8 @@ describe('CachedRoutes', () => {
         DAI,
         [Protocol.V2, Protocol.V3, Protocol.MIXED],
         blockNumber,
-        TradeType.EXACT_INPUT
+        TradeType.EXACT_INPUT,
+        '1.1'
       )!;
     });
 

--- a/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
+++ b/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
@@ -84,6 +84,7 @@ export function getCachedRoutesStub(blockNumber: number): CachedRoutes | undefin
     DAI,
     [Protocol.V2, Protocol.V3, Protocol.MIXED],
     blockNumber,
-    TradeType.EXACT_INPUT
+    TradeType.EXACT_INPUT,
+    '1.1'
   );
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
logs update

- **What is the current behavior?** (You can also link to an open issue here)
There's currently no way to know what's the original amount that created a cached route

- **What is the new behavior (if this is a feature change)?**
We will insert the cache route alongside the original amount that created it, this will be helpful to analize buckets

- **Other information**:
