### PR TITLE
add v3 in-memory caching pool hit miss metrics

### DIFF
--- a/src/providers/v3/caching-pool-provider.ts
+++ b/src/providers/v3/caching-pool-provider.ts
@@ -8,6 +8,7 @@ import { log } from '../../util/log';
 import { ICache } from './../cache';
 import { ProviderConfig } from './../provider';
 import { IV3PoolProvider, V3PoolAccessor } from './pool-provider';
+import { metric, MetricLoggerUnit } from '../../util';
 
 /**
  * Provider for getting V3 pools, with functionality for caching the results.
@@ -59,10 +60,12 @@ export class CachingV3PoolProvider implements IV3PoolProvider {
         this.POOL_KEY(this.chainId, poolAddress)
       );
       if (cachedPool) {
+        metric.putMetric('V3_INMEMORY_CACHING_POOL_HIT_IN_MEMORY', 1, MetricLoggerUnit.None)
         poolAddressToPool[poolAddress] = cachedPool;
         continue;
       }
 
+      metric.putMetric('V3_INMEMORY_CACHING_POOL_MISS_NOT_IN_MEMORY', 1, MetricLoggerUnit.None)
       poolsToGetTokenPairs.push([token0, token1, feeAmount]);
       poolsToGetAddresses.push(poolAddress);
     }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Enhancement

- **What is the current behavior?** (You can also link to an open issue here)
We don't know the cache hit/miss ratio for the existing v3 caching pool provider.

- **What is the new behavior (if this is a feature change)?**
We will see cache hit/miss ratio for the existing v3 caching pool provider. I tested this in routing-api personal cdk stack (via local tarball [method](https://github.com/Uniswap/routing-api/compare/jsy1218/explore-sor-local-tarball?expand=1)). I can see in-memory cache hit/miss metrics getting exported:
<img width="1512" alt="In-memory Pool Caching Hit:Miss" src="https://github.com/Uniswap/smart-order-router/assets/91580504/7a41a2a9-78b4-4d87-a232-52cc07b105be">

- **Other information**:
The high hit rate has caught my attention. Originally we thought that the hit rate might be low in prod, so we want to add the dynamo caching. Since this metric is exported via my personal cdk stack, I want to first see how many [hosts](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-10800~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20hostname*0a*7c*20stats*20count_distinct*28hostname*29*20by*20bin*285m*29~queryId~'edfa904d8fdc13-114a9d70-41ae572-ec5a13f9-adb25cf6ebe4ca31a9675b24~source~(~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-pOSkckAzB5N6~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-xxMl8mSwRJxq))) are there in the lambda function in my personal cdk stack:

<img width="1510" alt="# hosts personal cdk" src="https://github.com/Uniswap/smart-order-router/assets/91580504/fc2edfdb-a67a-4a70-b3b6-a007d2331254">

Turned out there's only one host, so that explains the high in-memory hit rate. Then I want to see how many [hosts](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20hostname*0a*7c*20stats*20count_distinct*28hostname*29*20by*20bin*285m*29~queryId~'edfa904d8fdc13-114a9d70-41ae572-ec5a13f9-adb25cf6ebe4ca31a9675b24~source~(~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-R-RoutingLambda2C4DF0900-Bbcx5MI4vlM6~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-Ro-RoutingLambdaF7AD8A1A-erFTueZgLnZ1))) are there in the prod lambda functions:
<img width="1511" alt="# hosts prod lambda" src="https://github.com/Uniswap/smart-order-router/assets/91580504/e33d6294-2cf0-4867-8a9e-4fa1aadc53f3">
There seems to be 150+ hosts on average, so we probably expect a much lower in-memory cache hit rate in prod.