### PR TITLE
fix base multicall multichunk for gas

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -388,7 +388,6 @@ export class AlphaRouter
       switch (chainId) {
         case ChainId.OPTIMISM:
         case ChainId.OPTIMISM_GOERLI:
-
           this.onChainQuoteProvider = new OnChainQuoteProvider(
             chainId,
             provider,

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -388,6 +388,39 @@ export class AlphaRouter
       switch (chainId) {
         case ChainId.OPTIMISM:
         case ChainId.OPTIMISM_GOERLI:
+
+          this.onChainQuoteProvider = new OnChainQuoteProvider(
+            chainId,
+            provider,
+            this.multicall2Provider,
+            {
+              retries: 2,
+              minTimeout: 100,
+              maxTimeout: 1000,
+            },
+            {
+              multicallChunk: 110,
+              gasLimitPerCall: 1_200_000,
+              quoteMinSuccessRate: 0.1,
+            },
+            {
+              gasLimitOverride: 3_000_000,
+              multicallChunk: 45,
+            },
+            {
+              gasLimitOverride: 3_000_000,
+              multicallChunk: 45,
+            },
+            {
+              baseBlockOffset: -10,
+              rollback: {
+                enabled: true,
+                attemptsBeforeRollback: 1,
+                rollbackBlockOffset: -10,
+              },
+            }
+          );
+          break;
         case ChainId.BASE:
         case ChainId.BASE_GOERLI:
           this.onChainQuoteProvider = new OnChainQuoteProvider(
@@ -400,7 +433,7 @@ export class AlphaRouter
               maxTimeout: 1000,
             },
             {
-              multicallChunk: 110,
+              multicallChunk: 80,
               gasLimitPerCall: 1_200_000,
               quoteMinSuccessRate: 0.1,
             },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Base mainnet integ-tests are failing due to gas https://app.warp.dev/block/tCQ8sTuuw42vtQjttnDlAE.

- **What is the new behavior (if this is a feature change)?**
Reduce Base multichunk so swap integ-tests aren't failing anymore. https://app.warp.dev/block/qBFFXAPgnzIsqjX4atI7Pd

- **Other information**:
Not sure when we started to see BASE gas failures. But it might impact prod, as we started seeing the gas error [metrics](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'QuoteOutOfGasExceptionRetry~'Service~'RoutingAPI))~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT8640H~end~'P0D~stat~'Sum~period~300)&query=~'*7bUniswap*2cService*7d*20GAS) recently:
<img width="1383" alt="Screenshot 2023-08-11 at 9 43 54 PM" src="https://github.com/Uniswap/smart-order-router/assets/91580504/ecd4c109-351f-4378-bb90-ccc4e544fc9e">

The timeline doesn't really match, but we could keep an eye out.