### PR TITLE
feat: add base chain names

### DIFF
--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -72,6 +72,10 @@ export const ID_TO_CHAIN_ID = (id: number): ChainId => {
       return ChainId.MOONBEAM;
     case 43114:
       return ChainId.AVALANCHE;
+    case 8453:
+      return ChainId.BASE;
+    case 84531:
+      return ChainId.BASE_GOERLI;
     default:
       throw new Error(`Unknown chain id: ${id}`);
   }
@@ -93,6 +97,8 @@ export enum ChainName {
   MOONBEAM = 'moonbeam-mainnet',
   BNB = 'bnb-mainnet',
   AVALANCHE = 'avalanche-mainnet',
+  BASE = 'base-mainnet',
+  BASE_GOERLI = 'base-goerli',
 }
 
 
@@ -215,6 +221,10 @@ export const ID_TO_NETWORK_NAME = (id: number): ChainName => {
       return ChainName.MOONBEAM;
     case 43114:
       return ChainName.AVALANCHE;
+    case 8453:
+      return ChainName.BASE;
+    case 84531:
+      return ChainName.BASE_GOERLI;
     default:
       throw new Error(`Unknown chain id: ${id}`);
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

adds a couple values to enums. routing still doesn't work for these chains, but now the error is more accurate: "Could not find USD pools for gas estimation" (instead of "unknown chain ID")

- **What is the current behavior?** (You can also link to an open issue here)

error with "Unknown chain ID" when trying to load a quote on these chains

- **What is the new behavior (if this is a feature change)?**

error with "No USD pools for gas estimation" on these chains

- **Other information**:
