### PR TITLE
fix: bump ur sdk in sor to support BASE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@uniswap/swap-router-contracts": "^1.3.0",
         "@uniswap/token-lists": "^1.0.0-beta.31",
         "@uniswap/universal-router": "^1.0.1",
-        "@uniswap/universal-router-sdk": "^1.5.4",
+        "@uniswap/universal-router-sdk": "^1.5.7",
         "@uniswap/v2-sdk": "^3.2.0",
         "@uniswap/v3-sdk": "^3.10.0",
         "async-retry": "^1.3.1",
@@ -3245,9 +3245,9 @@
       }
     },
     "node_modules/@uniswap/universal-router-sdk": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-1.5.4.tgz",
-      "integrity": "sha512-9vbB1AFFW3QeZWjtRFE0PVnMa2L+yjJpbU9EqCaEAYdR3+T4zx8fuml+84XUQzjKTp1cnndwusc1Mm+g0/Djpg==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-1.5.7.tgz",
+      "integrity": "sha512-5T08dTZoAEN3W7fw467WoNwzfF8Ks5+t4/l0xVAhadUNq6UB/Ng9q5P70j+D+FVLwZbcbyv5zIkPtooADfjEKw==",
       "dependencies": {
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",
@@ -14226,9 +14226,9 @@
       }
     },
     "@uniswap/universal-router-sdk": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-1.5.4.tgz",
-      "integrity": "sha512-9vbB1AFFW3QeZWjtRFE0PVnMa2L+yjJpbU9EqCaEAYdR3+T4zx8fuml+84XUQzjKTp1cnndwusc1Mm+g0/Djpg==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-1.5.7.tgz",
+      "integrity": "sha512-5T08dTZoAEN3W7fw467WoNwzfF8Ks5+t4/l0xVAhadUNq6UB/Ng9q5P70j+D+FVLwZbcbyv5zIkPtooADfjEKw==",
       "requires": {
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@uniswap/swap-router-contracts": "^1.3.0",
     "@uniswap/token-lists": "^1.0.0-beta.31",
     "@uniswap/universal-router": "^1.0.1",
-    "@uniswap/universal-router-sdk": "^1.5.4",
+    "@uniswap/universal-router-sdk": "^1.5.7",
     "@uniswap/v2-sdk": "^3.2.0",
     "@uniswap/v3-sdk": "^3.10.0",
     "@uniswap/sdk-core": "^4.0.6",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We are on the older version of universal-router-sdk that doesn't support BASE yet.

- **What is the new behavior (if this is a feature change)?**
We bump universal-router-sdk to version 1.5.7 that supports BASE.

- **Other information**:
I noticed our sor integ-tests filtered out the BASE, so that we didn't catch this. https://github.com/Uniswap/smart-order-router/blob/main/test/integ/routers/alpha-router/alpha-router.integration.test.ts#L2598
