### PR TITLE
[ROUTE-9] pass down block number to v3 static subgraph provider

### DIFF
--- a/src/providers/v3/static-subgraph-provider.ts
+++ b/src/providers/v3/static-subgraph-provider.ts
@@ -79,6 +79,7 @@ import {
 
 import { IV3PoolProvider } from './pool-provider';
 import { IV3SubgraphProvider, V3SubgraphPool } from './subgraph-provider';
+import { ProviderConfig } from '../provider';
 
 type ChainTokenList = {
   readonly [chainId in ChainId]: Token[];
@@ -219,7 +220,8 @@ export class StaticV3SubgraphProvider implements IV3SubgraphProvider {
 
   public async getPools(
     tokenIn?: Token,
-    tokenOut?: Token
+    tokenOut?: Token,
+    providerConfig?: ProviderConfig
   ): Promise<V3SubgraphPool[]> {
     log.info('In static subgraph provider for V3');
     const bases = BASES_TO_CHECK_TRADES_AGAINST[this.chainId];
@@ -258,7 +260,7 @@ export class StaticV3SubgraphProvider implements IV3SubgraphProvider {
     log.info(
       `V3 Static subgraph provider about to get ${pairs.length} pools on-chain`
     );
-    const poolAccessor = await this.poolProvider.getPools(pairs);
+    const poolAccessor = await this.poolProvider.getPools(pairs, providerConfig);
     const pools = poolAccessor.getAllPools();
 
     const poolAddressSet = new Set<string>();


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
`StaticV3SubgraphProvider` currently doesn't get the block number from the alpha router to get the pools.

- **What is the new behavior (if this is a feature change)?**
`StaticV3SubgraphProvider` gets the block number from the alpha router, and passes down to the downstream pool provider (concrete instance of `IV3PoolProvider`) to get the pools.

- **Other information**:
This is to complement the routing-api pr [211](https://github.com/Uniswap/routing-api/pull/211). Dynamo caching pool provider will always be cache miss until we pass down the block number.