### PR TITLE
fix integ-test

### DIFF
--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -2559,8 +2559,9 @@ describe('quote for other networks', () => {
     [ChainId.MOONBEAM]: WBTC_MOONBEAM,
     [ChainId.BNB]: USDC_BNB,
     [ChainId.AVALANCHE]: USDC_ON(ChainId.AVALANCHE),
-    [ChainId.BASE]: USDC_ON(ChainId.BASE),
-    [ChainId.BASE_GOERLI]: USDC_ON(ChainId.BASE_GOERLI),
+    // TODO ROUTE-41: Use Base and BASE_GOERLI stablecoin
+    [ChainId.BASE]: USDC_ON(ChainId.AVALANCHE),
+    [ChainId.BASE_GOERLI]: USDC_ON(ChainId.AVALANCHE),
   };
   const TEST_ERC20_2: { [chainId in ChainId]: Token } = {
     [ChainId.MAINNET]: DAI_ON(1),
@@ -2578,8 +2579,9 @@ describe('quote for other networks', () => {
     [ChainId.MOONBEAM]: WBTC_MOONBEAM,
     [ChainId.BNB]: USDT_BNB,
     [ChainId.AVALANCHE]: DAI_ON(ChainId.AVALANCHE),
-    [ChainId.BASE]: USDC_ON(ChainId.BASE),
-    [ChainId.BASE_GOERLI]: USDC_ON(ChainId.BASE_GOERLI),
+    // TODO ROUTE-41: Use Base and BASE_GOERLI stablecoin
+    [ChainId.BASE]: USDC_ON(ChainId.AVALANCHE),
+    [ChainId.BASE_GOERLI]: USDC_ON(ChainId.AVALANCHE),
   };
 
   // TODO: Find valid pools/tokens on optimistic kovan and polygon mumbai. We skip those tests for now.
@@ -2593,8 +2595,8 @@ describe('quote for other networks', () => {
       // Tests are failing https://github.com/Uniswap/smart-order-router/issues/104
       c != ChainId.CELO_ALFAJORES &&
       c != ChainId.SEPOLIA &&
-      // skip avalanche for now, need to add liquidity pools.
-      c != ChainId.AVALANCHE
+      c != ChainId.BASE &&
+      c != ChainId.BASE_GOERLI
   )) {
     for (const tradeType of [TradeType.EXACT_INPUT, TradeType.EXACT_OUTPUT]) {
       const erc1 = TEST_ERC20_1[chain];


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

- **What is the current behavior?** (You can also link to an open issue here)
Integ-tests are failing at runtime, because we don't have stablecoins on BASE and BASE_GOERLI yet.
In addition, we skipped avalanche for testing

- **What is the new behavior (if this is a feature change)?**
We hard-code the BASE and BASE_GOERLI to be avalanche one, but skip BASE and BASE_GOERLI for now.

- **Other information**:
Somehow my local can't run BNB and AVAX chain tests successful. Want to see if others can run successfully on their local.