### PR TITLE
fix: hardhat fork in the integ-tests

### DIFF
--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -73,7 +73,7 @@ import { Permit2__factory } from '../../../../src/types/other/factories/Permit2_
 import { getBalanceAndApprove } from '../../../test-util/getBalanceAndApprove';
 import { WHALES } from '../../../test-util/whales';
 
-const FORK_BLOCK = 16075500;
+const FORK_BLOCK = 17894002;
 const UNIVERSAL_ROUTER_ADDRESS = UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN(1);
 const SLIPPAGE = new Percent(15, 100); // 5% or 10_000?
 
@@ -439,7 +439,7 @@ describe('alpha router integration', () => {
       alice._address,
       [parseAmount('4000', WETH9[1])],
       [
-        '0x06920c9fc643de77b99cb7670a944ad31eaaa260', // WETH whale
+        '0x2fEb1512183545f48f6b9C5b4EbfCaF49CfCa6F3', // WETH whale
       ]
     );
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
All the hardfork integ-tests are failing. See the warp link under https://github.com/Uniswap/smart-order-router/pull/299.

- **What is the new behavior (if this is a feature change)?**
We use a later block, that has the universal router v1.2 deploy address. And for WETH whale, we need to change the address where the new address has at least 4000 WETH with the newly hard-coded block.

- **Other information**:
For some reason, base mainnet integ-tests start failing with insufficient gas limits https://app.warp.dev/block/tCQ8sTuuw42vtQjttnDlAE. But we can follow-up in a linear ticket.

See more context on why this fix in the slack [thread](https://uniswapteam.slack.com/archives/C021SU4PMR7/p1690932052416269?thread_ts=1690565283.482299&cid=C021SU4PMR7). (A bit convoluted, not going to illustrate here..)