### PR TITLE
3.11.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.11.5",
+  "version": "3.11.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "3.11.5",
+      "version": "3.11.6",
       "license": "GPL",
       "dependencies": {
         "@uniswap/default-token-list": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.11.5",
+  "version": "3.11.6",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Release containing bugfix addressed in #241 

- **What is the current behavior?** (You can also link to an open issue here)
Token Symbols obtained from Bytes32 are not parsed and currently display the Hex value.

- **What is the new behavior (if this is a feature change)?**
In 3.11.6 the Token symbols that are obtained from a Bytes32 function will be parsed into their UTF values

- **Other information**:
