### PR TITLE
Measure per-protocol quote latencies and request counts for both cached routes and non-cached routes

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1278,9 +1278,9 @@ export class AlphaRouter
 
     if (v3Routes.length > 0) {
       const v3RoutesFromCache: V3Route[] = v3Routes.map((cachedRoute) => cachedRoute.route as V3Route);
+      metric.putMetric("SwapRouteFromCache_V3_GetQuotes_Request", 1, MetricLoggerUnit.Count);
 
       const beforeGetQuotes = Date.now();
-      metric.putMetric("SwapRouteFromCache_V3_GetQuotes_Request", 1, MetricLoggerUnit.Count);
 
       quotePromises.push(
         this.v3Quoter.getQuotes(
@@ -1305,6 +1305,7 @@ export class AlphaRouter
     }
 
     if (v2Routes.length > 0) {
+      metric.putMetric("SwapRouteFromCache_V2_GetQuotes_Request", 1, MetricLoggerUnit.Count);
       const beforeGetRoutesAndQuotes = Date.now();
 
       quotePromises.push(
@@ -1334,9 +1335,9 @@ export class AlphaRouter
 
     if (mixedRoutes.length > 0) {
       const mixedRoutesFromCache: MixedRoute[] = mixedRoutes.map((cachedRoute) => cachedRoute.route as MixedRoute);
+      metric.putMetric("SwapRouteFromCache_Mixed_GetQuotes_Request", 1, MetricLoggerUnit.Count);
 
       const beforeGetQuotes = Date.now();
-      metric.putMetric("SwapRouteFromCache_Mixed_GetQuotes_Request", 1, MetricLoggerUnit.Count);
 
       quotePromises.push(
         this.mixedQuoter.getQuotes(

--- a/src/routers/alpha-router/quoters/base-quoter.ts
+++ b/src/routers/alpha-router/quoters/base-quoter.ts
@@ -5,13 +5,7 @@ import { Pool } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
 import { ITokenListProvider, ITokenProvider, ITokenValidatorProvider, TokenValidationResult } from '../../../providers';
-import {
-  CurrencyAmount,
-  log,
-  metric,
-  MetricLoggerUnit,
-  poolToString
-} from '../../../util';
+import { CurrencyAmount, log, poolToString } from '../../../util';
 import { MixedRoute, V2Route, V3Route } from '../../router';
 import { AlphaRouterConfig } from '../alpha-router';
 import { RouteWithValidQuote } from '../entities/route-with-valid-quote';
@@ -32,7 +26,6 @@ export abstract class BaseQuoter<Route extends V2Route | V3Route | MixedRoute> {
   protected chainId: ChainId;
   protected blockedTokenListProvider?: ITokenListProvider;
   protected tokenValidatorProvider?: ITokenValidatorProvider;
-  protected abstract quoterVersion: string
 
   constructor(
     tokenProvider: ITokenProvider,
@@ -114,41 +107,19 @@ export abstract class BaseQuoter<Route extends V2Route | V3Route | MixedRoute> {
     gasModel?: IGasModel<RouteWithValidQuote>,
     gasPriceWei?: BigNumber
   ): Promise<GetQuotesResult> {
-    const beforeGetRoutesThenQuotes = Date.now();
-
     return this.getRoutes(tokenIn, tokenOut, tradeType, routingConfig)
-      .then((routesResult) => {
-          const beforeGetQuotes = Date.now();
-
-          return this.getQuotes(
-            routesResult.routes,
-            amounts,
-            percents,
-            quoteToken,
-            tradeType,
-            routingConfig,
-            routesResult.candidatePools,
-            gasModel,
-            gasPriceWei
-          ).then((quotesResult) => {
-            metric.putMetric(
-              `${this.quoterVersion}OverallGetQuotesLoad`,
-              Date.now() - beforeGetQuotes,
-              MetricLoggerUnit.Milliseconds
-            );
-
-            return quotesResult
-          })
-        }
-      ).then((quotesResult) => {
-          metric.putMetric(
-            `${this.quoterVersion}OverallGetRoutesThenQuotesLoad`,
-            Date.now() - beforeGetRoutesThenQuotes,
-            MetricLoggerUnit.Milliseconds
-          );
-
-          return quotesResult;
-        }
+      .then((routesResult) =>
+        this.getQuotes(
+          routesResult.routes,
+          amounts,
+          percents,
+          quoteToken,
+          tradeType,
+          routingConfig,
+          routesResult.candidatePools,
+          gasModel,
+          gasPriceWei
+        )
       );
   }
 

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -29,7 +29,6 @@ export class MixedQuoter extends BaseQuoter<MixedRoute> {
   protected v2SubgraphProvider: IV2SubgraphProvider;
   protected v2PoolProvider: IV2PoolProvider;
   protected onChainQuoteProvider: IOnChainQuoteProvider;
-  protected override quoterVersion = 'Mixed';
 
   constructor(
     v3SubgraphProvider: IV3SubgraphProvider,

--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -28,7 +28,6 @@ export class V2Quoter extends BaseQuoter<V2Route> {
   protected v2PoolProvider: IV2PoolProvider;
   protected v2QuoteProvider: IV2QuoteProvider;
   protected v2GasModelFactory: IV2GasModelFactory;
-  protected override quoterVersion = 'V2';
 
   constructor(
     v2SubgraphProvider: IV2SubgraphProvider,

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -26,7 +26,6 @@ export class V3Quoter extends BaseQuoter<V3Route> {
   protected v3SubgraphProvider: IV3SubgraphProvider;
   protected v3PoolProvider: IV3PoolProvider;
   protected onChainQuoteProvider: IOnChainQuoteProvider;
-  protected override quoterVersion = 'V3';
 
   constructor(
     v3SubgraphProvider: IV3SubgraphProvider,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add per-protocol and cached vs non-cached latencies and request count instrumentation

- **What is the current behavior?** (You can also link to an open issue here)
With https://github.com/Uniswap/smart-order-router/pull/316, we did gain a bit of insights on the per-protocol `getRoutesThenQuotes` latencies breakdown. However this alone is not good enough for us to see where we can most effectively shave off the fast quote latencies. This is because the metrics being added mostly correspond to the non-cached routes getting routes and quotes path. With cached routes, we want to understand the request count distribution of cached routes vs. non-cached routes, and then within each one, we then want to understand the per-protocol breakdown. We want to see whether it's more effective to focus on shave off cached routes or non-cached routes first. Then because getting quotes is known to be a bottleneck (because for v2, we constantly reload reserves without caching at all in routing-api only, and for v3, the currently very low distribution percent (5%) caused the on-chain quote provider to get the multiple of 20 quotes per discovered route), we want to see is it v2 or v3 or mixed that's mostly bottleneck the quote latencies. This is important because interface sends `v2,v3,mixed` for all quotes, and we use `Promise.all` to parallelize all the calls.

<img width="1462" alt="Screenshot 2023-08-18 at 4 26 31 PM" src="https://github.com/Uniswap/smart-order-router/assets/91580504/bc01b0ae-88c2-47df-84f0-ddd8c892bfd3">

- **What is the new behavior (if this is a feature change)?**
We added the per-protocol break down and cached vs non-cached latencies and request volume instrumentation.

We can breakdown sor algorithm to following couple high-levels (true for v2, v3, as well as mixed):

1. routes discovery algorithm
2. routes getting valid quotes algorithm
3. calculate best swap algorithm from routes with valid quotes.

For (1), it's optimized by cached routes. But we don't know how many quotes requests from interface hits the cached routes. For (2), we already know v2 getting reserves don't have cache, and v3 has very low distribution percent. For (3), meanwhile the quotes latencies can be impacted by graph complexities, view (3) as a complete in-memory Dijkstra's Shortest Path Algorithm (within `getBestSwapRoute`), and hence less effective in shaving off the quote latencies.

- **Other information**:
Tested via local tarball method, and can see metrics in my local routing-api:
<img width="1207" alt="Screenshot 2023-08-20 at 2 35 02 PM" src="https://github.com/Uniswap/smart-order-router/assets/91580504/122ed6ad-f1bb-442a-8a60-f3c38fb0e1c6">
