### PR TITLE
fix: buggy max by sorting for liquidity among pools

### DIFF
--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -1,13 +1,22 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Protocol } from '@uniswap/router-sdk';
-import { ChainId, Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core';
+import {
+  ChainId,
+  Currency,
+  CurrencyAmount,
+  Token,
+  TradeType,
+} from '@uniswap/sdk-core';
 import { Pair } from '@uniswap/v2-sdk/dist/entities';
 import { FeeAmount, Pool } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
 import { IV2PoolProvider } from '../providers';
 import { ProviderConfig } from '../providers/provider';
-import { ArbitrumGasData, OptimismGasData, } from '../providers/v3/gas-data-provider';
+import {
+  ArbitrumGasData,
+  OptimismGasData,
+} from '../providers/v3/gas-data-provider';
 import { IV3PoolProvider } from '../providers/v3/pool-provider';
 import {
   MethodParameters,
@@ -19,6 +28,7 @@ import {
 } from '../routers';
 import { log, WRAPPED_NATIVE_CURRENCY } from '../util';
 
+import JSBI from 'jsbi';
 import { buildTrade } from './methodParameters';
 
 export async function getV2NativePool(
@@ -89,7 +99,9 @@ export async function getHighestLiquidityV3NativePool(
     return null;
   }
 
-  const maxPool = _.maxBy(pools, (pool) => pool.liquidity) as Pool;
+  const maxPool = pools.reduce((prev, current) => {
+    return JSBI.greaterThan(prev.liquidity, current.liquidity) ? prev : current;
+  });
 
   return maxPool;
 }
@@ -152,7 +164,9 @@ export async function getHighestLiquidityV3USDPool(
     throw new Error(message);
   }
 
-  const maxPool = _.maxBy(pools, (pool) => pool.liquidity) as Pool;
+  const maxPool = pools.reduce((prev, current) => {
+    return JSBI.greaterThan(prev.liquidity, current.liquidity) ? prev : current;
+  });
 
   return maxPool;
 }
@@ -258,12 +272,7 @@ export async function calculateGasUsed(
   const gasPriceWei = route.gasPriceWei;
   // calculate L2 to L1 security fee if relevant
   let l2toL1FeeInWei = BigNumber.from(0);
-  if (
-    [
-      ChainId.ARBITRUM_ONE,
-      ChainId.ARBITRUM_GOERLI,
-    ].includes(chainId)
-  ) {
+  if ([ChainId.ARBITRUM_ONE, ChainId.ARBITRUM_GOERLI].includes(chainId)) {
     l2toL1FeeInWei = calculateArbitrumToL1FeeFromCalldata(
       route.methodParameters!.calldata,
       l2GasData as ArbitrumGasData
@@ -302,7 +311,11 @@ export async function calculateGasUsed(
   // get fee in terms of quote token
   if (!quoteToken.equals(nativeCurrency)) {
     const nativePools = await Promise.all([
-      getHighestLiquidityV3NativePool(quoteToken, v3PoolProvider, providerConfig),
+      getHighestLiquidityV3NativePool(
+        quoteToken,
+        v3PoolProvider,
+        providerConfig
+      ),
       getV2NativePool(quoteToken, v2PoolProvider),
     ]);
     const nativePool = nativePools.find((pool) => pool !== null);
@@ -448,10 +461,10 @@ export function initSwapRouteFromExisting(
     blockNumber: BigNumber.from(swapRoute.blockNumber),
     methodParameters: swapRoute.methodParameters
       ? ({
-        calldata: swapRoute.methodParameters.calldata,
-        value: swapRoute.methodParameters.value,
-        to: swapRoute.methodParameters.to,
-      } as MethodParameters)
+          calldata: swapRoute.methodParameters.calldata,
+          value: swapRoute.methodParameters.value,
+          to: swapRoute.methodParameters.to,
+        } as MethodParameters)
       : undefined,
     simulationStatus: swapRoute.simulationStatus,
   };

--- a/test/test-util/mock-data.ts
+++ b/test/test-util/mock-data.ts
@@ -84,6 +84,35 @@ export const USDC_WETH_MEDIUM = new Pool(
   0
 );
 
+// Mock USDC weth pools with different liquidity
+
+export const USDC_WETH_LOW_LIQ_LOW = new Pool(
+  USDC,
+  WRAPPED_NATIVE_CURRENCY[1]!,
+  FeeAmount.LOW,
+  encodeSqrtRatioX96(1, 1),
+  100,
+  0
+);
+
+export const USDC_WETH_MED_LIQ_MEDIUM = new Pool(
+  USDC,
+  WRAPPED_NATIVE_CURRENCY[1]!,
+  FeeAmount.MEDIUM,
+  encodeSqrtRatioX96(1, 1),
+  500,
+  0
+);
+
+export const USDC_WETH_HIGH_LIQ_HIGH = new Pool(
+  USDC,
+  WRAPPED_NATIVE_CURRENCY[1]!,
+  FeeAmount.HIGH,
+  encodeSqrtRatioX96(1, 1),
+  1000,
+  0
+);
+
 export const WETH9_USDT_LOW = new Pool(
   WRAPPED_NATIVE_CURRENCY[1]!,
   USDT,

--- a/test/unit/routers/alpha-router/util/gas-factory-helpers.test.ts
+++ b/test/unit/routers/alpha-router/util/gas-factory-helpers.test.ts
@@ -22,7 +22,7 @@ const mockUSDCNativePools = [
   USDC_WETH_HIGH_LIQ_HIGH,
 ];
 
-describe.only('getHighestLiquidity pool tests', () => {
+describe('getHighestLiquidity pool tests', () => {
   let mockPoolProvider: sinon.SinonStubbedInstance<V3PoolProvider>;
 
   beforeEach(() => {

--- a/test/unit/routers/alpha-router/util/gas-factory-helpers.test.ts
+++ b/test/unit/routers/alpha-router/util/gas-factory-helpers.test.ts
@@ -41,7 +41,7 @@ describe.only('getHighestLiquidity pool tests', () => {
       expect(nativeAmountPool).toStrictEqual(USDC_WETH_HIGH_LIQ_HIGH);
     });
 
-    it('should return null if there are no native pools with the amount token', async () => {
+    it('should return null if there are no native pools with the specified token', async () => {
       const mockPoolProvider = sinon.createStubInstance(V3PoolProvider);
       mockPoolProvider.getPools.resolves(
         buildMockV3PoolAccessor([USDC_DAI_LOW])

--- a/test/unit/routers/alpha-router/util/gas-factory-helpers.test.ts
+++ b/test/unit/routers/alpha-router/util/gas-factory-helpers.test.ts
@@ -1,0 +1,81 @@
+import sinon from 'sinon';
+import {
+  USDC_MAINNET,
+  V3PoolProvider,
+  WRAPPED_NATIVE_CURRENCY,
+} from '../../../../../src';
+import {
+  getHighestLiquidityV3NativePool,
+  getHighestLiquidityV3USDPool,
+} from '../../../../../src/util/gas-factory-helpers';
+import {
+  buildMockV3PoolAccessor,
+  USDC_DAI_LOW,
+  USDC_WETH_HIGH_LIQ_HIGH,
+  USDC_WETH_LOW_LIQ_LOW,
+  USDC_WETH_MED_LIQ_MEDIUM,
+} from '../../../../test-util/mock-data';
+
+const mockUSDCNativePools = [
+  USDC_WETH_LOW_LIQ_LOW,
+  USDC_WETH_MED_LIQ_MEDIUM,
+  USDC_WETH_HIGH_LIQ_HIGH,
+];
+
+describe.only('getHighestLiquidity pool tests', () => {
+  let mockPoolProvider: sinon.SinonStubbedInstance<V3PoolProvider>;
+
+  beforeEach(() => {
+    mockPoolProvider = sinon.createStubInstance(V3PoolProvider);
+    mockPoolProvider.getPools.resolves(
+      buildMockV3PoolAccessor(mockUSDCNativePools)
+    );
+  });
+
+  describe('getHighestLiquidityV3NativePool', () => {
+    it('should return the highest native liquidity pool', async () => {
+      const nativeAmountPool = await getHighestLiquidityV3NativePool(
+        USDC_MAINNET,
+        mockPoolProvider as unknown as V3PoolProvider
+      );
+      expect(nativeAmountPool).toStrictEqual(USDC_WETH_HIGH_LIQ_HIGH);
+    });
+
+    it('should return null if there are no native pools with the amount token', async () => {
+      const mockPoolProvider = sinon.createStubInstance(V3PoolProvider);
+      mockPoolProvider.getPools.resolves(
+        buildMockV3PoolAccessor([USDC_DAI_LOW])
+      );
+      const nativeAmountPool = await getHighestLiquidityV3NativePool(
+        USDC_MAINNET,
+        mockPoolProvider as unknown as V3PoolProvider
+      );
+      expect(nativeAmountPool).toBeNull();
+    });
+  });
+
+  describe('getHighestLiquidityV3USDPool', () => {
+    it('should return the highest usd liquidity pool', async () => {
+      const usdPool = await getHighestLiquidityV3USDPool(
+        1,
+        mockPoolProvider as unknown as V3PoolProvider
+      );
+      expect(usdPool).toStrictEqual(USDC_WETH_HIGH_LIQ_HIGH);
+    });
+
+    it('should throw error if there are no usd native pools', async () => {
+      const mockPoolProvider = sinon.createStubInstance(V3PoolProvider);
+      mockPoolProvider.getPools.resolves(
+        buildMockV3PoolAccessor([USDC_DAI_LOW])
+      );
+      await expect(
+        getHighestLiquidityV3USDPool(
+          1,
+          mockPoolProvider as unknown as V3PoolProvider
+        )
+      ).rejects.toThrowError(
+        `Could not find a USD/${WRAPPED_NATIVE_CURRENCY[1].symbol} pool for computing gas costs.`
+      );
+    });
+  });
+});


### PR DESCRIPTION
TLDR: there is a bug in how the pool with the highest liquidity is chosen amount v3 pools. This was causing us to use a very illiquid 1inch<>WETH pool for quoting gas prices, leading to a severely low gas estimation. 

This fixes it, though we should add a task to refactor this logic / design 
