### PR TITLE
Optimistic Quotes preparation

### DIFF
--- a/src/providers/caching/route/model/cached-routes.ts
+++ b/src/providers/caching/route/model/cached-routes.ts
@@ -117,8 +117,13 @@ export class CachedRoutes {
    * Function to determine if, given a block number, the CachedRoute is expired or not.
    *
    * @param currentBlockNumber
+   * @param optimistic
    */
-  public notExpired(currentBlockNumber: number): boolean {
-    return (currentBlockNumber - this.blockNumber) <= this.blocksToLive;
+  public notExpired(currentBlockNumber: number, optimistic = false): boolean {
+    // When it's not optimistic, we only allow the route of the existing block.
+    const blocksToLive = optimistic ? this.blocksToLive : 0;
+    const blocksDifference = currentBlockNumber - this.blockNumber;
+
+    return blocksDifference <= blocksToLive;
   }
 }

--- a/src/providers/caching/route/route-caching-provider.ts
+++ b/src/providers/caching/route/route-caching-provider.ts
@@ -40,7 +40,15 @@ export abstract class IRouteCachingProvider {
       return undefined;
     }
 
-    const cachedRoute = await this._getCachedRoute(chainId, amount, quoteToken, tradeType, protocols, optimistic);
+    const cachedRoute = await this._getCachedRoute(
+      chainId,
+      amount,
+      quoteToken,
+      tradeType,
+      protocols,
+      blockNumber,
+      optimistic
+    );
 
     return this.filterExpiredCachedRoutes(cachedRoute, blockNumber, optimistic);
   };
@@ -107,7 +115,7 @@ export abstract class IRouteCachingProvider {
     protocols: Protocol[]
   ): Promise<CacheMode>
 
-  private filterExpiredCachedRoutes(
+  protected filterExpiredCachedRoutes(
     cachedRoutes: CachedRoutes | undefined,
     blockNumber: number,
     optimistic: boolean
@@ -132,6 +140,7 @@ export abstract class IRouteCachingProvider {
     quoteToken: Token,
     tradeType: TradeType,
     protocols: Protocol[],
+    currentBlockNumber: number,
     optimistic: boolean
   ): Promise<CachedRoutes | undefined>
 

--- a/src/providers/caching/route/route-caching-provider.ts
+++ b/src/providers/caching/route/route-caching-provider.ts
@@ -34,14 +34,15 @@ export abstract class IRouteCachingProvider {
     tradeType: TradeType,
     protocols: Protocol[],
     blockNumber: number,
+    optimistic = false
   ): Promise<CachedRoutes | undefined> => {
     if (await this.getCacheMode(chainId, amount, quoteToken, tradeType, protocols) == CacheMode.Darkmode) {
       return undefined;
     }
 
-    const cachedRoute = await this._getCachedRoute(chainId, amount, quoteToken, tradeType, protocols);
+    const cachedRoute = await this._getCachedRoute(chainId, amount, quoteToken, tradeType, protocols, optimistic);
 
-    return this.filterExpiredCachedRoutes(cachedRoute, blockNumber);
+    return this.filterExpiredCachedRoutes(cachedRoute, blockNumber, optimistic);
   };
 
   /**
@@ -108,9 +109,10 @@ export abstract class IRouteCachingProvider {
 
   private filterExpiredCachedRoutes(
     cachedRoutes: CachedRoutes | undefined,
-    blockNumber: number
+    blockNumber: number,
+    optimistic: boolean
   ): CachedRoutes | undefined {
-    return cachedRoutes?.notExpired(blockNumber) ? cachedRoutes : undefined;
+    return cachedRoutes?.notExpired(blockNumber, optimistic) ? cachedRoutes : undefined;
   }
 
   /**
@@ -129,7 +131,8 @@ export abstract class IRouteCachingProvider {
     amount: CurrencyAmount<Currency>,
     quoteToken: Token,
     tradeType: TradeType,
-    protocols: Protocol[]
+    protocols: Protocol[],
+    optimistic: boolean
   ): Promise<CachedRoutes | undefined>
 
   /**

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -323,6 +323,11 @@ export type AlphaRouterConfig = {
    * By default, the cached routes will be written to.
    */
   writeToCachedRoutes?: boolean;
+  /**
+   * Flag to indicate whether to use the CachedRoutes in optimistic mode.
+   * Optimistic mode means that we will allow blocksToLive greater than 1.
+   */
+  optimisticCachedRoutes?: boolean;
 };
 
 export class AlphaRouter
@@ -923,6 +928,7 @@ export class AlphaRouter
         // These settings could be changed by the partialRoutingConfig
         useCachedRoutes: true,
         writeToCachedRoutes: true,
+        optimisticCachedRoutes: false,
       },
       DEFAULT_ROUTING_CONFIG_BY_CHAIN(this.chainId),
       partialRoutingConfig,
