### PR TITLE
add debug routing config as part of alpha router config

### DIFF
--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -3,6 +3,10 @@ export type ProviderConfig = {
    * The block number to use when getting data on-chain.
    */
   blockNumber?: number | Promise<number>;
+  /*
+  * Debug flag to test some codepaths
+   */
+  debugRouting?: boolean;
 };
 
 export type LocalCacheEntry<T> = {

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -328,6 +328,10 @@ export type AlphaRouterConfig = {
    * Optimistic mode means that we will allow blocksToLive greater than 1.
    */
   optimisticCachedRoutes?: boolean;
+  /**
+   * Debug param that helps to see the short-term latencies improvements without impacting the main path.
+   */
+  debugRouting?: boolean;
 };
 
 export class AlphaRouter

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -617,6 +617,7 @@ export async function getV2CandidatePools({
       topNWithEachBaseToken,
       topNWithBaseToken,
     },
+    debugRouting,
   } = routingConfig;
   const tokenInAddress = tokenIn.address.toLowerCase();
   const tokenOutAddress = tokenOut.address.toLowerCase();
@@ -939,7 +940,7 @@ export async function getV2CandidatePools({
 
   const beforePoolsLoad = Date.now();
 
-  const poolAccessor = await poolProvider.getPools(tokenPairs, { blockNumber });
+  const poolAccessor = await poolProvider.getPools(tokenPairs, { blockNumber, debugRouting });
 
   metric.putMetric(
     'V2PoolsLoad',
@@ -983,7 +984,7 @@ export async function getMixedRouteCandidatePools({
   candidatePools: CandidatePoolsBySelectionCriteria;
   subgraphPools: (V2SubgraphPool | V3SubgraphPool)[];
 }> {
-  const { blockNumber } = routingConfig;
+  const { blockNumber, debugRouting } = routingConfig;
   const { subgraphPools: V3subgraphPools, candidatePools: V3candidatePools } =
     await getV3CandidatePools({
       tokenIn,
@@ -1152,9 +1153,11 @@ export async function getMixedRouteCandidatePools({
   const [V2poolAccessor, V3poolAccessor] = await Promise.all([
     v2poolProvider.getPools(V2tokenPairs, {
       blockNumber,
+      debugRouting,
     }),
     v3poolProvider.getPools(V3tokenPairs, {
       blockNumber,
+      debugRouting
     }),
   ]);
 

--- a/src/routers/alpha-router/gas-models/gas-model.ts
+++ b/src/routers/alpha-router/gas-models/gas-model.ts
@@ -47,7 +47,7 @@ import {
 } from '../entities/route-with-valid-quote';
 
 
-// When adding new usd gas tokens, ensure the tokens are ordered 
+// When adding new usd gas tokens, ensure the tokens are ordered
 // from tokens with highest decimals to lowest decimals. For example,
 // DAI_AVAX has 18 decimals and comes before USDC_AVAX which has 6 decimals.
 export const usdGasTokensByChain: { [chainId in ChainId]?: Token[] } = {
@@ -97,6 +97,7 @@ export type BuildV2GasModelFactoryType = {
   gasPriceWei: BigNumber;
   poolProvider: IV2PoolProvider;
   token: Token;
+  providerConfig?: ProviderConfig;
 };
 
 export type LiquidityCalculationPools = {

--- a/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
@@ -58,6 +58,7 @@ export class MixedRouteHeuristicGasModelFactory extends IOnChainGasModelFactory 
     pools,
     quoteToken,
     v2poolProvider: V2poolProvider,
+    providerConfig: providerConfig,
   }: BuildOnChainGasModelFactoryType): Promise<
     IGasModel<MixedRouteWithValidQuote>
   > {
@@ -110,7 +111,7 @@ export class MixedRouteHeuristicGasModelFactory extends IOnChainGasModelFactory 
     let nativeV2Pool: Pair | null;
     if (V2poolProvider) {
       /// MixedRoutes
-      nativeV2Pool = await getV2NativePool(quoteToken, V2poolProvider);
+      nativeV2Pool = await getV2NativePool(quoteToken, V2poolProvider, providerConfig);
     }
 
     const usdToken =

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -33,12 +33,13 @@ import { buildTrade } from './methodParameters';
 
 export async function getV2NativePool(
   token: Token,
-  poolProvider: IV2PoolProvider
+  poolProvider: IV2PoolProvider,
+  providerConfig?: ProviderConfig,
 ): Promise<Pair | null> {
   const chainId = token.chainId as ChainId;
   const weth = WRAPPED_NATIVE_CURRENCY[chainId]!;
 
-  const poolAccessor = await poolProvider.getPools([[weth, token]]);
+  const poolAccessor = await poolProvider.getPools([[weth, token]], providerConfig);
   const pool = poolAccessor.getPool(weth, token);
 
   if (!pool || pool.reserve0.equalTo(0) || pool.reserve1.equalTo(0)) {
@@ -316,7 +317,7 @@ export async function calculateGasUsed(
         v3PoolProvider,
         providerConfig
       ),
-      getV2NativePool(quoteToken, v2PoolProvider),
+      getV2NativePool(quoteToken, v2PoolProvider, providerConfig),
     ]);
     const nativePool = nativePools.find((pool) => pool !== null);
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Debug

- **What is the current behavior?** (You can also link to an open issue here)
We don't have an easy way to know whether adding caching on top of v2 pool provider will help the E2E quote latencies easily

- **What is the new behavior (if this is a feature change)?**
We add a debugRouting param as part of the alpha router config, so that we can easily add the hacky caching pool provider on the routing-api side.

- **Other information**:
This PR is meant to be very short-term hack. We may revert after we have collected enough datapoints.