### PR TITLE
fix: revert OP multicall chunk size back to normal

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -392,17 +392,17 @@ export class AlphaRouter
               maxTimeout: 1000,
             },
             {
-              multicallChunk: 30,
+              multicallChunk: 110,
               gasLimitPerCall: 1_200_000,
               quoteMinSuccessRate: 0.1,
             },
             {
               gasLimitOverride: 3_000_000,
-              multicallChunk: 15,
+              multicallChunk: 45,
             },
             {
               gasLimitOverride: 3_000_000,
-              multicallChunk: 15,
+              multicallChunk: 45,
             },
             {
               baseBlockOffset: -10,


### PR DESCRIPTION
Infura has fixed gas issues for Optimism as of yesterday. Reverting on-call fix for optimism since things are back to normal. 

Local test run worked: 
<img width="1186" alt="Screen Shot 2023-06-09 at 3 46 16 PM" src="https://github.com/Uniswap/smart-order-router/assets/41491154/fde58ae4-a4e9-4caa-93b5-d3410e1d628c">
