### PR TITLE
[ROUTE-9] Pass down block number to v3 candidate pool

### DIFF
--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -570,7 +570,9 @@ export async function getV3CandidatePools({
 
   const beforePoolsLoad = Date.now();
 
-  const poolAccessor = await poolProvider.getPools(tokenPairs);
+  const poolAccessor = await poolProvider.getPools(tokenPairs, {
+    blockNumber,
+  });
 
   metric.putMetric(
     'V3PoolsLoad',

--- a/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
+++ b/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
@@ -116,7 +116,7 @@ describe('get candidate pools', () => {
       mockV3PoolProvider.getPools.calledWithExactly([
         [USDC, WRAPPED_NATIVE_CURRENCY[1]!, FeeAmount.LOW],
         [WRAPPED_NATIVE_CURRENCY[1]!, USDT, FeeAmount.LOW],
-      ])
+      ], { blockNumber: undefined })
     ).toBeTruthy();
   });
 
@@ -143,7 +143,7 @@ describe('get candidate pools', () => {
       mockV3PoolProvider.getPools.calledWithExactly([
         [DAI, USDC, FeeAmount.LOW],
         [DAI, USDC, FeeAmount.MEDIUM],
-      ])
+      ], { blockNumber: undefined })
     ).toBeTruthy();
   });
 
@@ -170,7 +170,7 @@ describe('get candidate pools', () => {
       mockV3PoolProvider.getPools.calledWithExactly([
         [USDC, WRAPPED_NATIVE_CURRENCY[1]!, FeeAmount.LOW],
         [DAI, USDC, FeeAmount.LOW],
-      ])
+      ], { blockNumber: undefined })
     ).toBeTruthy();
   });
 
@@ -227,7 +227,7 @@ describe('get candidate pools', () => {
         [DAI, WRAPPED_NATIVE_CURRENCY[1]!, FeeAmount.MEDIUM],
         [DAI, WRAPPED_NATIVE_CURRENCY[1]!, FeeAmount.LOW],
         [DAI, WRAPPED_NATIVE_CURRENCY[1]!, FeeAmount.LOWEST],
-      ])
+      ], { blockNumber: undefined })
     ).toBeTruthy();
   });
 });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
With the left over item from https://github.com/Uniswap/smart-order-router/pull/253, we expect to still see some Dynamo pool caching miss due to the missing block number:

> I think we want to pass down the block number to candidate pools in a separate PR to see the cache hit improvement incrementally.

- **What is the new behavior (if this is a feature change)?**
We first ran the integ-test in routing-api before making this change. We saw some cache miss due to missing block number as expected. Then we make this PR change, and locally test via [tarball](https://github.com/Uniswap/routing-api/compare/main...jsy1218/explore-sor-local-tarball) method. Then we re-ran the integ-test in routing-api after deploying cdk via personal AWS account. We no longer see missing block number:

<img width="1435" alt="Screenshot 2023-06-13 at 2 47 49 PM" src="https://github.com/Uniswap/smart-order-router/assets/91580504/c2a287f8-ea62-4f94-ba4f-6f1075538090">


- **Other information**:

In Prod, I think the dynamo caching miss due to not in the table is a bit high, as compared to the dynamo caching hit in the table:

<img width="1438" alt="Screenshot 2023-06-13 at 2 51 32 PM" src="https://github.com/Uniswap/smart-order-router/assets/91580504/c8d1e302-b1eb-463d-86e4-d7c29791c150">

With average block settlement time of 10-15 seconds on ETH L1, I expect the ratio to be roughly 1:3 - 1:5, currently it's smaller than 1:2. Even with Dynamo eventual consistency, the latency is not that [high](https://github.com/alexdebrie/dynamodb-performance-testing/tree/master/consistency-performance). There might be further opportunity to improve the cache hit in the block number existent but cache miss path. 