### PR TITLE
Chore: measure per protocol version getRoutesThenQuotes and getQuotes latencies

### DIFF
--- a/src/routers/alpha-router/quoters/base-quoter.ts
+++ b/src/routers/alpha-router/quoters/base-quoter.ts
@@ -132,7 +132,7 @@ export abstract class BaseQuoter<Route extends V2Route | V3Route | MixedRoute> {
             gasPriceWei
           ).then((quotesResult) => {
             metric.putMetric(
-              `${this.quoterVersion}GetQuotesLoad`,
+              `${this.quoterVersion}OverallGetQuotesLoad`,
               Date.now() - beforeGetQuotes,
               MetricLoggerUnit.Milliseconds
             );
@@ -142,7 +142,7 @@ export abstract class BaseQuoter<Route extends V2Route | V3Route | MixedRoute> {
         }
       ).then((quotesResult) => {
           metric.putMetric(
-            `${this.quoterVersion}GetRoutesThenQuotesLoad`,
+            `${this.quoterVersion}OverallGetRoutesThenQuotesLoad`,
             Date.now() - beforeGetRoutesThenQuotes,
             MetricLoggerUnit.Milliseconds
           );

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -29,7 +29,7 @@ export class MixedQuoter extends BaseQuoter<MixedRoute> {
   protected v2SubgraphProvider: IV2SubgraphProvider;
   protected v2PoolProvider: IV2PoolProvider;
   protected onChainQuoteProvider: IOnChainQuoteProvider;
-  protected override quoterVersion = 'mixed';
+  protected override quoterVersion = 'Mixed';
 
   constructor(
     v3SubgraphProvider: IV3SubgraphProvider,

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -29,6 +29,7 @@ export class MixedQuoter extends BaseQuoter<MixedRoute> {
   protected v2SubgraphProvider: IV2SubgraphProvider;
   protected v2PoolProvider: IV2PoolProvider;
   protected onChainQuoteProvider: IOnChainQuoteProvider;
+  protected override quoterVersion = 'mixed';
 
   constructor(
     v3SubgraphProvider: IV3SubgraphProvider,

--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -28,6 +28,7 @@ export class V2Quoter extends BaseQuoter<V2Route> {
   protected v2PoolProvider: IV2PoolProvider;
   protected v2QuoteProvider: IV2QuoteProvider;
   protected v2GasModelFactory: IV2GasModelFactory;
+  protected override quoterVersion = 'v2';
 
   constructor(
     v2SubgraphProvider: IV2SubgraphProvider,

--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -28,7 +28,7 @@ export class V2Quoter extends BaseQuoter<V2Route> {
   protected v2PoolProvider: IV2PoolProvider;
   protected v2QuoteProvider: IV2QuoteProvider;
   protected v2GasModelFactory: IV2GasModelFactory;
-  protected override quoterVersion = 'v2';
+  protected override quoterVersion = 'V2';
 
   constructor(
     v2SubgraphProvider: IV2SubgraphProvider,

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -26,6 +26,7 @@ export class V3Quoter extends BaseQuoter<V3Route> {
   protected v3SubgraphProvider: IV3SubgraphProvider;
   protected v3PoolProvider: IV3PoolProvider;
   protected onChainQuoteProvider: IOnChainQuoteProvider;
+  protected override quoterVersion = 'v3';
 
   constructor(
     v3SubgraphProvider: IV3SubgraphProvider,

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -26,7 +26,7 @@ export class V3Quoter extends BaseQuoter<V3Route> {
   protected v3SubgraphProvider: IV3SubgraphProvider;
   protected v3PoolProvider: IV3PoolProvider;
   protected onChainQuoteProvider: IOnChainQuoteProvider;
-  protected override quoterVersion = 'v3';
+  protected override quoterVersion = 'V3';
 
   constructor(
     v3SubgraphProvider: IV3SubgraphProvider,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add latency instrumentation

- **What is the current behavior?** (You can also link to an open issue here)
We don't know the overall per-protocol version quotes latencies.

- **What is the new behavior (if this is a feature change)?**
We will measure the overall per-protocol version quotes latencies.

- **Other information**:
The latencies breakdown we have might miss something. In order to do better fast quote analysis, we need to see the per-protocol overall latencies.
Tested in quoting-api via https://github.com/Uniswap/routing-api/compare/main...jsy1218/explore-sor-local-tarball:
<img width="1197" alt="Screenshot 2023-08-18 at 4 01 30 PM" src="https://github.com/Uniswap/smart-order-router/assets/91580504/961ceecd-5815-49f8-974f-893d9c015543">
