### PR TITLE
export v2 rpc call volume metric

### DIFF
--- a/src/providers/v2/pool-provider.ts
+++ b/src/providers/v2/pool-provider.ts
@@ -5,7 +5,7 @@ import retry, { Options as RetryOptions } from 'async-retry';
 import _ from 'lodash';
 
 import { IUniswapV2Pair__factory } from '../../types/v2/factories/IUniswapV2Pair__factory';
-import { ChainId, CurrencyAmount } from '../../util';
+import { ChainId, CurrencyAmount, metric, MetricLoggerUnit } from '../../util';
 import { log } from '../../util/log';
 import { poolToString } from '../../util/routes';
 import { IMulticallProvider, Result } from '../multicall-provider';
@@ -106,6 +106,8 @@ export class V2PoolProvider implements IV2PoolProvider {
     log.debug(
       `getPools called with ${tokenPairs.length} token pairs. Deduped down to ${poolAddressSet.size}`
     );
+
+    metric.putMetric('V2_RPC_POOL_RPC_CALL', 1, MetricLoggerUnit.None)
 
     const reservesResults = await this.getPoolsData<IReserves>(
       sortedPoolAddresses,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Enhancement

- **What is the current behavior?** (You can also link to an open issue here)
We don't know what is the v2 Pool Provider RPC call volume. From [routing-api](https://github.com/Uniswap/routing-api), we don't cache pool at all in v2, and instead we will always make a RPC call. In specific, this is in [inject-sor.ts](https://github.com/Uniswap/routing-api/blob/main/lib/handlers/injector-sor.ts#LL255C1-L256C1). 

- **What is the new behavior (if this is a feature change)?**
We will start exporting v2 pool provider RPC call metric, so we have an idea of the call volume. Depending on the call volume, we can then decide if we want to proceed to make the V2 dynamo caching pool as parity to v3 dynamo caching pool.

- **Other information**:
Tested via my personal cdk using local tarball [method](https://github.com/Uniswap/routing-api/compare/main...jsy1218/explore-sor-local-tarball), and can see new metric getting exported:
<img width="1441" alt="Screenshot 2023-06-15 at 4 19 43 PM" src="https://github.com/Uniswap/smart-order-router/assets/91580504/e4db3d30-aed6-4764-ac0c-8254ed832cb3">
