### PR TITLE
Release version 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "3.15.0",
+      "version": "3.15.1",
       "license": "GPL",
       "dependencies": {
         "@uniswap/default-token-list": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Release 3.15.1

This release contains an update of the subgraph url to point to the latest version rather than a specific version for BASE
