### PR TITLE
re-enable op mainnet integ-test

### DIFF
--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -2659,7 +2659,6 @@ describe('quote for other networks', () => {
       c != ChainId.OPTIMISM_GOERLI &&
       c != ChainId.POLYGON_MUMBAI &&
       c != ChainId.ARBITRUM_GOERLI &&
-      c != ChainId.OPTIMISM && /// @dev infura has been having issues with optimism lately
       // Tests are failing https://github.com/Uniswap/smart-order-router/issues/104
       c != ChainId.CELO_ALFAJORES &&
       c != ChainId.SEPOLIA


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Testing coverage

- **What is the current behavior?** (You can also link to an open issue here)
No OP mainnet integ-test coverage

- **What is the new behavior (if this is a feature change)?**
Have some OP mainnet integ-test coverage

- **Other information**:
With so many changes in the last couple days, it's good to re-enable the OP mainnet coverage, just in case we have more quick changes coming up.
I already ran on local to see that op mainnet test passes: https://app.warp.dev/block/IOLIltVU02GoxPqYHXQkZc