@@ -961,7 +967,8 @@ export class AlphaRouter
         quoteToken,
         tradeType,
         protocols,
-        await blockNumber
+        await blockNumber,
+        routingConfig.optimisticCachedRoutes
       );
     }
 

--- a/test/unit/providers/caching/route/model/cached-routes.test.ts
+++ b/test/unit/providers/caching/route/model/cached-routes.test.ts
@@ -83,24 +83,53 @@ describe('CachedRoutes', () => {
       });
 
       describe('after blocksToLive is updated', () => {
-        beforeEach(() => {
-          cachedRoutes.blocksToLive = 5;
+        describe('with optimistic quotes set to "true"', () => {
+          let optimistic: boolean;
+          beforeEach(() => {
+            cachedRoutes.blocksToLive = 5;
+            optimistic = true;
+          });
+
+          it('returns true when blockNumber is still the same as the one in the cached routes', () => {
+            expect(cachedRoutes.notExpired(blockNumber, optimistic)).toBeTruthy();
+          });
+
+          it('returns true when blockNumber has advanced from the one in the cached routes less than BTL', () => {
+            expect(cachedRoutes.notExpired(blockNumber + 1, optimistic)).toBeTruthy();
+          });
+
+          it('returns true when blockNumber has advanced as many as blocksToLive number of blocks', () => {
+            expect(cachedRoutes.notExpired(blockNumber + cachedRoutes.blocksToLive, optimistic)).toBeTruthy();
+          });
+
+          it('returns false when blockNumber has advanced one more than BTL', () => {
+            expect(cachedRoutes.notExpired(blockNumber + cachedRoutes.blocksToLive + 1, optimistic)).toBeFalsy();
+          });
         });
 
-        it('returns true when blockNumber is still the same as the one in the cached routes', () => {
-          expect(cachedRoutes.notExpired(blockNumber)).toBeTruthy();
-        });
+        describe('with optimistic quotes set to "false"', () => {
+          // When we are not supporting optimistic quotes, blocksToLive is 0
+          let optimistic: boolean;
+          beforeEach(() => {
+            cachedRoutes.blocksToLive = 5;
+            optimistic = false;
+          });
 
-        it('returns true when blockNumber has advanced from the one in the cached routes less than BTL', () => {
-          expect(cachedRoutes.notExpired(blockNumber + 1)).toBeTruthy();
-        });
+          it('returns true when blockNumber is still the same as the one in the cached routes', () => {
+            expect(cachedRoutes.notExpired(blockNumber, optimistic)).toBeTruthy();
+          });
 
-        it('returns true when blockNumber has advanced as many as blocksToLive number of blocks', () => {
-          expect(cachedRoutes.notExpired(blockNumber + cachedRoutes.blocksToLive)).toBeTruthy();
-        });
+          it('returns false when blockNumber has advanced from the one in the cached routes less than BTL', () => {
+            expect(cachedRoutes.notExpired(blockNumber + 1, optimistic)).toBeFalsy();
+          });
 
-        it('returns false when blockNumber has advanced one more than BTL', () => {
-          expect(cachedRoutes.notExpired(blockNumber + cachedRoutes.blocksToLive + 1)).toBeFalsy();
+          it('returns false when blockNumber has advanced as many as blocksToLive number of blocks', () => {
+            expect(cachedRoutes.notExpired(blockNumber + cachedRoutes.blocksToLive, optimistic)).toBeFalsy();
+          });
+
+          it('returns false when blockNumber has advanced one more than BTL', () => {
+            expect(cachedRoutes.notExpired(blockNumber + cachedRoutes.blocksToLive + 1, optimistic)).toBeFalsy();
+          });
         });
       });
     });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

this is a preparation for optimistic quotes, by creating a config `optimisticCachedRoutes` which allow the RoutingAPI to specify if they are requesting an optimistic route.
Optimistic routes are defined as using the routes from cache for previous blocks to get quotes and find the best one among those routes.

In this preparation what we are doing is that we will only respect the `blocksToLive` setting if the quote is optimistic, otherwise the cached route expires with a new block.
This will allow us to control whats the maximum number of blocks we can look back to prepare a quote.
