### PR TITLE
measure distribution change

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -98,6 +98,9 @@ import { MixedRouteHeuristicGasModelFactory } from './gas-models/mixedRoute/mixe
 import { V2HeuristicGasModelFactory } from './gas-models/v2/v2-heuristic-gas-model';
 import { V3HeuristicGasModelFactory } from './gas-models/v3/v3-heuristic-gas-model';
 import { GetQuotesResult, MixedQuoter, V2Quoter, V3Quoter } from './quoters';
+import {
+  measureDistributionPercentChangeImpact
+} from '../../util/alpha-config-measurement';
 
 export type AlphaRouterParams = {
   /**
@@ -1203,9 +1206,12 @@ export class AlphaRouter
         Date.now() - beforeSimulate,
         MetricLoggerUnit.Milliseconds
       );
+
+      measureDistributionPercentChangeImpact(5, 10, swapRouteWithSimulation, tokenIn, tokenOut, tradeType, this.chainId, amount)
       return swapRouteWithSimulation;
     }
 
+    measureDistributionPercentChangeImpact(5, 10, swapRoute, tokenIn, tokenOut, tradeType, this.chainId, amount)
     return swapRoute;
   }
 

--- a/src/util/alpha-config-measurement.ts
+++ b/src/util/alpha-config-measurement.ts
@@ -47,8 +47,7 @@ export const measureDistributionPercentChangeImpact = (distributionPercentBefore
   })
 
   if (routesImpacted.length > 0) {
-    // intentionally use log.info so 10% sampling
-    log.info(`Distribution percent change impacted the routes ${routesImpacted.join(',')},
+    log.warn(`Distribution percent change impacted the routes ${routesImpacted.join(',')},
       for currency ${tokenIn.symbol}
       amount ${amount.toExact()}
       quote currency ${tokenOut.symbol}

--- a/src/util/alpha-config-measurement.ts
+++ b/src/util/alpha-config-measurement.ts
@@ -1,0 +1,55 @@
+import { metric, MetricLoggerUnit, SwapRoute } from '../routers';
+import { ChainId, Token, TradeType } from '@uniswap/sdk-core';
+import { Protocol } from '@uniswap/router-sdk';
+import { log } from './log';
+import { CurrencyAmount } from './amounts';
+
+export const getDistribution = (distributionPercent: number) => {
+  const percents: Array<number> = new Array<number>();
+
+  for (let i = 1; i <= 100 / distributionPercent; i++) {
+    percents.push(i * distributionPercent);
+  }
+
+  return percents;
+};
+
+export const measureDistributionPercentChangeImpact = (distributionPercentBefore: number,
+                                                       distributionPercentAfter: number,
+                                                       bestSwapRoute: SwapRoute,
+                                                       tokenIn: Token,
+                                                       tokenOut: Token,
+                                                       tradeType: TradeType,
+                                                       chainId: ChainId,
+                                                       amount: CurrencyAmount) => {
+  const routesImpacted: Array<string> = new Array<string>();
+
+  const percentDistributionBefore = getDistribution(distributionPercentBefore);
+  const percentDistributionAfter = getDistribution(distributionPercentAfter);
+
+  bestSwapRoute.route.forEach((route) => {
+    switch (route.protocol) {
+      case Protocol.MIXED:
+      case Protocol.V3:
+        if (percentDistributionBefore.includes(route.percent) && !percentDistributionAfter.includes(route.percent)) {
+          routesImpacted.push(route.toString());
+        }
+        break;
+      case Protocol.V2:
+        // if it's v2, there's no distribution, skip the current route
+        break;
+    }
+  })
+
+  if (routesImpacted.length > 0) {
+    // intentionally use log.info so 10% sampling
+    log.info(`Distribution percent change impacted the routes ${routesImpacted.join(',')},
+      for currency ${tokenIn.symbol}
+      amount ${amount.toExact()}
+      quote currency ${tokenOut.symbol}
+      trade type ${tradeType}
+      chain id ${chainId}`);
+    metric.putMetric("BEST_SWAP_ROUTE_DISTRIBUTION_PERCENT_CHANGE_IMPACTED", 1, MetricLoggerUnit.Count);
+    metric.putMetric("ROUTES_WITH_VALID_QUOTE_DISTRIBUTION_PERCENT_CHANGE_IMPACTED", routesImpacted.length, MetricLoggerUnit.Count);
+  }
+}

--- a/src/util/alpha-config-measurement.ts
+++ b/src/util/alpha-config-measurement.ts
@@ -22,6 +22,11 @@ export const measureDistributionPercentChangeImpact = (distributionPercentBefore
                                                        tradeType: TradeType,
                                                        chainId: ChainId,
                                                        amount: CurrencyAmount) => {
+  if (chainId !== ChainId.MAINNET) {
+    // starts with mainnet impact measurement only
+    return;
+  }
+
   const routesImpacted: Array<string> = new Array<string>();
 
   const percentDistributionBefore = getDistribution(distributionPercentBefore);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Instrumentation

- **What is the current behavior?** (You can also link to an open issue here)
We don't know the impact of distribution percent change.

- **What is the new behavior (if this is a feature change)?**
We will measure the impact of distribution percent change from 5% to 10%.

- **Other information**:
We can measure it before increasing the distribution percent.
TODO - we can follow-up with unit testing coverage if we see distribution percent change helps.
Cowboy testing - On local, running tests and added console.log to see both impacted and not impacted best swap routes:
<img width="1106" alt="Screenshot 2023-08-16 at 10 34 41 AM" src="https://github.com/Uniswap/smart-order-router/assets/91580504/dc4b8537-1a83-4b48-b4a9-dc016a451168">
From [warp terminal](https://app.warp.dev/block/EbgrxCB7uOAxprRCluSA4s), we can see the impacted routes getting logged correctly, and not impacted routes are always evaluated to `false`