### PR TITLE
Quote the different percents for all routes when coming from cache

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1196,15 +1196,21 @@ export class AlphaRouter
     const v2Routes = cachedRoutes.routes.filter((route) => route.protocol === Protocol.V2);
     const mixedRoutes = cachedRoutes.routes.filter((route) => route.protocol === Protocol.MIXED);
 
-    // Calculate percents from all routes, we will fetch quotes for each percent in case we had stale data when the route was cached
-    const percentsSet: Set<number> = new Set(cachedRoutes.routes.map((route) => route.percent));
-    // Add some percents that could be helpful
-    percentsSet.add(100);
-    percentsSet.add(50);
-    // Convert set to array
-    const percents = Array.from(percentsSet.values());
-    // calculate amounts based on the percents
-    const amounts = percents.map((percent) => amount.multiply(new Fraction(percent, 100)));
+    let percents: number[];
+    let amounts: CurrencyAmount[];
+    if (cachedRoutes.routes.length > 1) {
+      // If we have more than 1 route, we will quote the different percents for it, following the regular process
+      [percents, amounts] = this.getAmountDistribution(
+        amount,
+        routingConfig
+      );
+    } else if (cachedRoutes.routes.length == 1) {
+      percents = [100];
+      amounts = [amount];
+    } else {
+      // In this case this means that there's no route, so we return null
+      return Promise.resolve(null);
+    }
 
     if (v3Routes.length > 0) {
       const v3RoutesFromCache: V3Route[] = v3Routes.map((cachedRoute) => cachedRoute.route as V3Route);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
currently we use the percents that are in cache

- **What is the new behavior (if this is a feature change)?**
the new behavior will be to quote the percents for all possible routes, just in case we get better quotes for that specific amount

- **Other information**:
