### PR TITLE
Use gas field instead of gas_used for tenderly sims, support custom m…

### DIFF
--- a/src/providers/eth-estimate-gas-provider.ts
+++ b/src/providers/eth-estimate-gas-provider.ts
@@ -126,7 +126,9 @@ export class EthEstimateGasSimulator extends Simulator {
       this.overrideEstimateMultiplier[this.chainId] ??
       DEFAULT_ESTIMATE_MULTIPLIER;
 
-    const adjustedGasEstimate = gasLimit.mul(estimateMultiplier);
+    const adjustedGasEstimate = BigNumber.from(gasLimit)
+      .mul(estimateMultiplier * 100)
+      .div(100);
 
     return adjustedGasEstimate;
   }

--- a/src/providers/eth-estimate-gas-provider.ts
+++ b/src/providers/eth-estimate-gas-provider.ts
@@ -123,9 +123,7 @@ export class EthEstimateGasSimulator extends Simulator {
       this.overrideEstimateMultiplier[this.chainId] ??
       DEFAULT_ESTIMATE_MULTIPLIER;
 
-    const adjustedGasEstimate = BigNumber.from(
-      (gasLimit.toNumber() * estimateMultiplier).toFixed(0)
-    );
+    const adjustedGasEstimate = gasLimit.mul(estimateMultiplier);
 
     return adjustedGasEstimate;
   }

--- a/src/providers/eth-estimate-gas-provider.ts
+++ b/src/providers/eth-estimate-gas-provider.ts
@@ -87,7 +87,10 @@ export class EthEstimateGasSimulator extends Simulator {
 
     estimatedGasUsed = this.adjustGasEstimate(estimatedGasUsed);
     log.info(
-      { methodParameters: route.methodParameters },
+      {
+        methodParameters: route.methodParameters,
+        estimatedGasUsed: estimatedGasUsed.toString(),
+      },
       'Simulated using eth_estimateGas on SwapRouter02'
     );
 

--- a/src/providers/simulation-provider.ts
+++ b/src/providers/simulation-provider.ts
@@ -17,7 +17,7 @@ import { ProviderConfig } from './provider';
 import { ArbitrumGasData, OptimismGasData } from './v3/gas-data-provider';
 
 export type SimulationResult = {
-  transaction: { hash: string; gas_used: number; error_message: string };
+  transaction: { hash: string; gas_used: number; gas: number; error_message: string };
   simulation: { state_overrides: Record<string, unknown> };
 };
 


### PR DESCRIPTION
…ultiplier for eth_estimateGas

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug Fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently when we do a simulation using Tenderly we use the `gas_used` field instead of the `gas` field. The Tenderly team recommend we use the `gas` field instead, as gas_used include gas refunds which are applied after the gas limit is reached

Additionally I add support for custom multipliers for the eth_estimateGas simulation path, and bump the estimateGas multiplier to 30% (from 25%)

- **What is the new behavior (if this is a feature change)?**
- Just better gas estimates

- **Other information**:
- This should help some of the gas limit issues we've been seeing in the mobile wallet
