### PR TITLE
Adjust gas estimates for single hop, and reduce cache length

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.13.6",
+  "version": "3.13.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "3.13.5",
+      "version": "3.13.7",
       "license": "GPL",
       "dependencies": {
         "@uniswap/default-token-list": "^11.2.0",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -585,7 +585,7 @@ export class AlphaRouter
         chainId,
         gasPriceProviderInstance,
         new NodeJSCache<GasPrice>(
-          new NodeCache({ stdTTL: 15, useClones: false })
+          new NodeCache({ stdTTL: 7, useClones: false })
         )
       );
     this.v3GasModelFactory =

--- a/src/routers/alpha-router/gas-models/v3/gas-costs.ts
+++ b/src/routers/alpha-router/gas-models/v3/gas-costs.ts
@@ -91,3 +91,26 @@ export const COST_PER_HOP = (id: ChainId): BigNumber => {
       return BigNumber.from(80000);
   }
 };
+
+export const SINGLE_HOP_OVERHEAD = (id: ChainId): BigNumber => {
+  switch (id) {
+    case ChainId.MAINNET:
+    case ChainId.GOERLI:
+    case ChainId.SEPOLIA:
+    case ChainId.BNB:
+    case ChainId.OPTIMISM:
+    case ChainId.OPTIMISM_GOERLI:
+    case ChainId.AVALANCHE:
+    case ChainId.BASE:
+    case ChainId.BASE_GOERLI:
+    case ChainId.ARBITRUM_ONE:
+    case ChainId.ARBITRUM_GOERLI:
+    case ChainId.POLYGON:
+    case ChainId.POLYGON_MUMBAI:
+    case ChainId.CELO:
+    case ChainId.CELO_ALFAJORES:
+    case ChainId.GNOSIS:
+    case ChainId.MOONBEAM:
+      return BigNumber.from(15000);
+  }
+};

--- a/src/routers/alpha-router/gas-models/v3/gas-costs.ts
+++ b/src/routers/alpha-router/gas-models/v3/gas-costs.ts
@@ -1,5 +1,8 @@
 import { BigNumber } from '@ethersproject/bignumber';
-import { ChainId } from '@uniswap/sdk-core';
+import { ChainId, Token } from '@uniswap/sdk-core';
+import { AAVE_MAINNET, LIDO_MAINNET } from '../../../../providers';
+
+import { V3Route } from '../../../router';
 
 // Cost for crossing an uninitialized tick.
 export const COST_PER_UNINIT_TICK = BigNumber.from(0);
@@ -92,25 +95,27 @@ export const COST_PER_HOP = (id: ChainId): BigNumber => {
   }
 };
 
-export const SINGLE_HOP_OVERHEAD = (id: ChainId): BigNumber => {
-  switch (id) {
-    case ChainId.MAINNET:
-    case ChainId.GOERLI:
-    case ChainId.SEPOLIA:
-    case ChainId.BNB:
-    case ChainId.OPTIMISM:
-    case ChainId.OPTIMISM_GOERLI:
-    case ChainId.AVALANCHE:
-    case ChainId.BASE:
-    case ChainId.BASE_GOERLI:
-    case ChainId.ARBITRUM_ONE:
-    case ChainId.ARBITRUM_GOERLI:
-    case ChainId.POLYGON:
-    case ChainId.POLYGON_MUMBAI:
-    case ChainId.CELO:
-    case ChainId.CELO_ALFAJORES:
-    case ChainId.GNOSIS:
-    case ChainId.MOONBEAM:
-      return BigNumber.from(15000);
+export const SINGLE_HOP_OVERHEAD = (_id: ChainId): BigNumber => {
+  return BigNumber.from(15000);
+};
+
+export const TOKEN_OVERHEAD = (id: ChainId, route: V3Route): BigNumber => {
+  const tokens: Token[] = route.tokenPath;
+  let overhead = BigNumber.from(0);
+
+  if (id == ChainId.MAINNET) {
+    // AAVE's transfer contains expensive governance snapshotting logic. We estimate
+    // it at around 150k.
+    if (tokens.some((t: Token) => t.equals(AAVE_MAINNET))) {
+      overhead = overhead.add(150000);
+    }
+
+    // LDO's reaches out to an external token controller which adds a large overhead
+    // of around 150k.
+    if (tokens.some((t: Token) => t.equals(LIDO_MAINNET))) {
+      overhead = overhead.add(150000);
+    }
   }
+
+  return overhead;
 };

--- a/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
@@ -32,6 +32,7 @@ import {
   COST_PER_INIT_TICK,
   COST_PER_UNINIT_TICK,
   SINGLE_HOP_OVERHEAD,
+  TOKEN_OVERHEAD,
 } from './gas-costs';
 
 /**
@@ -371,6 +372,11 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
       hopsGasUse = hopsGasUse.add(SINGLE_HOP_OVERHEAD(chainId));
     }
 
+    // Some tokens have extremely expensive transferFrom functions, which causes
+    // us to underestimate them by a large amount. For known tokens, we apply an
+    // adjustment.
+    const tokenOverhead = TOKEN_OVERHEAD(chainId, routeWithValidQuote.route);
+
     const tickGasUse = COST_PER_INIT_TICK(chainId).mul(
       totalInitializedTicksCrossed
     );
@@ -379,6 +385,7 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
     // base estimate gas used based on chainId estimates for hops and ticks gas useage
     const baseGasUse = BASE_SWAP_COST(chainId)
       .add(hopsGasUse)
+      .add(tokenOverhead)
       .add(tickGasUse)
       .add(uninitializedTickGasUse);
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Two modifications to the algorithm we use for computing gas estimates: 
1/ increase estimate for single hop swaps.
2/ add a custom overhead for certain known expensive to transfer tokens (AAVE and LDO)
Also reduces cache length for the gas price from 15s -> 7s


- **What is the current behavior?** (You can also link to an open issue here)

Gas prices are cached for 15s
There is no functionality for applying gas overheads based on the tokens being swapped
There is no gas overhead applied for single hop swaps


- **What is the new behavior (if this is a feature change)?**

Cache gas for 7s
Apply a 15k overhead to the route if it has 1 hop
Add a 150k overhead for routes that involve AAVE or LDO

- **Other information**:

Making this change based on a few pieces of data / thoughts
1/ https://uniswapteam.slack.com/archives/C021SU4PMR7/p1688666362630569 
2/ Multiple UniswapX market makers have stated that they feel we are underestimated gas costs to fill orders
3/ Generally it is best to overestimate than underestimate, both for the user (no surprises) and for UniswapX (if we are underestimating gas on classic swaps too much we end up sending much fewer swaps to X)
4/ Caching gas prices for longer than 1 block (12s) could lead to stale gas data being used. Better to shorten it. Also the 15s value was picked before PoS. Now that blocks are fairly consistently 12s, 15s is too long
5/ AAVE and LDO are well known to have expensive transferFrom functions. This has been well known for a long time (see https://www.notion.so/uniswaplabs/Improving-Gas-Estimates-in-the-Auto-Router-bd1982e86271429dbb24f436aebeb5ba?pvs=4#e7d3a0827027437ba550a0b726085fd4) but we have never taken action. This is now causing issues in UniswapX, as we parameterize X orders using the gasAdjustedOutput. The underestimate is causing us to price these tokens too highly