### PR TITLE
mixed route eth -> uni test that repro smarter pool filter mixed route failure

### DIFF
--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -2410,7 +2410,7 @@ describe('alpha router integration', () => {
           );
         });
 
-        it.only('ETH -> UNI', async () => {
+        it('ETH -> UNI', async () => {
           /// Fails for v3 for some reason, ProviderGasError
           const tokenIn = Ether.onChain(1) as Currency;
           const tokenOut = UNI_MAINNET;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
integ-test coverage enhancement

- **What is the current behavior?** (You can also link to an open issue here)
Adding ETH -> UNI using `mixed` protocol, that should force to use V2. The test should pass against main branch.

- **What is the new behavior (if this is a feature change)?**
I noticed during local testing, that with https://github.com/Uniswap/smart-order-router/pull/331, mixed route doesn't always find the route. I wrote this test to consistently repro the no swap route for https://github.com/Uniswap/smart-order-router/pull/331, and we can further QA before checking in.

- **Other information**:
