### PR TITLE
feat: make USD gas estimation optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.13.6",
+  "version": "3.13.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "3.13.5",
+      "version": "3.13.7",
       "license": "GPL",
       "dependencies": {
         "@uniswap/default-token-list": "^11.2.0",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1476,7 +1476,7 @@ export class AlphaRouter
     ])
 
     const pools: LiquidityCalculationPools = {
-      usdPool: usdPool,
+      usdPool,
       nativeQuoteTokenV3Pool: nativeQuoteTokenV3Pool,
       nativeAmountTokenV3Pool: nativeAmountTokenV3Pool
     };

--- a/src/routers/alpha-router/entities/route-with-valid-quote.ts
+++ b/src/routers/alpha-router/entities/route-with-valid-quote.ts
@@ -31,7 +31,7 @@ export interface IRouteWithValidQuote<
   gasEstimate: BigNumber;
   // The gas cost in terms of the quote token.
   gasCostInToken: CurrencyAmount;
-  gasCostInUSD: CurrencyAmount;
+  gasCostInUSD: CurrencyAmount | undefined;
   tradeType: TradeType;
   poolAddresses: string[];
   tokenPath: Token[];
@@ -86,7 +86,7 @@ export class V2RouteWithValidQuote implements IV2RouteWithValidQuote {
   public gasModel: IGasModel<V2RouteWithValidQuote>;
   public gasEstimate: BigNumber;
   public gasCostInToken: CurrencyAmount;
-  public gasCostInUSD: CurrencyAmount;
+  public gasCostInUSD: CurrencyAmount | undefined;
   public tradeType: TradeType;
   public poolAddresses: string[];
   public tokenPath: Token[];
@@ -107,7 +107,7 @@ export class V2RouteWithValidQuote implements IV2RouteWithValidQuote {
     gasModel,
     quoteToken,
     tradeType,
-    v2PoolProvider,
+    v2PoolProvider
   }: V2RouteWithValidQuoteParams) {
     this.amount = amount;
     this.rawQuote = rawQuote;
@@ -180,7 +180,7 @@ export class V3RouteWithValidQuote implements IV3RouteWithValidQuote {
   public gasModel: IGasModel<V3RouteWithValidQuote>;
   public gasEstimate: BigNumber;
   public gasCostInToken: CurrencyAmount;
-  public gasCostInUSD: CurrencyAmount;
+  public gasCostInUSD: CurrencyAmount | undefined;
   public tradeType: TradeType;
   public poolAddresses: string[];
   public tokenPath: Token[];
@@ -204,7 +204,7 @@ export class V3RouteWithValidQuote implements IV3RouteWithValidQuote {
     gasModel,
     quoteToken,
     tradeType,
-    v3PoolProvider,
+    v3PoolProvider
   }: V3RouteWithValidQuoteParams) {
     this.amount = amount;
     this.rawQuote = rawQuote;
@@ -282,7 +282,7 @@ export class MixedRouteWithValidQuote implements IMixedRouteWithValidQuote {
   public gasModel: IGasModel<MixedRouteWithValidQuote>;
   public gasEstimate: BigNumber;
   public gasCostInToken: CurrencyAmount;
-  public gasCostInUSD: CurrencyAmount;
+  public gasCostInUSD: CurrencyAmount | undefined;
   public tradeType: TradeType;
   public poolAddresses: string[];
   public tokenPath: Token[];
@@ -307,7 +307,7 @@ export class MixedRouteWithValidQuote implements IMixedRouteWithValidQuote {
     quoteToken,
     tradeType,
     v3PoolProvider,
-    v2PoolProvider,
+    v2PoolProvider
   }: MixedRouteWithValidQuoteParams) {
     this.amount = amount;
     this.rawQuote = rawQuote;

--- a/src/routers/alpha-router/gas-models/gas-model.ts
+++ b/src/routers/alpha-router/gas-models/gas-model.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { ChainId, Token } from '@uniswap/sdk-core';
-
 import { Pool } from '@uniswap/v3-sdk';
+
 import { ProviderConfig } from '../../../providers/provider';
 import {
   CUSD_CELO,
@@ -95,7 +95,7 @@ export type BuildV2GasModelFactoryType = {
 };
 
 export type LiquidityCalculationPools = {
-  usdPool: Pool
+  usdPool: Pool | undefined
   nativeQuoteTokenV3Pool: Pool | null
   nativeAmountTokenV3Pool: Pool | null
 }
@@ -160,10 +160,10 @@ export abstract class IOnChainGasModelFactory {
   public abstract buildGasModel({
     chainId,
     gasPriceWei,
-    pools: LiquidityCalculationPools,
+    pools,
     amountToken,
     quoteToken,
-    v2poolProvider: V2poolProvider,
+    v2poolProvider,
     l2GasDataProvider,
   }: BuildOnChainGasModelFactoryType): Promise<
     IGasModel<V3RouteWithValidQuote | MixedRouteWithValidQuote>

--- a/src/routers/alpha-router/gas-models/gas-model.ts
+++ b/src/routers/alpha-router/gas-models/gas-model.ts
@@ -33,18 +33,21 @@ import {
   USDT_MAINNET,
   USDT_OPTIMISM,
   USDT_OPTIMISM_GOERLI,
-  WBTC_GOERLI,
+  WBTC_GOERLI
 } from '../../../providers/token-provider';
 import { IV2PoolProvider } from '../../../providers/v2/pool-provider';
-import { ArbitrumGasData, IL2GasDataProvider, OptimismGasData, } from '../../../providers/v3/gas-data-provider';
+import {
+  ArbitrumGasData,
+  IL2GasDataProvider,
+  OptimismGasData
+} from '../../../providers/v3/gas-data-provider';
 import { CurrencyAmount } from '../../../util/amounts';
 import {
   MixedRouteWithValidQuote,
   RouteWithValidQuote,
   V2RouteWithValidQuote,
-  V3RouteWithValidQuote,
+  V3RouteWithValidQuote
 } from '../entities/route-with-valid-quote';
-
 
 export const usdGasTokensByChain: { [chainId in ChainId]?: Token[] } = {
   [ChainId.MAINNET]: [DAI_MAINNET, USDC_MAINNET, USDT_MAINNET],
@@ -53,7 +56,7 @@ export const usdGasTokensByChain: { [chainId in ChainId]?: Token[] } = {
   [ChainId.OPTIMISM_GOERLI]: [
     DAI_OPTIMISM_GOERLI,
     USDC_OPTIMISM_GOERLI,
-    USDT_OPTIMISM_GOERLI,
+    USDT_OPTIMISM_GOERLI
   ],
   [ChainId.ARBITRUM_GOERLI]: [USDC_ARBITRUM_GOERLI],
   [ChainId.GOERLI]: [DAI_GOERLI, USDC_GOERLI, USDT_GOERLI, WBTC_GOERLI],
@@ -65,12 +68,12 @@ export const usdGasTokensByChain: { [chainId in ChainId]?: Token[] } = {
   [ChainId.GNOSIS]: [USDC_ETHEREUM_GNOSIS],
   [ChainId.MOONBEAM]: [USDC_MOONBEAM],
   [ChainId.BNB]: [USDT_BNB, USDC_BNB, DAI_BNB],
-  [ChainId.AVALANCHE]: [DAI_AVAX, USDC_AVAX],
+  [ChainId.AVALANCHE]: [DAI_AVAX, USDC_AVAX]
 };
 
 export type L1ToL2GasCosts = {
   gasUsedL1: BigNumber;
-  gasCostL1USD: CurrencyAmount;
+  gasCostL1USD: CurrencyAmount | undefined;
   gasCostL1QuoteToken: CurrencyAmount;
 };
 
@@ -95,10 +98,10 @@ export type BuildV2GasModelFactoryType = {
 };
 
 export type LiquidityCalculationPools = {
-  usdPool: Pool | undefined
-  nativeQuoteTokenV3Pool: Pool | null
-  nativeAmountTokenV3Pool: Pool | null
-}
+  usdPool: Pool | undefined;
+  nativeQuoteTokenV3Pool: Pool | null;
+  nativeAmountTokenV3Pool: Pool | null;
+};
 
 /**
  * Contains functions for generating gas estimates for given routes.
@@ -120,7 +123,7 @@ export type IGasModel<TRouteWithValidQuote extends RouteWithValidQuote> = {
   estimateGasCost(routeWithValidQuote: TRouteWithValidQuote): {
     gasEstimate: BigNumber;
     gasCostInToken: CurrencyAmount;
-    gasCostInUSD: CurrencyAmount;
+    gasCostInUSD: CurrencyAmount | undefined;
   };
   calculateL1GasFees?(routes: TRouteWithValidQuote[]): Promise<L1ToL2GasCosts>;
 };
@@ -141,7 +144,7 @@ export abstract class IV2GasModelFactory {
     chainId,
     gasPriceWei,
     poolProvider,
-    token,
+    token
   }: BuildV2GasModelFactoryType): Promise<IGasModel<V2RouteWithValidQuote>>;
 }
 
@@ -164,7 +167,7 @@ export abstract class IOnChainGasModelFactory {
     amountToken,
     quoteToken,
     v2poolProvider,
-    l2GasDataProvider,
+    l2GasDataProvider
   }: BuildOnChainGasModelFactoryType): Promise<
     IGasModel<V3RouteWithValidQuote | MixedRouteWithValidQuote>
   >;

--- a/src/routers/router.ts
+++ b/src/routers/router.ts
@@ -3,14 +3,14 @@ import {
   CondensedAddLiquidityOptions,
   MixedRouteSDK,
   Protocol,
-  Trade,
+  Trade
 } from '@uniswap/router-sdk';
 import {
   Currency,
   Fraction,
   Percent,
   Token,
-  TradeType,
+  TradeType
 } from '@uniswap/sdk-core';
 import { SwapOptions as UniversalRouterSwapOptions } from '@uniswap/universal-router-sdk';
 import { Route as V2RouteRaw } from '@uniswap/v2-sdk';
@@ -18,7 +18,7 @@ import {
   Pool,
   Position,
   MethodParameters as SDKMethodParameters,
-  Route as V3RouteRaw,
+  Route as V3RouteRaw
 } from '@uniswap/v3-sdk';
 
 import { SimulationStatus } from '../providers';
@@ -61,7 +61,7 @@ export type SwapRoute = {
   /**
    * The estimate of the gas used by the swap in USD.
    */
-  estimatedGasUsedUSD: CurrencyAmount;
+  estimatedGasUsedUSD: CurrencyAmount | undefined;
   /**
    * The gas price used when computing quoteGasAdjusted, estimatedGasUsedQuoteToken, etc.
    */
@@ -101,7 +101,7 @@ export type SwapToRatioRoute = SwapRoute & {
 export enum SwapToRatioStatus {
   SUCCESS = 1,
   NO_ROUTE_FOUND = 2,
-  NO_SWAP_NEEDED = 3,
+  NO_SWAP_NEEDED = 3
 }
 
 export type SwapToRatioSuccess = {
@@ -125,7 +125,7 @@ export type SwapToRatioResponse =
 
 export enum SwapType {
   UNIVERSAL_ROUTER,
-  SWAP_ROUTER_02,
+  SWAP_ROUTER_02
 }
 
 // Swap options for Universal Router and Permit2.

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -101,14 +101,12 @@ export async function getHighestLiquidityV3USDPool(
   chainId: ChainId,
   poolProvider: IV3PoolProvider,
   providerConfig?: ProviderConfig
-): Promise<Pool> {
+): Promise<Pool | undefined> {
   const usdTokens = usdGasTokensByChain[chainId];
   const wrappedCurrency = WRAPPED_NATIVE_CURRENCY[chainId]!;
 
   if (!usdTokens) {
-    throw new Error(
-      `Could not find a USD token for computing gas costs on ${chainId}`
-    );
+    return undefined
   }
 
   const usdPools = _([
@@ -291,13 +289,15 @@ export async function calculateGasUsed(
     gasCostInWei
   );
 
-  const usdPool: Pool = await getHighestLiquidityV3USDPool(
+  const usdPool: Pool | undefined = await getHighestLiquidityV3USDPool(
     chainId,
     v3PoolProvider,
     providerConfig
   );
 
-  const gasCostUSD = await getGasCostInUSD(usdPool, costNativeCurrency);
+  const gasCostUSD = usdPool ? 
+    getGasCostInUSD(usdPool, costNativeCurrency) : 
+    CurrencyAmount.fromRawAmount(nativeCurrency, 0)
 
   let gasCostQuoteToken = costNativeCurrency;
   // get fee in terms of quote token

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -6,6 +6,7 @@ import _ from 'lodash';
 
 import { RouteWithValidQuote } from '../routers/alpha-router';
 import { MixedRoute, V2Route, V3Route } from '../routers/router';
+
 import { V3_CORE_FACTORY_ADDRESSES } from './addresses';
 
 import { CurrencyAmount } from '.';

--- a/test/unit/routers/alpha-router/alpha-router.test.ts
+++ b/test/unit/routers/alpha-router/alpha-router.test.ts
@@ -558,9 +558,9 @@ describe('alpha router', () => {
         )
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -774,9 +774,9 @@ describe('alpha router', () => {
         )
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -946,9 +946,9 @@ describe('alpha router', () => {
         )
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -1057,9 +1057,9 @@ describe('alpha router', () => {
         )
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -1122,9 +1122,9 @@ describe('alpha router', () => {
         )
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -1198,9 +1198,9 @@ describe('alpha router', () => {
         )
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -1459,9 +1459,9 @@ describe('alpha router', () => {
         )
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -1531,9 +1531,9 @@ describe('alpha router', () => {
         )
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -1607,9 +1607,9 @@ describe('alpha router', () => {
         )
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -1690,9 +1690,9 @@ describe('alpha router', () => {
         )
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -1918,9 +1918,9 @@ describe('alpha router', () => {
         swap!.estimatedGasUsedQuoteToken.currency.equals(USDC)
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -2001,9 +2001,9 @@ describe('alpha router', () => {
         swap!.estimatedGasUsedQuoteToken.currency.equals(USDC!)
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -2059,9 +2059,9 @@ describe('alpha router', () => {
         swap!.estimatedGasUsedQuoteToken.currency.equals(USDC!)
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -2138,9 +2138,9 @@ describe('alpha router', () => {
         swap!.estimatedGasUsedQuoteToken.currency.equals(USDC!)
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()
@@ -2217,9 +2217,9 @@ describe('alpha router', () => {
         swap!.estimatedGasUsedQuoteToken.currency.equals(USDC!)
       ).toBeTruthy();
       expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
+        swap!.estimatedGasUsedUSD?.currency.equals(USDC) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(USDT) ||
+        swap!.estimatedGasUsedUSD?.currency.equals(DAI)
       ).toBeTruthy();
       expect(swap!.gasPriceWei.toString()).toEqual(
         mockGasPriceWeiBN.toString()


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Default to a USD Gas Estimation of 0  if there are no USD-type Token pools.

- **What is the current behavior?** (You can also link to an open issue here)

Currently, this package throws an Error if there are no USD-type Token pools specified.

- **What is the new behavior (if this is a feature change)?**
If we don't have a USD pool, we just fallback to a gas estimation of zero.

- **Other information**:

### Test Plan
I was able to run the unit tests successfully, but couldn't get the integ-tests to run on my machine even with the .env file populated.

I'm also not sure where exactly to add a unit test for this new behavior, so looking for guidance on that.