### PR TITLE
V2 / V3 Speed Ups

### DIFF
--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -654,7 +654,6 @@ export async function getV2CandidatePools({
 
   const beforePoolsFiltered = Date.now();
 
-  // In-place sort rather than using lodash's sortBy to avoid the additional array copy.
   // Sort by pool reserve in descending order.
   const subgraphPoolsSorted = allPoolsRaw.sort((a, b) => b.reserve - a.reserve)
 


### PR DESCRIPTION
Mainly avoiding unnecessary copying. This mainly benefits V2 pools. In-place sort rather than using lodash's sortBy to avoid the additional array copy.
