### PR TITLE
fix: add subgraph & cachedNativeCurrency method for avax

### DIFF
--- a/src/providers/v3/subgraph-provider.ts
+++ b/src/providers/v3/subgraph-provider.ts
@@ -59,6 +59,8 @@ const SUBGRAPH_URL_BY_CHAIN: { [chainId in ChainId]?: string } = {
     'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v3-gorli',
   [ChainId.BNB]:
     'https://api.thegraph.com/subgraphs/name/ilyamk/uniswap-v3---bnb-chain',
+  [ChainId.AVALANCHE]:
+    'https://api.thegraph.com/subgraphs/name/lynnshaoyu/uniswap-v3-avax',
 };
 
 const PAGE_SIZE = 1000; // 1k is max possible query size from subgraph.

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -491,6 +491,30 @@ class MoonbeamNativeCurrency extends NativeCurrency {
   }
 }
 
+function isAvax(chainId: number): chainId is ChainId.AVALANCHE {
+  return chainId === ChainId.AVALANCHE;
+}
+
+class AvalancheNativeCurrency extends NativeCurrency {
+  equals(other: Currency): boolean {
+    return other.isNative && other.chainId === this.chainId;
+  }
+
+  get wrapped(): Token {
+    if (!isAvax(this.chainId)) throw new Error('Not avalanche');
+    const nativeCurrency = WRAPPED_NATIVE_CURRENCY[this.chainId];
+    if (nativeCurrency) {
+      return nativeCurrency;
+    }
+    throw new Error(`Does not support this chain ${this.chainId}`);
+  }
+
+  public constructor(chainId: number) {
+    if (!isAvax(chainId)) throw new Error('Not avalanche');
+    super(chainId, 18, 'AVAX', 'Avalanche');
+  }
+}
+
 export class ExtendedEther extends Ether {
   public get wrapped(): Token {
     if (this.chainId in WRAPPED_NATIVE_CURRENCY)
@@ -523,6 +547,8 @@ export function nativeOnChain(chainId: number): NativeCurrency {
     cachedNativeCurrency[chainId] = new MoonbeamNativeCurrency(chainId);
   else if (isBnb(chainId))
     cachedNativeCurrency[chainId] = new BnbNativeCurrency(chainId);
+  else if (isAvax(chainId))
+    cachedNativeCurrency[chainId] = new AvalancheNativeCurrency(chainId);
   else cachedNativeCurrency[chainId] = ExtendedEther.onChain(chainId);
 
   return cachedNativeCurrency[chainId]!;


### PR DESCRIPTION
adding items I missed in last PRs for AVAX support. discovered due to routing-api integration tests failing for avax