### PR TITLE
[fix] [ROUTE-9] pass block number to v3 get liquidity TVL

### DIFF
--- a/src/providers/eth-estimate-gas-provider.ts
+++ b/src/providers/eth-estimate-gas-provider.ts
@@ -39,7 +39,8 @@ export class EthEstimateGasSimulator extends Simulator {
     fromAddress: string,
     swapOptions: SwapOptions,
     route: SwapRoute,
-    l2GasData?: ArbitrumGasData | OptimismGasData
+    l2GasData?: ArbitrumGasData | OptimismGasData,
+    providerConfig?: ProviderConfig
   ): Promise<SwapRoute> {
     const currencyIn = route.trade.inputAmount.currency;
     let estimatedGasUsed: BigNumber;
@@ -104,7 +105,8 @@ export class EthEstimateGasSimulator extends Simulator {
       estimatedGasUsed,
       this.v2PoolProvider,
       this.v3PoolProvider,
-      l2GasData
+      l2GasData,
+      providerConfig
     );
 
     return {

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -100,7 +100,8 @@ export class FallbackTenderlySimulator extends Simulator {
             fromAddress,
             swapOptions,
             swapRoute,
-            l2GasData
+            l2GasData,
+            providerConfig
           );
         return swapRouteWithGasEstimate;
       } catch (err) {
@@ -402,7 +403,8 @@ export class TenderlySimulator extends Simulator {
       estimatedGasUsed,
       this.v2PoolProvider,
       this.v3PoolProvider,
-      l2GasData
+      l2GasData,
+      providerConfig
     );
     return {
       ...initSwapRouteFromExisting(

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -91,6 +91,7 @@ import { MixedRouteHeuristicGasModelFactory } from './gas-models/mixedRoute/mixe
 import { V2HeuristicGasModelFactory } from './gas-models/v2/v2-heuristic-gas-model';
 import { V3HeuristicGasModelFactory } from './gas-models/v3/v3-heuristic-gas-model';
 import { GetQuotesResult, MixedQuoter, V2Quoter, V3Quoter } from './quoters';
+import { ProviderConfig } from '../../providers/provider';
 
 export type AlphaRouterParams = {
   /**
@@ -884,7 +885,8 @@ export class AlphaRouter
     const [v3GasModel, mixedRouteGasModel] = await this.getGasModels(
       gasPriceWei,
       amount.currency.wrapped,
-      quoteToken
+      quoteToken,
+      { blockNumber }
     );
 
     // Create a Set to sanitize the protocols input, a Set of undefined becomes an empty set,
@@ -1436,7 +1438,8 @@ export class AlphaRouter
   private async getGasModels(
     gasPriceWei: BigNumber,
     amountToken: Token,
-    quoteToken: Token
+    quoteToken: Token,
+    providerConfig?: ProviderConfig
   ): Promise<[
     IGasModel<V3RouteWithValidQuote>,
     IGasModel<MixedRouteWithValidQuote>
@@ -1451,6 +1454,7 @@ export class AlphaRouter
       quoteToken,
       v2poolProvider: this.v2PoolProvider,
       l2GasDataProvider: this.l2GasDataProvider,
+      providerConfig: providerConfig
     });
 
     const mixedRouteGasModelPromise = this.mixedRouteGasModelFactory.buildGasModel({
@@ -1460,6 +1464,7 @@ export class AlphaRouter
       amountToken,
       quoteToken,
       v2poolProvider: this.v2PoolProvider,
+      providerConfig: providerConfig
     });
 
     const [v3GasModel, mixedRouteGasModel] = await Promise.all([

--- a/src/routers/alpha-router/gas-models/gas-model.ts
+++ b/src/routers/alpha-router/gas-models/gas-model.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Token } from '@uniswap/sdk-core';
 
+import { ProviderConfig } from '../../../providers/provider';
 import {
   CUSD_CELO,
   CUSD_CELO_ALFAJORES,
@@ -102,6 +103,7 @@ export type BuildOnChainGasModelFactoryType = {
   l2GasDataProvider?:
     | IL2GasDataProvider<OptimismGasData>
     | IL2GasDataProvider<ArbitrumGasData>;
+  providerConfig?: ProviderConfig;
 };
 
 export type BuildV2GasModelFactoryType = {

--- a/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
@@ -59,12 +59,14 @@ export class MixedRouteHeuristicGasModelFactory extends IOnChainGasModelFactory 
     v3poolProvider: V3poolProvider,
     quoteToken,
     v2poolProvider: V2poolProvider,
+    providerConfig
   }: BuildOnChainGasModelFactoryType): Promise<
     IGasModel<MixedRouteWithValidQuote>
   > {
     const usdPool: Pool = await getHighestLiquidityV3USDPool(
       chainId,
-      V3poolProvider
+      V3poolProvider,
+      providerConfig
     );
 
     // If our quote token is WETH, we don't need to convert our gas use to be in terms

--- a/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
@@ -113,7 +113,8 @@ export class MixedRouteHeuristicGasModelFactory extends IOnChainGasModelFactory 
     // We do this by getting the highest liquidity <quoteToken>/<nativeCurrency> pool. eg. <quoteToken>/ETH pool.
     const nativeV3Pool: Pool | null = await getHighestLiquidityV3NativePool(
       quoteToken,
-      V3poolProvider
+      V3poolProvider,
+      providerConfig
     );
 
     let nativeV2Pool: Pair | null;

--- a/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
@@ -68,16 +68,18 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
     amountToken,
     quoteToken,
     l2GasDataProvider,
+    providerConfig
   }: BuildOnChainGasModelFactoryType): Promise<
     IGasModel<V3RouteWithValidQuote>
   > {
     const l2GasData = l2GasDataProvider
       ? await l2GasDataProvider.getGasData()
       : undefined;
-
+    
     const usdPool: Pool = await getHighestLiquidityV3USDPool(
       chainId,
-      poolProvider
+      poolProvider,
+      providerConfig
     );
 
     const calculateL1GasFees = async (
@@ -268,7 +270,7 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
           `Unable to find ${nativeCurrency.symbol} pool with the quote token, ${quoteToken.symbol} to produce gas adjusted costs. Using amountToken to calculate gas costs.`
         );
       }
-      
+
       // Highest liquidity pool for the non quote token / ETH
       // A pool with the non quote token / ETH should not be required and errors should be handled separately
       if (nativeAmountPool) {
@@ -279,7 +281,7 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
           routeWithValidQuote.amount.quotient,
           routeWithValidQuote.quote.quotient
         );
-        
+
         const inputIsToken0 =
           nativeAmountPool.token0.address == nativeCurrency.address;
         // ratio of input / native

--- a/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
@@ -75,7 +75,7 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
     const l2GasData = l2GasDataProvider
       ? await l2GasDataProvider.getGasData()
       : undefined;
-    
+
     const usdPool: Pool = await getHighestLiquidityV3USDPool(
       chainId,
       poolProvider,
@@ -140,7 +140,8 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
       if (!quoteToken.equals(nativeCurrency)) {
         const nativePool: Pool | null = await getHighestLiquidityV3NativePool(
           quoteToken,
-          poolProvider
+          poolProvider,
+          providerConfig
         );
         if (!nativePool) {
           log.info(
@@ -209,14 +210,16 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
     // We do this by getting the highest liquidity <quoteToken>/<nativeCurrency> pool. eg. <quoteToken>/ETH pool.
     const nativePool: Pool | null = await getHighestLiquidityV3NativePool(
       quoteToken,
-      poolProvider
+      poolProvider,
+      providerConfig
     );
 
     let nativeAmountPool: Pool | null = null;
     if (!amountToken.equals(nativeCurrency)) {
       nativeAmountPool = await getHighestLiquidityV3NativePool(
         amountToken,
-        poolProvider
+        poolProvider,
+        providerConfig
       );
     }
 

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -6,6 +6,7 @@ import { FeeAmount, Pool } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
 import { IV2PoolProvider } from '../providers';
+import { ProviderConfig } from '../providers/provider';
 import {
   ArbitrumGasData,
   OptimismGasData,
@@ -97,7 +98,8 @@ export async function getHighestLiquidityV3NativePool(
 
 export async function getHighestLiquidityV3USDPool(
   chainId: ChainId,
-  poolProvider: IV3PoolProvider
+  poolProvider: IV3PoolProvider,
+  providerConfig?: ProviderConfig
 ): Promise<Pool> {
   const usdTokens = usdGasTokensByChain[chainId];
   const wrappedCurrency = WRAPPED_NATIVE_CURRENCY[chainId]!;
@@ -123,7 +125,7 @@ export async function getHighestLiquidityV3USDPool(
     })
     .value();
 
-  const poolAccessor = await poolProvider.getPools(usdPools);
+  const poolAccessor = await poolProvider.getPools(usdPools, providerConfig);
 
   const pools = _([
     FeeAmount.HIGH,
@@ -251,7 +253,8 @@ export async function calculateGasUsed(
   simulatedGasUsed: BigNumber,
   v2PoolProvider: IV2PoolProvider,
   v3PoolProvider: IV3PoolProvider,
-  l2GasData?: ArbitrumGasData | OptimismGasData
+  l2GasData?: ArbitrumGasData | OptimismGasData,
+  providerConfig?: ProviderConfig
 ) {
   const quoteToken = route.quote.currency.wrapped;
   const gasPriceWei = route.gasPriceWei;
@@ -291,7 +294,8 @@ export async function calculateGasUsed(
 
   const usdPool: Pool = await getHighestLiquidityV3USDPool(
     chainId,
-    v3PoolProvider
+    v3PoolProvider,
+    providerConfig
   );
 
   const gasCostUSD = await getGasCostInUSD(usdPool, costNativeCurrency);

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -53,7 +53,8 @@ export async function getV2NativePool(
 
 export async function getHighestLiquidityV3NativePool(
   token: Token,
-  poolProvider: IV3PoolProvider
+  poolProvider: IV3PoolProvider,
+  providerConfig?: ProviderConfig
 ): Promise<Pool | null> {
   const nativeCurrency = WRAPPED_NATIVE_CURRENCY[token.chainId as ChainId]!;
 
@@ -68,7 +69,7 @@ export async function getHighestLiquidityV3NativePool(
     })
     .value();
 
-  const poolAccessor = await poolProvider.getPools(nativePools);
+  const poolAccessor = await poolProvider.getPools(nativePools, providerConfig);
 
   const pools = _([
     FeeAmount.HIGH,
@@ -304,7 +305,7 @@ export async function calculateGasUsed(
   // get fee in terms of quote token
   if (!quoteToken.equals(nativeCurrency)) {
     const nativePools = await Promise.all([
-      getHighestLiquidityV3NativePool(quoteToken, v3PoolProvider),
+      getHighestLiquidityV3NativePool(quoteToken, v3PoolProvider, providerConfig),
       getV2NativePool(quoteToken, v2PoolProvider),
     ]);
     const nativePool = nativePools.find((pool) => pool !== null);

--- a/test/unit/routers/alpha-router/alpha-router.test.ts
+++ b/test/unit/routers/alpha-router/alpha-router.test.ts
@@ -493,6 +493,9 @@ describe('alpha router', () => {
           quoteToken: WRAPPED_NATIVE_CURRENCY[1],
           v2poolProvider: sinon.match.any,
           l2GasDataProvider: undefined,
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
       expect(
@@ -511,6 +514,7 @@ describe('alpha router', () => {
           v2poolProvider: sinon.match.any,
           amountToken: amount.currency,
           quoteToken: WRAPPED_NATIVE_CURRENCY[1],
+          providerConfig: sinon.match.any
         })
       ).toBeTruthy();
 
@@ -711,6 +715,9 @@ describe('alpha router', () => {
           quoteToken: WRAPPED_NATIVE_CURRENCY[1],
           v2poolProvider: sinon.match.any,
           l2GasDataProvider: undefined,
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
       expect(
@@ -721,6 +728,9 @@ describe('alpha router', () => {
           v2poolProvider: sinon.match.any,
           amountToken: amount.currency,
           quoteToken: WRAPPED_NATIVE_CURRENCY[1],
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
 
@@ -883,6 +893,9 @@ describe('alpha router', () => {
           quoteToken: WRAPPED_NATIVE_CURRENCY[1],
           v2poolProvider: sinon.match.any,
           l2GasDataProvider: undefined,
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
       expect(
@@ -1005,6 +1018,9 @@ describe('alpha router', () => {
           quoteToken: WRAPPED_NATIVE_CURRENCY[1],
           v2poolProvider: sinon.match.any,
           l2GasDataProvider: undefined,
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
 
@@ -1141,6 +1157,9 @@ describe('alpha router', () => {
           v2poolProvider: sinon.match.any,
           amountToken: amount.currency,
           quoteToken: WRAPPED_NATIVE_CURRENCY[1],
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
 
@@ -1403,6 +1422,9 @@ describe('alpha router', () => {
           quoteToken: WRAPPED_NATIVE_CURRENCY[1],
           v2poolProvider: sinon.match.any,
           l2GasDataProvider: undefined,
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
 
@@ -1552,6 +1574,9 @@ describe('alpha router', () => {
           v2poolProvider: sinon.match.any,
           amountToken: amount.currency,
           quoteToken: WRAPPED_NATIVE_CURRENCY[1],
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
 
@@ -1628,6 +1653,9 @@ describe('alpha router', () => {
           quoteToken: WRAPPED_NATIVE_CURRENCY[1],
           v2poolProvider: sinon.match.any,
           l2GasDataProvider: undefined,
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
 
@@ -1831,6 +1859,9 @@ describe('alpha router', () => {
           quoteToken: USDC,
           v2poolProvider: sinon.match.any,
           l2GasDataProvider: undefined,
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
       expect(
@@ -1849,6 +1880,9 @@ describe('alpha router', () => {
           v2poolProvider: sinon.match.any,
           amountToken: WRAPPED_NATIVE_CURRENCY[1],
           quoteToken: USDC,
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
 
@@ -1936,6 +1970,9 @@ describe('alpha router', () => {
           quoteToken: USDC,
           v2poolProvider: sinon.match.any,
           l2GasDataProvider: undefined,
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
       expect(
@@ -2149,6 +2186,9 @@ describe('alpha router', () => {
           quoteToken: USDC,
           v2poolProvider: sinon.match.any,
           l2GasDataProvider: undefined,
+          providerConfig: sinon.match({
+            blockNumber: sinon.match.instanceOf(Promise)
+          })
         })
       ).toBeTruthy();
       expect(


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
We want to pass the block number down to the v3 pool provider on the TVL heuristics path on v3, so that [DynamoCachingV3PoolProps](https://github.com/Uniswap/routing-api/blob/main/lib/handlers/pools/pool-caching/v3/cache-dynamo-pool.ts) can actually cache the per-block pool depending on which token pairs.

- **What is the current behavior?** (You can also link to an open issue here)
In prod, each hour we have about 100k dynamo pool cache misses due to no block number:
<img width="1512" alt="Dynamo Pool Cache Prod Per Hour" src="https://github.com/Uniswap/smart-order-router/assets/91580504/e05dcfed-8353-4b9d-b905-ae6304de0d9f">

This is quite a large number, considering we only enabled 1% shadow sampling into dynamo pool cache. This means if we would've enabled 100% sampling, then each hour there would've been 100M dynamo pool cache misses due to no block number. We suspect there is a major call flow that calls into the pool provider to get the v3 pools. This call cannot be in the subgraph provider as we were fixing in https://github.com/Uniswap/smart-order-router/pull/248, since static subgraph provider only falls back in case of the [AWSSubGraphProvider](https://github.com/Uniswap/routing-api/blob/main/lib/handlers/injector-sor.ts#LL282C1-L294C1) S3 Cache eager build failure.

After some code deep dive, and cowboy approaches, we think the potential candidate is during the TVL heuristics path on v3, where each route request will unavoidably call pool provider to get the TVL heuristics. 

- **What is the new behavior (if this is a feature change)?**
We pass down the block number to both USDC pool and native pool TVL heuristics paths, and eventually to the v3 pool provider. Along with the existing dynamo cache hit/miss rate, we will be able to tell how much this PR would improve. Also we have another change to track the in-memory v3 pool provider cache hit/miss rate, so we have a better idea of the existing RPC call volumes.

- **Other information**:
It seems like prod requests don't have distributed tracing enabled, so it's a bit hard to categorize the cache miss codepath patterns. I ended like adding the no block number message along with the call stack trace, deployed in personal cdk stack, and ran integ-test against routing stack to see all the [logs](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252FRoutingAPIStack-RoutingLa-RouteToRatioLambda23FC7C-2i0yJXhQD8js/log-events/2023$252F06$252F09$252F$255B$2524LATEST$255D2f5ecd7fcf714389b4d5ce26e22be287$3FfilterPattern$3DNo+block+number+for):
<img width="1512" alt="No block number log error stack" src="https://github.com/Uniswap/smart-order-router/assets/91580504/881f3776-0081-4da9-87a7-cb9772c5fdd6">

Once I have this call stack, then I can use the log insights to see the call patterns. In total we see 257 error stack [traces](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-604800~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40message*0a*7c*20filter*20*40message*20like*20*27No*20block*20number*20for*20pool*27~queryId~'6d9f38d78a1589a-403cdb4-4358acf-e4f3f121-1645d14d9e317af52ffbf58~source~(~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-pOSkckAzB5N6~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-xxMl8mSwRJxq))):

<img width="1504" alt="log insights total error stacktrace" src="https://github.com/Uniswap/smart-order-router/assets/91580504/cd813645-87fc-4f26-8143-3f2854b7fd45">

Out of which, [148](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-604800~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40message*0a*7c*20filter*20*40message*20like*20*27gas-factory-helpers.ts*3a126*3a24*27~queryId~'6d9f38d78a1589a-403cdb4-4358acf-e4f3f121-1645d14d9e317af52ffbf58~source~(~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-pOSkckAzB5N6~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-xxMl8mSwRJxq))) and [64](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-604800~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40message*0a*7c*20filter*20*40message*20like*20*27gas-factory-helpers.ts*3a70*3a24*27~queryId~'6d9f38d78a1589a-403cdb4-4358acf-e4f3f121-1645d14d9e317af52ffbf58~source~(~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-pOSkckAzB5N6~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-xxMl8mSwRJxq))) are due to TVL heuristics:
<img width="1507" alt="62 gas tvl calls" src="https://github.com/Uniswap/smart-order-router/assets/91580504/f03304d9-0948-4015-9d71-b8ee30bc8c5e">
<img width="1511" alt="148 gas tvl calls" src="https://github.com/Uniswap/smart-order-router/assets/91580504/0651ac9a-5c5c-451a-b106-ebd8a9fbe64f">

[57](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-604800~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40message*0a*7c*20filter*20*40message*20like*20*27get-candidate-pools.ts*3a573*3a24*27~queryId~'6d9f38d78a1589a-403cdb4-4358acf-e4f3f121-1645d14d9e317af52ffbf58~source~(~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-pOSkckAzB5N6~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-xxMl8mSwRJxq))) due to get candidate pools from swap then route from chains:
<img width="1505" alt="57 get candidate pools as part of swap then route from chain" src="https://github.com/Uniswap/smart-order-router/assets/91580504/0f7ec7e3-98fc-4b0d-8ddb-947076ca3475">

Math doesn't exactly line up (148+64+57 != 257), but they are close enough for us to speculate the TVL heuristics calculation paths are the majority of the cache hiss. I think we want to pass down the block number to candidate pools in a separate PR to see the cache hit improvement incrementally.