### PR TITLE
parallelize v2 and v3 get candidate pools in mixed

### DIFF
--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -1002,8 +1002,11 @@ export async function getMixedRouteCandidatePools({
 }> {
   const beforeSubgraphPools = Date.now();
   const { blockNumber, debugRouting } = routingConfig;
-  const { subgraphPools: V3subgraphPools, candidatePools: V3candidatePools } =
-    await getV3CandidatePools({
+  const [
+    { subgraphPools: V3subgraphPools, candidatePools: V3candidatePools},
+    { subgraphPools: V2subgraphPools, candidatePools: V2candidatePools}
+  ] = await Promise.all([
+    getV3CandidatePools({
       tokenIn,
       tokenOut,
       tokenProvider,
@@ -1013,9 +1016,8 @@ export async function getMixedRouteCandidatePools({
       subgraphProvider: v3subgraphProvider,
       routingConfig,
       chainId,
-    });
-  const { subgraphPools: V2subgraphPools, candidatePools: V2candidatePools } =
-    await getV2CandidatePools({
+    }),
+    getV2CandidatePools({
       tokenIn,
       tokenOut,
       tokenProvider,
@@ -1025,7 +1027,8 @@ export async function getMixedRouteCandidatePools({
       subgraphProvider: v2subgraphProvider,
       routingConfig,
       chainId,
-    });
+    }),
+  ])
 
   metric.putMetric('MixedSubgraphPoolsLoad', Date.now() - beforeSubgraphPools, MetricLoggerUnit.Milliseconds);
   const beforePoolsFiltered = Date.now();


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Perf fix

- **What is the current behavior?** (You can also link to an open issue here)
`getMixedRouteCandidatePool` sequentially calls `getV3CandidatePools` and `getV2CandidatePools`. Speaking from the latencies instrumentation perspective (see internal dashboard QuoterLatencies), MixedSubgraphPoolsLoad = V3SubgraphPoolsLoad + V3PoolsFilterLoad + V3PoolsLoad + V2SubgraphPoolsLoad + V2PoolsFilterLoad + V2PoolsLoad. 

- **What is the new behavior (if this is a feature change)?**
We are changing the behavior to make it MixedSubgraphPoolsLoad = max(V3SubgraphPoolsLoad + V3PoolsFilterLoad + V3PoolsLoad , V2SubgraphPoolsLoad + V2PoolsFilterLoad + V2PoolsLoad)

- **Other information**:
@mikeki is working on a separate perf fix to speed up V2PoolsFilterLoad. As it stands, V2PoolsFilterLoad is the unaccounted latencies bottleneck in v2. This explains why when we make topN* heuristics down to 0, and distribution percent to 100% via routing-api `debugRoutingConfig` prod endpoint, we still see high quote latencies.