### PR TITLE
Jsy1218/fix avax stablecoin gas usd ordering

### DIFF
--- a/src/routers/alpha-router/gas-models/gas-model.ts
+++ b/src/routers/alpha-router/gas-models/gas-model.ts
@@ -65,7 +65,7 @@ export const usdGasTokensByChain: { [chainId in ChainId]?: Token[] } = {
   [ChainId.GNOSIS]: [USDC_ETHEREUM_GNOSIS],
   [ChainId.MOONBEAM]: [USDC_MOONBEAM],
   [ChainId.BNB]: [USDT_BNB, USDC_BNB, DAI_BNB],
-  [ChainId.AVALANCHE]: [USDC_AVAX, DAI_AVAX],
+  [ChainId.AVALANCHE]: [DAI_AVAX, USDC_AVAX],
 };
 
 export type L1ToL2GasCosts = {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
For avax chain swap, all the swaps are failing due to the insufficient gas decimals (using USDC.e which has 6 decimals)

- **What is the new behavior (if this is a feature change)?**
We use DAI instead for estimating gas decimals (DAI has 18 decimals)

- **Other information**:
We need to ship this as soon as possible. None of the avax swap is successful for 2+ days now from explorer [page](https://snowtrace.io/address/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad).

I tested locally via local [tarball methodology](https://github.com/Uniswap/routing-api/compare/main...jsy1218/explore-sor-local-tarball), and the avax quote succeeded on my personal AWS account (curl --request GET 'https://evhd4n1t9b.execute-api.us-east-2.amazonaws.com/prod/quote?tokenInAddress=AVAX&tokenInChainId=43114&tokenOutAddress=0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB&tokenOutChainId=43114&amount=1000000000000000000&type=exactIn')