### PR TITLE
BugFix: When symbol is bytes32 we are crashing, this fixes it and handles it gracefully

### DIFF
--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -673,7 +673,7 @@ export class TokenProvider implements ITokenProvider {
       } catch (error) {
         log.fatal({ addresses }, `TokenProvider.getTokenSymbol[bytes32] failed with error ${error}.`);
 
-        return Promise.reject(new Error('[TokenProvider.getTokenSymbol] Impossible to fetch token symbol.'));
+        throw new Error('[TokenProvider.getTokenSymbol] Impossible to fetch token symbol.');
       }
     }
 

--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -1,5 +1,5 @@
+import { Interface } from '@ethersproject/abi';
 import { Token } from '@uniswap/sdk-core';
-import { utils } from 'ethers';
 import _ from 'lodash';
 
 import { IERC20Metadata__factory } from '../types/v3/factories/IERC20Metadata__factory';
@@ -644,7 +644,7 @@ export class TokenProvider implements ITokenProvider {
     } catch (error) {
       log.error(`TokenProvider.getTokenSymbol failed with error ${error}. Trying with bytes32.`);
 
-      const bytes32Interface = new utils.Interface([
+      const bytes32Interface = new Interface([
         {
           inputs: [],
           name: 'symbol',

--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -642,7 +642,7 @@ export class TokenProvider implements ITokenProvider {
         providerConfig,
       });
     } catch (error) {
-      log.error(`TokenProvider.getTokenSymbol failed with error ${error}. Trying with bytes32.`);
+      log.error({ addresses }, `TokenProvider.getTokenSymbol[string] failed with error ${error}. Trying with bytes32.`);
 
       const bytes32Interface = new Interface([
         {
@@ -660,15 +660,21 @@ export class TokenProvider implements ITokenProvider {
         }
       ]);
 
-      result = this.multicall2Provider.callSameFunctionOnMultipleContracts<
-        undefined,
-        [string]
-      >({
-        addresses,
-        contractInterface: bytes32Interface,
-        functionName: 'symbol',
-        providerConfig,
-      });
+      try {
+        result = this.multicall2Provider.callSameFunctionOnMultipleContracts<
+          undefined,
+          [string]
+        >({
+          addresses,
+          contractInterface: bytes32Interface,
+          functionName: 'symbol',
+          providerConfig,
+        });
+      } catch (error) {
+        log.fatal({ addresses }, `TokenProvider.getTokenSymbol[bytes32] failed with error ${error}.`);
+
+        return Promise.reject(new Error('[TokenProvider.getTokenSymbol] Impossible to fetch token symbol.'));
+      }
     }
 
     return result;

--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -1,4 +1,5 @@
 import { Token } from '@uniswap/sdk-core';
+import { utils } from 'ethers';
 import _ from 'lodash';
 
 import { IERC20Metadata__factory } from '../types/v3/factories/IERC20Metadata__factory';
@@ -627,6 +628,64 @@ export class TokenProvider implements ITokenProvider {
   ) {
   }
 
+  private async getTokenSymbol(addresses: string[], providerConfig?: ProviderConfig) {
+    let result;
+
+    try {
+      result = await this.multicall2Provider.callSameFunctionOnMultipleContracts<
+        undefined,
+        [string]
+      >({
+        addresses,
+        contractInterface: IERC20Metadata__factory.createInterface(),
+        functionName: 'symbol',
+        providerConfig,
+      });
+    } catch (error) {
+      log.error(`TokenProvider.getTokenSymbol failed with error ${error}. Trying with bytes32.`);
+
+      const bytes32Interface = new utils.Interface([
+        {
+          inputs: [],
+          name: 'symbol',
+          outputs: [
+            {
+              internalType: 'bytes32',
+              name: '',
+              type: 'bytes32',
+            },
+          ],
+          stateMutability: 'view',
+          type: 'function',
+        }
+      ]);
+
+      result = this.multicall2Provider.callSameFunctionOnMultipleContracts<
+        undefined,
+        [string]
+      >({
+        addresses,
+        contractInterface: bytes32Interface,
+        functionName: 'symbol',
+        providerConfig,
+      });
+    }
+
+    return result;
+  }
+
+  private async getTokenDecimals(addresses: string[], providerConfig?: ProviderConfig) {
+    return this.multicall2Provider.callSameFunctionOnMultipleContracts<
+      undefined,
+      [number]
+    >({
+      addresses,
+      contractInterface: IERC20Metadata__factory.createInterface(),
+      functionName: 'decimals',
+      providerConfig,
+    });
+  }
+
   public async getTokens(
     _addresses: string[],
     providerConfig?: ProviderConfig
@@ -641,24 +700,8 @@ export class TokenProvider implements ITokenProvider {
 
     if (addresses.length > 0) {
       const [symbolsResult, decimalsResult] = await Promise.all([
-        this.multicall2Provider.callSameFunctionOnMultipleContracts<
-          undefined,
-          [string]
-        >({
-          addresses,
-          contractInterface: IERC20Metadata__factory.createInterface(),
-          functionName: 'symbol',
-          providerConfig,
-        }),
-        this.multicall2Provider.callSameFunctionOnMultipleContracts<
-          undefined,
-          [number]
-        >({
-          addresses,
-          contractInterface: IERC20Metadata__factory.createInterface(),
-          functionName: 'decimals',
-          providerConfig,
-        }),
+        this.getTokenSymbol(addresses, providerConfig),
+        this.getTokenDecimals(addresses, providerConfig)
       ]);
 
       const { results: symbols } = symbolsResult;

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -581,7 +581,7 @@ describe('alpha router integration', () => {
           );
         });
 
-        it.only('erc20 -> erc20 works when symbol is returning bytes32', async () => {
+        it('erc20 -> erc20 works when symbol is returning bytes32', async () => {
           // This token has a bytes32 symbol type
           const tokenIn = new Token(
             ChainId.MAINNET,

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -2,14 +2,24 @@
  * @jest-environment hardhat
  */
 
+import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
+import { AllowanceTransfer, PermitSingle } from '@uniswap/permit2-sdk';
+import { Protocol } from '@uniswap/router-sdk';
+import { Currency, CurrencyAmount, Ether, Percent, Token, TradeType, } from '@uniswap/sdk-core';
 import {
-  Currency,
-  CurrencyAmount,
-  Ether,
-  Percent,
-  Token,
-  TradeType,
-} from '@uniswap/sdk-core';
+  PERMIT2_ADDRESS,
+  UNIVERSAL_ROUTER_ADDRESS as UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN,
+} from '@uniswap/universal-router-sdk';
+import { Permit2Permit } from '@uniswap/universal-router-sdk/dist/utils/permit2';
+import { Pair } from '@uniswap/v2-sdk';
+import { encodeSqrtRatioX96, FeeAmount, Pool } from '@uniswap/v3-sdk';
+import bunyan from 'bunyan';
+import { BigNumber, providers, Wallet } from 'ethers';
+import { parseEther } from 'ethers/lib/utils';
+
+import 'jest-environment-hardhat';
+import _ from 'lodash';
+import NodeCache from 'node-cache';
 import {
   AlphaRouter,
   AlphaRouterConfig,
@@ -27,8 +37,8 @@ import {
   ID_TO_PROVIDER,
   MethodParameters,
   MixedRoute,
-  nativeOnChain,
   NATIVE_CURRENCY,
+  nativeOnChain,
   NodeJSCache,
   OnChainQuoteProvider,
   parseAmount,
@@ -36,23 +46,22 @@ import {
   SimulationStatus,
   StaticGasPriceProvider,
   SUPPORTED_CHAINS,
-  // SUPPORTED_CHAINS,
+  SWAP_ROUTER_02_ADDRESSES,
   SwapOptions,
   SwapType,
-  SWAP_ROUTER_02_ADDRESSES,
   TenderlySimulator,
-  UniswapMulticallProvider,
   UNI_GÖRLI,
   UNI_MAINNET,
+  UniswapMulticallProvider,
   USDC_BSC,
   USDC_ETHEREUM_GNOSIS,
   USDC_MAINNET,
   USDC_ON,
   USDT_BSC,
   USDT_MAINNET,
+  V2_SUPPORTED,
   V2PoolProvider,
   V2Route,
-  V2_SUPPORTED,
   V3PoolProvider,
   V3Route,
   WBTC_GNOSIS,
@@ -60,28 +69,11 @@ import {
   WETH9,
   WNATIVE_ON,
 } from '../../../../src';
-import { WHALES } from '../../../test-util/whales';
-
-import 'jest-environment-hardhat';
-
-import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
-import { AllowanceTransfer, PermitSingle } from '@uniswap/permit2-sdk';
-import { Protocol } from '@uniswap/router-sdk';
-import {
-  PERMIT2_ADDRESS,
-  UNIVERSAL_ROUTER_ADDRESS as UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN,
-} from '@uniswap/universal-router-sdk';
-import { Permit2Permit } from '@uniswap/universal-router-sdk/dist/utils/permit2';
-import { Pair } from '@uniswap/v2-sdk';
-import { encodeSqrtRatioX96, FeeAmount, Pool } from '@uniswap/v3-sdk';
-import bunyan from 'bunyan';
-import { BigNumber, providers, Wallet } from 'ethers';
-import { parseEther } from 'ethers/lib/utils';
-import _ from 'lodash';
-import NodeCache from 'node-cache';
 import { DEFAULT_ROUTING_CONFIG_BY_CHAIN } from '../../../../src/routers/alpha-router/config';
 import { Permit2__factory } from '../../../../src/types/other/factories/Permit2__factory';
 import { getBalanceAndApprove } from '../../../test-util/getBalanceAndApprove';
+import { WHALES } from '../../../test-util/whales';
+
 const FORK_BLOCK = 16075500;
 const UNIVERSAL_ROUTER_ADDRESS = UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN(1);
 const SLIPPAGE = new Percent(15, 100); // 5% or 10_000?
@@ -587,6 +579,42 @@ describe('alpha router integration', () => {
             100,
             100
           );
+        });
+
+        it.only('erc20 -> erc20 works when symbol is returning bytes32', async () => {
+          // This token has a bytes32 symbol type
+          const tokenIn = new Token(
+            ChainId.MAINNET,
+            '0x0d88ed6e74bbfd96b831231638b66c05571e824f',
+            18,
+            'AVT',
+            'AVT'
+          );
+
+          const tokenOut = USDT_MAINNET;
+          const amount =
+            tradeType == TradeType.EXACT_INPUT
+              ? parseAmount('100', tokenIn)
+              : parseAmount('100', tokenOut);
+
+          const swap = await alphaRouter.route(
+            amount,
+            getQuoteToken(tokenIn, tokenOut, tradeType),
+            tradeType,
+            {
+
+              type: SwapType.UNIVERSAL_ROUTER,
+              recipient: alice._address,
+              slippageTolerance: SLIPPAGE,
+              deadlineOrPreviousBlockhash: parseDeadline(360),
+            },
+            {
+              ...ROUTING_CONFIG,
+            }
+          );
+
+          expect(swap).toBeDefined();
+          expect(swap).not.toBeNull();
         });
 
         it('erc20 -> erc20 swapRouter02', async () => {
@@ -2577,7 +2605,7 @@ describe('quote for other networks', () => {
       const erc1 = TEST_ERC20_1[chain];
       const erc2 = TEST_ERC20_2[chain];
 
-      describe(`${ID_TO_NETWORK_NAME(chain)} ${tradeType} 2xx`, function () {
+      describe(`${ID_TO_NETWORK_NAME(chain)} ${tradeType} 2xx`, function() {
         const wrappedNative = WNATIVE_ON(chain);
 
         let alphaRouter: AlphaRouter;
@@ -2631,7 +2659,7 @@ describe('quote for other networks', () => {
           });
         });
 
-        describe(`Swap`, function () {
+        describe(`Swap`, function() {
           it(`${wrappedNative.symbol} -> erc20`, async () => {
             const tokenIn = wrappedNative;
             const tokenOut = erc1;
@@ -2695,8 +2723,8 @@ describe('quote for other networks', () => {
                   ? parseAmount('10', tokenIn)
                   : parseAmount('10', tokenOut)
                 : tradeType == TradeType.EXACT_INPUT
-                ? parseAmount('1', tokenIn)
-                : parseAmount('1', tokenOut);
+                  ? parseAmount('1', tokenIn)
+                  : parseAmount('1', tokenOut);
 
             const swap = await alphaRouter.route(
               amount,
@@ -2795,7 +2823,7 @@ describe('quote for other networks', () => {
         });
 
         if (isTenderlyEnvironmentSet()) {
-          describe(`Simulate + Swap`, function () {
+          describe(`Simulate + Swap`, function() {
             // Tenderly does not support Celo
             if ([ChainId.CELO, ChainId.CELO_ALFAJORES].includes(chain)) {
               return;
@@ -2812,19 +2840,19 @@ describe('quote for other networks', () => {
               const swapOptions: SwapOptions =
                 chain == ChainId.GÖRLI
                   ? {
-                      type: SwapType.SWAP_ROUTER_02,
-                      recipient: WHALES(tokenIn),
-                      slippageTolerance: SLIPPAGE,
-                      deadline: parseDeadline(360),
-                      simulate: { fromAddress: WHALES(tokenIn) },
-                    }
+                    type: SwapType.SWAP_ROUTER_02,
+                    recipient: WHALES(tokenIn),
+                    slippageTolerance: SLIPPAGE,
+                    deadline: parseDeadline(360),
+                    simulate: { fromAddress: WHALES(tokenIn) },
+                  }
                   : {
-                      type: SwapType.UNIVERSAL_ROUTER,
-                      recipient: WHALES(tokenIn),
-                      slippageTolerance: SLIPPAGE,
-                      deadlineOrPreviousBlockhash: parseDeadline(360),
-                      simulate: { fromAddress: WHALES(tokenIn) },
-                    };
+                    type: SwapType.UNIVERSAL_ROUTER,
+                    recipient: WHALES(tokenIn),
+                    slippageTolerance: SLIPPAGE,
+                    deadlineOrPreviousBlockhash: parseDeadline(360),
+                    simulate: { fromAddress: WHALES(tokenIn) },
+                  };
 
               const swap = await alphaRouter.route(
                 amount,
@@ -2867,19 +2895,19 @@ describe('quote for other networks', () => {
               const swapOptions: SwapOptions =
                 chain == ChainId.GÖRLI
                   ? {
-                      type: SwapType.SWAP_ROUTER_02,
-                      recipient: WHALES(tokenIn),
-                      slippageTolerance: SLIPPAGE,
-                      deadline: parseDeadline(360),
-                      simulate: { fromAddress: WHALES(tokenIn) },
-                    }
+                    type: SwapType.SWAP_ROUTER_02,
+                    recipient: WHALES(tokenIn),
+                    slippageTolerance: SLIPPAGE,
+                    deadline: parseDeadline(360),
+                    simulate: { fromAddress: WHALES(tokenIn) },
+                  }
                   : {
-                      type: SwapType.UNIVERSAL_ROUTER,
-                      recipient: WHALES(tokenIn),
-                      slippageTolerance: SLIPPAGE,
-                      deadlineOrPreviousBlockhash: parseDeadline(360),
-                      simulate: { fromAddress: WHALES(tokenIn) },
-                    };
+                    type: SwapType.UNIVERSAL_ROUTER,
+                    recipient: WHALES(tokenIn),
+                    slippageTolerance: SLIPPAGE,
+                    deadlineOrPreviousBlockhash: parseDeadline(360),
+                    simulate: { fromAddress: WHALES(tokenIn) },
+                  };
 
               const swap = await alphaRouter.route(
                 amount,
@@ -2922,19 +2950,19 @@ describe('quote for other networks', () => {
               const swapOptions: SwapOptions =
                 chain == ChainId.GÖRLI
                   ? {
-                      type: SwapType.SWAP_ROUTER_02,
-                      recipient: WHALES(tokenIn),
-                      slippageTolerance: SLIPPAGE,
-                      deadline: parseDeadline(360),
-                      simulate: { fromAddress: WHALES(tokenIn) },
-                    }
+                    type: SwapType.SWAP_ROUTER_02,
+                    recipient: WHALES(tokenIn),
+                    slippageTolerance: SLIPPAGE,
+                    deadline: parseDeadline(360),
+                    simulate: { fromAddress: WHALES(tokenIn) },
+                  }
                   : {
-                      type: SwapType.UNIVERSAL_ROUTER,
-                      recipient: WHALES(tokenIn),
-                      slippageTolerance: SLIPPAGE,
-                      deadlineOrPreviousBlockhash: parseDeadline(360),
-                      simulate: { fromAddress: WHALES(tokenIn) },
-                    };
+                    type: SwapType.UNIVERSAL_ROUTER,
+                    recipient: WHALES(tokenIn),
+                    slippageTolerance: SLIPPAGE,
+                    deadlineOrPreviousBlockhash: parseDeadline(360),
+                    simulate: { fromAddress: WHALES(tokenIn) },
+                  };
 
               const swap = await alphaRouter.route(
                 amount,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently if the symbol method is a bytes32 instead of string, we would crash

- **What is the new behavior (if this is a feature change)?**
We don't crash anymore

- **Other information**:
Tested manually with `./bin/cli quote --tokenIn 0x0d88ed6e74bbfd96b831231638b66c05571e824f --tokenOut 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 --amount 1 --exactIn --chainId 1` and got a 200 response with a real quote.

Also added an integration test.