### PR TITLE
Add weth wrap / unwrap gas cost to heuristics and add unit tests for gas models

### DIFF
--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber } from '@ethersproject/bignumber';
 
 export type ProviderConfig = {
   /**

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,10 +1,16 @@
+import { BigNumber } from 'ethers';
+
 export type ProviderConfig = {
   /**
    * The block number to use when getting data on-chain.
    */
   blockNumber?: number | Promise<number>;
   /*
-  * Debug flag to test some codepaths
+   * Any additional overhead to add to the gas estimate
+   */
+  additionalGasOverhead?: BigNumber;
+  /*
+   * Debug flag to test some codepaths
    */
   debugRouting?: boolean;
 };

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -2,13 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { BaseProvider, JsonRpcProvider } from '@ethersproject/providers';
 import DEFAULT_TOKEN_LIST from '@uniswap/default-token-list';
 import { Protocol, SwapRouter, Trade } from '@uniswap/router-sdk';
-import {
-  ChainId,
-  Currency,
-  Fraction,
-  Token,
-  TradeType,
-} from '@uniswap/sdk-core';
+import { ChainId, Currency, Fraction, Token, TradeType } from '@uniswap/sdk-core';
 import { TokenList } from '@uniswap/token-lists';
 import { Pool, Position, SqrtPriceMath, TickMath } from '@uniswap/v3-sdk';
 import retry from 'async-retry';
@@ -46,24 +40,12 @@ import {
   V2SubgraphProviderWithFallBacks,
   V3SubgraphProviderWithFallBacks,
 } from '../../providers';
-import {
-  CachingTokenListProvider,
-  ITokenListProvider,
-} from '../../providers/caching-token-list-provider';
-import {
-  GasPrice,
-  IGasPriceProvider,
-} from '../../providers/gas-price-provider';
+import { CachingTokenListProvider, ITokenListProvider } from '../../providers/caching-token-list-provider';
+import { GasPrice, IGasPriceProvider } from '../../providers/gas-price-provider';
 import { ProviderConfig } from '../../providers/provider';
 import { ITokenProvider, TokenProvider } from '../../providers/token-provider';
-import {
-  ITokenValidatorProvider,
-  TokenValidatorProvider,
-} from '../../providers/token-validator-provider';
-import {
-  IV2PoolProvider,
-  V2PoolProvider,
-} from '../../providers/v2/pool-provider';
+import { ITokenValidatorProvider, TokenValidatorProvider, } from '../../providers/token-validator-provider';
+import { IV2PoolProvider, V2PoolProvider } from '../../providers/v2/pool-provider';
 import {
   ArbitrumGasData,
   ArbitrumGasDataProvider,
@@ -71,28 +53,15 @@ import {
   OptimismGasData,
   OptimismGasDataProvider,
 } from '../../providers/v3/gas-data-provider';
-import {
-  IV3PoolProvider,
-  V3PoolProvider,
-} from '../../providers/v3/pool-provider';
+import { IV3PoolProvider, V3PoolProvider } from '../../providers/v3/pool-provider';
 import { IV3SubgraphProvider } from '../../providers/v3/subgraph-provider';
 import { Erc20__factory } from '../../types/other/factories/Erc20__factory';
 import { SWAP_ROUTER_02_ADDRESSES, WRAPPED_NATIVE_CURRENCY } from '../../util';
 import { CurrencyAmount } from '../../util/amounts';
-import {
-  ID_TO_CHAIN_ID,
-  ID_TO_NETWORK_NAME,
-  V2_SUPPORTED,
-} from '../../util/chains';
-import {
-  getHighestLiquidityV3NativePool,
-  getHighestLiquidityV3USDPool,
-} from '../../util/gas-factory-helpers';
+import { ID_TO_CHAIN_ID, ID_TO_NETWORK_NAME, V2_SUPPORTED } from '../../util/chains';
+import { getHighestLiquidityV3NativePool, getHighestLiquidityV3USDPool } from '../../util/gas-factory-helpers';
 import { log } from '../../util/log';
-import {
-  buildSwapMethodParameters,
-  buildTrade,
-} from '../../util/methodParameters';
+import { buildSwapMethodParameters, buildTrade } from '../../util/methodParameters';
 import { metric, MetricLoggerUnit } from '../../util/metric';
 import { UNSUPPORTED_TOKENS } from '../../util/unsupported-tokens';
 import {
@@ -111,10 +80,7 @@ import {
   V3Route,
 } from '../router';
 
-import {
-  DEFAULT_ROUTING_CONFIG_BY_CHAIN,
-  ETH_GAS_STATION_API_URL,
-} from './config';
+import { DEFAULT_ROUTING_CONFIG_BY_CHAIN, ETH_GAS_STATION_API_URL } from './config';
 import {
   MixedRouteWithValidQuote,
   RouteWithValidQuote,
@@ -134,11 +100,10 @@ import {
   IGasModel,
   IOnChainGasModelFactory,
   IV2GasModelFactory,
-  LiquidityCalculationPools,
+  LiquidityCalculationPools
 } from './gas-models/gas-model';
 import { MixedRouteHeuristicGasModelFactory } from './gas-models/mixedRoute/mixed-route-heuristic-gas-model';
 import { V2HeuristicGasModelFactory } from './gas-models/v2/v2-heuristic-gas-model';
-import { NATIVE_OVERHEAD } from './gas-models/v3/gas-costs';
 import { V3HeuristicGasModelFactory } from './gas-models/v3/v3-heuristic-gas-model';
 import { GetQuotesResult, MixedQuoter, V2Quoter, V3Quoter } from './quoters';
 
@@ -378,10 +343,8 @@ export type AlphaRouterConfig = {
 };
 
 export class AlphaRouter
-  implements
-    IRouter<AlphaRouterConfig>,
-    ISwapToRatio<AlphaRouterConfig, SwapAndAddConfig>
-{
+  implements IRouter<AlphaRouterConfig>,
+    ISwapToRatio<AlphaRouterConfig, SwapAndAddConfig> {
   protected chainId: ChainId;
   protected provider: BaseProvider;
   protected multicall2Provider: UniswapMulticallProvider;
@@ -671,9 +634,7 @@ export class AlphaRouter
         new LegacyGasPriceProvider(this.provider as JsonRpcProvider)
       );
     } else {
-      gasPriceProviderInstance = new ETHGasStationInfoProvider(
-        ETH_GAS_STATION_API_URL
-      );
+      gasPriceProviderInstance = new ETHGasStationInfoProvider(ETH_GAS_STATION_API_URL);
     }
 
     this.gasPriceProvider =
@@ -953,12 +914,7 @@ export class AlphaRouter
     swapConfig?: SwapOptions,
     partialRoutingConfig: Partial<AlphaRouterConfig> = {}
   ): Promise<SwapRoute | null> {
-    const { currencyIn, currencyOut } =
-      this.determineCurrencyInOutFromTradeType(
-        tradeType,
-        amount,
-        quoteCurrency
-      );
+    const { currencyIn, currencyOut } = this.determineCurrencyInOutFromTradeType(tradeType, amount, quoteCurrency);
 
     const tokenIn = currencyIn.wrapped;
     const tokenOut = currencyOut.wrapped;
@@ -967,10 +923,7 @@ export class AlphaRouter
     metric.setProperty('pair', `${tokenIn.symbol}/${tokenOut.symbol}`);
     metric.setProperty('tokenIn', tokenIn.address);
     metric.setProperty('tokenOut', tokenOut.address);
-    metric.setProperty(
-      'tradeType',
-      tradeType === TradeType.EXACT_INPUT ? 'ExactIn' : 'ExactOut'
-    );
+    metric.setProperty('tradeType', tradeType === TradeType.EXACT_INPUT ? 'ExactIn' : 'ExactOut');
 
     metric.putMetric(
       `QuoteRequestedForChain${this.chainId}`,
@@ -980,8 +933,7 @@ export class AlphaRouter
 
     // Get a block number to specify in all our calls. Ensures data we fetch from chain is
     // from the same block.
-    const blockNumber =
-      partialRoutingConfig.blockNumber ?? this.getBlockNumberPromise();
+    const blockNumber = partialRoutingConfig.blockNumber ?? this.getBlockNumberPromise();
 
     const routingConfig: AlphaRouterConfig = _.merge(
       {
@@ -1007,17 +959,12 @@ export class AlphaRouter
       gasPriceWei,
       amount.currency.wrapped,
       quoteToken,
-      {
-        blockNumber,
-        additionalGasOverhead: NATIVE_OVERHEAD(this.chainId, amount.currency, quoteCurrency),
-      }
+      { blockNumber, additionalGasOverhead: NATIVE_OVERHEAD(this.chainId, amount.currency, quoteCurrency) }
     );
 
     // Create a Set to sanitize the protocols input, a Set of undefined becomes an empty set,
     // Then create an Array from the values of that Set.
-    const protocols: Protocol[] = Array.from(
-      new Set(routingConfig.protocols).values()
-    );
+    const protocols: Protocol[] = Array.from(new Set(routingConfig.protocols).values());
 
     const cacheMode = await this.routeCachingProvider?.getCacheMode(
       this.chainId,
@@ -1056,13 +1003,9 @@ export class AlphaRouter
           cacheMode,
           amount: amount.toExact(),
           chainId: this.chainId,
-          tradeType: this.tradeTypeStr(tradeType),
+          tradeType: this.tradeTypeStr(tradeType)
         },
-        `GetCachedRoute miss ${cacheMode} for ${this.tokenPairSymbolTradeTypeChainId(
-          tokenIn,
-          tokenOut,
-          tradeType
-        )}`
+        `GetCachedRoute miss ${cacheMode} for ${this.tokenPairSymbolTradeTypeChainId(tokenIn, tokenOut, tradeType)}`
       );
     } else if (cachedRoutes) {
       metric.putMetric(
@@ -1079,18 +1022,13 @@ export class AlphaRouter
           cacheMode,
           amount: amount.toExact(),
           chainId: this.chainId,
-          tradeType: this.tradeTypeStr(tradeType),
+          tradeType: this.tradeTypeStr(tradeType)
         },
-        `GetCachedRoute hit ${cacheMode} for ${this.tokenPairSymbolTradeTypeChainId(
-          tokenIn,
-          tokenOut,
-          tradeType
-        )}`
+        `GetCachedRoute hit ${cacheMode} for ${this.tokenPairSymbolTradeTypeChainId(tokenIn, tokenOut, tradeType)}`
       );
     }
 
-    let swapRouteFromCachePromise: Promise<BestSwapRoute | null> =
-      Promise.resolve(null);
+    let swapRouteFromCachePromise: Promise<BestSwapRoute | null> = Promise.resolve(null);
     if (cachedRoutes) {
       swapRouteFromCachePromise = this.getSwapRouteFromCache(
         cachedRoutes,
@@ -1105,8 +1043,7 @@ export class AlphaRouter
       );
     }
 
-    let swapRouteFromChainPromise: Promise<BestSwapRoute | null> =
-      Promise.resolve(null);
+    let swapRouteFromChainPromise: Promise<BestSwapRoute | null> = Promise.resolve(null);
     if (!cachedRoutes || cacheMode !== CacheMode.Livemode) {
       swapRouteFromChainPromise = this.getSwapRouteFromChain(
         amount,
@@ -1124,46 +1061,27 @@ export class AlphaRouter
 
     const [swapRouteFromCache, swapRouteFromChain] = await Promise.all([
       swapRouteFromCachePromise,
-      swapRouteFromChainPromise,
+      swapRouteFromChainPromise
     ]);
 
     let swapRouteRaw: BestSwapRoute | null;
     if (cacheMode === CacheMode.Livemode && swapRouteFromCache) {
-      log.info(
-        `CacheMode is ${cacheMode}, and we are using swapRoute from cache`
-      );
+      log.info(`CacheMode is ${cacheMode}, and we are using swapRoute from cache`);
       swapRouteRaw = swapRouteFromCache;
     } else {
-      log.info(
-        `CacheMode is ${cacheMode}, and we are using materialized swapRoute`
-      );
+      log.info(`CacheMode is ${cacheMode}, and we are using materialized swapRoute`);
       swapRouteRaw = swapRouteFromChain;
     }
 
-    if (
-      cacheMode === CacheMode.Tapcompare &&
-      swapRouteFromCache &&
-      swapRouteFromChain
-    ) {
-      const quoteDiff = swapRouteFromChain.quote.subtract(
-        swapRouteFromCache.quote
-      );
-      const quoteGasAdjustedDiff = swapRouteFromChain.quoteGasAdjusted.subtract(
-        swapRouteFromCache.quoteGasAdjusted
-      );
-      const gasUsedDiff = swapRouteFromChain.estimatedGasUsed.sub(
-        swapRouteFromCache.estimatedGasUsed
-      );
+    if (cacheMode === CacheMode.Tapcompare && swapRouteFromCache && swapRouteFromChain) {
+      const quoteDiff = swapRouteFromChain.quote.subtract(swapRouteFromCache.quote);
+      const quoteGasAdjustedDiff = swapRouteFromChain.quoteGasAdjusted.subtract(swapRouteFromCache.quoteGasAdjusted);
+      const gasUsedDiff = swapRouteFromChain.estimatedGasUsed.sub(swapRouteFromCache.estimatedGasUsed);
 
       // Only log if quoteDiff is different from 0, or if quoteGasAdjustedDiff and gasUsedDiff are both different from 0
-      if (
-        !quoteDiff.equalTo(0) ||
-        !(quoteGasAdjustedDiff.equalTo(0) || gasUsedDiff.eq(0))
-      ) {
+      if (!quoteDiff.equalTo(0) || !(quoteGasAdjustedDiff.equalTo(0) || gasUsedDiff.eq(0))) {
         // Calculates the percentage of the difference with respect to the quoteFromChain (not from cache)
-        const misquotePercent = quoteGasAdjustedDiff
-          .divide(swapRouteFromChain.quoteGasAdjusted)
-          .multiply(100);
+        const misquotePercent = quoteGasAdjustedDiff.divide(swapRouteFromChain.quoteGasAdjusted).multiply(100);
 
         metric.putMetric(
           `TapcompareCachedRoute_quoteGasAdjustedDiffPercent`,
@@ -1176,10 +1094,8 @@ export class AlphaRouter
             quoteFromChain: swapRouteFromChain.quote.toExact(),
             quoteFromCache: swapRouteFromCache.quote.toExact(),
             quoteDiff: quoteDiff.toExact(),
-            quoteGasAdjustedFromChain:
-              swapRouteFromChain.quoteGasAdjusted.toExact(),
-            quoteGasAdjustedFromCache:
-              swapRouteFromCache.quoteGasAdjusted.toExact(),
+            quoteGasAdjustedFromChain: swapRouteFromChain.quoteGasAdjusted.toExact(),
+            quoteGasAdjustedFromCache: swapRouteFromCache.quoteGasAdjusted.toExact(),
             quoteGasAdjustedDiff: quoteGasAdjustedDiff.toExact(),
             gasUsedFromChain: swapRouteFromChain.estimatedGasUsed.toString(),
             gasUsedFromCache: swapRouteFromCache.estimatedGasUsed.toString(),
@@ -1188,12 +1104,8 @@ export class AlphaRouter
             routesFromCache: swapRouteFromCache.routes.toString(),
             amount: amount.toExact(),
             originalAmount: cachedRoutes?.originalAmount,
-            pair: this.tokenPairSymbolTradeTypeChainId(
-              tokenIn,
-              tokenOut,
-              tradeType
-            ),
-            blockNumber,
+            pair: this.tokenPairSymbolTradeTypeChainId(tokenIn, tokenOut, tradeType),
+            blockNumber
           },
           `Comparing quotes between Chain and Cache for ${this.tokenPairSymbolTradeTypeChainId(
             tokenIn,
@@ -1238,37 +1150,31 @@ export class AlphaRouter
       if (routesToCache) {
         // Attempt to insert the entry in cache. This is fire and forget promise.
         // The catch method will prevent any exception from blocking the normal code execution.
-        this.routeCachingProvider
-          .setCachedRoute(routesToCache, amount)
-          .then((success) => {
-            const status = success ? 'success' : 'rejected';
-            metric.putMetric(
-              `SetCachedRoute_${status}`,
-              1,
-              MetricLoggerUnit.Count
-            );
-          })
-          .catch((reason) => {
-            log.error(
-              {
-                reason: reason,
-                tokenPair: this.tokenPairSymbolTradeTypeChainId(
-                  tokenIn,
-                  tokenOut,
-                  tradeType
-                ),
-              },
-              `SetCachedRoute failure`
-            );
+        this.routeCachingProvider.setCachedRoute(routesToCache, amount).then((success) => {
+          const status = success ? 'success' : 'rejected';
+          metric.putMetric(
+            `SetCachedRoute_${status}`,
+            1,
+            MetricLoggerUnit.Count
+          );
+        }).catch((reason) => {
+          log.error(
+            {
+              reason: reason,
+              tokenPair: this.tokenPairSymbolTradeTypeChainId(tokenIn, tokenOut, tradeType),
+            },
+            `SetCachedRoute failure`
+          );
 
-            metric.putMetric(
-              `SetCachedRoute_failure`,
-              1,
-              MetricLoggerUnit.Count
-            );
-          });
+          metric.putMetric(
+            `SetCachedRoute_failure`,
+            1,
+            MetricLoggerUnit.Count
+          );
+        });
       }
     }
+
 
     metric.putMetric(
       `QuoteFoundForChain${this.chainId}`,
@@ -1368,21 +1274,18 @@ export class AlphaRouter
     );
     const quotePromises: Promise<GetQuotesResult>[] = [];
 
-    const v3Routes = cachedRoutes.routes.filter(
-      (route) => route.protocol === Protocol.V3
-    );
-    const v2Routes = cachedRoutes.routes.filter(
-      (route) => route.protocol === Protocol.V2
-    );
-    const mixedRoutes = cachedRoutes.routes.filter(
-      (route) => route.protocol === Protocol.MIXED
-    );
+    const v3Routes = cachedRoutes.routes.filter((route) => route.protocol === Protocol.V3);
+    const v2Routes = cachedRoutes.routes.filter((route) => route.protocol === Protocol.V2);
+    const mixedRoutes = cachedRoutes.routes.filter((route) => route.protocol === Protocol.MIXED);
 
     let percents: number[];
     let amounts: CurrencyAmount[];
     if (cachedRoutes.routes.length > 1) {
       // If we have more than 1 route, we will quote the different percents for it, following the regular process
-      [percents, amounts] = this.getAmountDistribution(amount, routingConfig);
+      [percents, amounts] = this.getAmountDistribution(
+        amount,
+        routingConfig
+      );
     } else if (cachedRoutes.routes.length == 1) {
       [percents, amounts] = [[100], [amount]];
     } else {
@@ -1391,119 +1294,92 @@ export class AlphaRouter
     }
 
     if (v3Routes.length > 0) {
-      const v3RoutesFromCache: V3Route[] = v3Routes.map(
-        (cachedRoute) => cachedRoute.route as V3Route
-      );
-      metric.putMetric(
-        'SwapRouteFromCache_V3_GetQuotes_Request',
-        1,
-        MetricLoggerUnit.Count
-      );
+      const v3RoutesFromCache: V3Route[] = v3Routes.map((cachedRoute) => cachedRoute.route as V3Route);
+      metric.putMetric('SwapRouteFromCache_V3_GetQuotes_Request', 1, MetricLoggerUnit.Count);
 
       const beforeGetQuotes = Date.now();
 
       quotePromises.push(
-        this.v3Quoter
-          .getQuotes(
-            v3RoutesFromCache,
-            amounts,
-            percents,
-            quoteToken,
-            tradeType,
-            routingConfig,
-            undefined,
-            v3GasModel
-          )
-          .then((result) => {
-            metric.putMetric(
-              `SwapRouteFromCache_V3_GetQuotes_Load`,
-              Date.now() - beforeGetQuotes,
-              MetricLoggerUnit.Milliseconds
-            );
+        this.v3Quoter.getQuotes(
+          v3RoutesFromCache,
+          amounts,
+          percents,
+          quoteToken,
+          tradeType,
+          routingConfig,
+          undefined,
+          v3GasModel
+        ).then((result) => {
+          metric.putMetric(
+            `SwapRouteFromCache_V3_GetQuotes_Load`,
+            Date.now() - beforeGetQuotes,
+            MetricLoggerUnit.Milliseconds
+          );
 
-            return result;
-          })
+          return result;
+        })
       );
     }
 
     if (v2Routes.length > 0) {
-      const v2RoutesFromCache: V2Route[] = v2Routes.map(
-        (cachedRoute) => cachedRoute.route as V2Route
-      );
-      metric.putMetric(
-        'SwapRouteFromCache_V2_GetQuotes_Request',
-        1,
-        MetricLoggerUnit.Count
-      );
+      const v2RoutesFromCache: V2Route[] = v2Routes.map((cachedRoute) => cachedRoute.route as V2Route);
+      metric.putMetric('SwapRouteFromCache_V2_GetQuotes_Request', 1, MetricLoggerUnit.Count);
 
       const beforeGetQuotes = Date.now();
 
       quotePromises.push(
-        this.v2Quoter
-          .refreshRoutesThenGetQuotes(
-            cachedRoutes.tokenIn,
-            cachedRoutes.tokenOut,
-            v2RoutesFromCache,
-            amounts,
-            percents,
-            quoteToken,
-            tradeType,
-            routingConfig,
-            gasPriceWei
-          )
-          .then((result) => {
-            metric.putMetric(
-              `SwapRouteFromCache_V2_GetQuotes_Load`,
-              Date.now() - beforeGetQuotes,
-              MetricLoggerUnit.Milliseconds
-            );
+        this.v2Quoter.refreshRoutesThenGetQuotes(
+          cachedRoutes.tokenIn,
+          cachedRoutes.tokenOut,
+          v2RoutesFromCache,
+          amounts,
+          percents,
+          quoteToken,
+          tradeType,
+          routingConfig,
+          gasPriceWei
+        ).then((result) => {
+          metric.putMetric(
+            `SwapRouteFromCache_V2_GetQuotes_Load`,
+            Date.now() - beforeGetQuotes,
+            MetricLoggerUnit.Milliseconds
+          );
 
-            return result;
-          })
+          return result;
+        })
       );
     }
 
     if (mixedRoutes.length > 0) {
-      const mixedRoutesFromCache: MixedRoute[] = mixedRoutes.map(
-        (cachedRoute) => cachedRoute.route as MixedRoute
-      );
-      metric.putMetric(
-        'SwapRouteFromCache_Mixed_GetQuotes_Request',
-        1,
-        MetricLoggerUnit.Count
-      );
+      const mixedRoutesFromCache: MixedRoute[] = mixedRoutes.map((cachedRoute) => cachedRoute.route as MixedRoute);
+      metric.putMetric('SwapRouteFromCache_Mixed_GetQuotes_Request', 1, MetricLoggerUnit.Count);
 
       const beforeGetQuotes = Date.now();
 
       quotePromises.push(
-        this.mixedQuoter
-          .getQuotes(
-            mixedRoutesFromCache,
-            amounts,
-            percents,
-            quoteToken,
-            tradeType,
-            routingConfig,
-            undefined,
-            mixedRouteGasModel
-          )
-          .then((result) => {
-            metric.putMetric(
-              `SwapRouteFromCache_Mixed_GetQuotes_Load`,
-              Date.now() - beforeGetQuotes,
-              MetricLoggerUnit.Milliseconds
-            );
+        this.mixedQuoter.getQuotes(
+          mixedRoutesFromCache,
+          amounts,
+          percents,
+          quoteToken,
+          tradeType,
+          routingConfig,
+          undefined,
+          mixedRouteGasModel
+        ).then((result) => {
+          metric.putMetric(
+            `SwapRouteFromCache_Mixed_GetQuotes_Load`,
+            Date.now() - beforeGetQuotes,
+            MetricLoggerUnit.Milliseconds
+          );
 
-            return result;
-          })
+          return result;
+        })
       );
     }
 
     const getQuotesResults = await Promise.all(quotePromises);
-    const allRoutesWithValidQuotes = _.flatMap(
-      getQuotesResults,
-      (quoteResult) => quoteResult.routesWithValidQuotes
-    );
+    const allRoutesWithValidQuotes = _.flatMap(getQuotesResults, (quoteResult) => quoteResult.routesWithValidQuotes);
 
     return getBestSwapRoute(
       amount,
@@ -1540,17 +1416,13 @@ export class AlphaRouter
     const v3ProtocolSpecified = protocols.includes(Protocol.V3);
     const v2ProtocolSpecified = protocols.includes(Protocol.V2);
     const v2SupportedInChain = V2_SUPPORTED.includes(this.chainId);
-    const shouldQueryMixedProtocol =
-      protocols.includes(Protocol.MIXED) ||
-      (noProtocolsSpecified && v2SupportedInChain);
-    const mixedProtocolAllowed =
-      [ChainId.MAINNET, ChainId.GOERLI].includes(this.chainId) &&
+    const shouldQueryMixedProtocol = protocols.includes(Protocol.MIXED) || (noProtocolsSpecified && v2SupportedInChain);
+    const mixedProtocolAllowed = [ChainId.MAINNET, ChainId.GOERLI].includes(this.chainId) &&
       tradeType === TradeType.EXACT_INPUT;
 
     const beforeGetCandidates = Date.now();
 
-    let v3CandidatePoolsPromise: Promise<V3CandidatePools | undefined> =
-      Promise.resolve(undefined);
+    let v3CandidatePoolsPromise: Promise<V3CandidatePools | undefined> = Promise.resolve(undefined);
     if (
       v3ProtocolSpecified ||
       noProtocolsSpecified ||
@@ -1567,17 +1439,12 @@ export class AlphaRouter
         routingConfig,
         chainId: this.chainId,
       }).then((candidatePools) => {
-        metric.putMetric(
-          'GetV3CandidatePools',
-          Date.now() - beforeGetCandidates,
-          MetricLoggerUnit.Milliseconds
-        );
+        metric.putMetric('GetV3CandidatePools', Date.now() - beforeGetCandidates, MetricLoggerUnit.Milliseconds);
         return candidatePools;
       });
     }
 
-    let v2CandidatePoolsPromise: Promise<V2CandidatePools | undefined> =
-      Promise.resolve(undefined);
+    let v2CandidatePoolsPromise: Promise<V2CandidatePools | undefined> = Promise.resolve(undefined);
     if (
       (v2SupportedInChain && (v2ProtocolSpecified || noProtocolsSpecified)) ||
       (shouldQueryMixedProtocol && mixedProtocolAllowed)
@@ -1596,11 +1463,7 @@ export class AlphaRouter
         routingConfig,
         chainId: this.chainId,
       }).then((candidatePools) => {
-        metric.putMetric(
-          'GetV2CandidatePools',
-          Date.now() - beforeGetCandidates,
-          MetricLoggerUnit.Milliseconds
-        );
+        metric.putMetric('GetV2CandidatePools', Date.now() - beforeGetCandidates, MetricLoggerUnit.Milliseconds);
         return candidatePools;
       });
     }
@@ -1611,36 +1474,30 @@ export class AlphaRouter
     if (v3ProtocolSpecified || noProtocolsSpecified) {
       log.info({ protocols, tradeType }, 'Routing across V3');
 
-      metric.putMetric(
-        'SwapRouteFromChain_V3_GetRoutesThenQuotes_Request',
-        1,
-        MetricLoggerUnit.Count
-      );
+      metric.putMetric('SwapRouteFromChain_V3_GetRoutesThenQuotes_Request', 1, MetricLoggerUnit.Count);
       const beforeGetRoutesThenQuotes = Date.now();
 
       quotePromises.push(
         v3CandidatePoolsPromise.then((v3CandidatePools) =>
-          this.v3Quoter
-            .getRoutesThenQuotes(
-              tokenIn,
-              tokenOut,
-              amounts,
-              percents,
-              quoteToken,
-              v3CandidatePools!,
-              tradeType,
-              routingConfig,
-              v3GasModel
-            )
-            .then((result) => {
-              metric.putMetric(
-                `SwapRouteFromChain_V3_GetRoutesThenQuotes_Load`,
-                Date.now() - beforeGetRoutesThenQuotes,
-                MetricLoggerUnit.Milliseconds
-              );
+          this.v3Quoter.getRoutesThenQuotes(
+            tokenIn,
+            tokenOut,
+            amounts,
+            percents,
+            quoteToken,
+            v3CandidatePools!,
+            tradeType,
+            routingConfig,
+            v3GasModel
+          ).then((result) => {
+            metric.putMetric(
+              `SwapRouteFromChain_V3_GetRoutesThenQuotes_Load`,
+              Date.now() - beforeGetRoutesThenQuotes,
+              MetricLoggerUnit.Milliseconds
+            );
 
-              return result;
-            })
+            return result;
+          })
         )
       );
     }
@@ -1649,37 +1506,31 @@ export class AlphaRouter
     if (v2SupportedInChain && (v2ProtocolSpecified || noProtocolsSpecified)) {
       log.info({ protocols, tradeType }, 'Routing across V2');
 
-      metric.putMetric(
-        'SwapRouteFromChain_V2_GetRoutesThenQuotes_Request',
-        1,
-        MetricLoggerUnit.Count
-      );
+      metric.putMetric('SwapRouteFromChain_V2_GetRoutesThenQuotes_Request', 1, MetricLoggerUnit.Count);
       const beforeGetRoutesThenQuotes = Date.now();
 
       quotePromises.push(
         v2CandidatePoolsPromise.then((v2CandidatePools) =>
-          this.v2Quoter
-            .getRoutesThenQuotes(
-              tokenIn,
-              tokenOut,
-              amounts,
-              percents,
-              quoteToken,
-              v2CandidatePools!,
-              tradeType,
-              routingConfig,
-              undefined,
-              gasPriceWei
-            )
-            .then((result) => {
-              metric.putMetric(
-                `SwapRouteFromChain_V2_GetRoutesThenQuotes_Load`,
-                Date.now() - beforeGetRoutesThenQuotes,
-                MetricLoggerUnit.Milliseconds
-              );
+          this.v2Quoter.getRoutesThenQuotes(
+            tokenIn,
+            tokenOut,
+            amounts,
+            percents,
+            quoteToken,
+            v2CandidatePools!,
+            tradeType,
+            routingConfig,
+            undefined,
+            gasPriceWei
+          ).then((result) => {
+            metric.putMetric(
+              `SwapRouteFromChain_V2_GetRoutesThenQuotes_Load`,
+              Date.now() - beforeGetRoutesThenQuotes,
+              MetricLoggerUnit.Milliseconds
+            );
 
-              return result;
-            })
+            return result;
+          })
         )
       );
     }
@@ -1690,37 +1541,30 @@ export class AlphaRouter
     if (shouldQueryMixedProtocol && mixedProtocolAllowed) {
       log.info({ protocols, tradeType }, 'Routing across MixedRoutes');
 
-      metric.putMetric(
-        'SwapRouteFromChain_Mixed_GetRoutesThenQuotes_Request',
-        1,
-        MetricLoggerUnit.Count
-      );
+      metric.putMetric('SwapRouteFromChain_Mixed_GetRoutesThenQuotes_Request', 1, MetricLoggerUnit.Count);
       const beforeGetRoutesThenQuotes = Date.now();
 
       quotePromises.push(
-        Promise.all([v3CandidatePoolsPromise, v2CandidatePoolsPromise]).then(
-          ([v3CandidatePools, v2CandidatePools]) =>
-            this.mixedQuoter
-              .getRoutesThenQuotes(
-                tokenIn,
-                tokenOut,
-                amounts,
-                percents,
-                quoteToken,
-                [v3CandidatePools!, v2CandidatePools!],
-                tradeType,
-                routingConfig,
-                mixedRouteGasModel
-              )
-              .then((result) => {
-                metric.putMetric(
-                  `SwapRouteFromChain_Mixed_GetRoutesThenQuotes_Load`,
-                  Date.now() - beforeGetRoutesThenQuotes,
-                  MetricLoggerUnit.Milliseconds
-                );
+        Promise.all([v3CandidatePoolsPromise, v2CandidatePoolsPromise]).then(([v3CandidatePools, v2CandidatePools]) =>
+          this.mixedQuoter.getRoutesThenQuotes(
+            tokenIn,
+            tokenOut,
+            amounts,
+            percents,
+            quoteToken,
+            [v3CandidatePools!, v2CandidatePools!],
+            tradeType,
+            routingConfig,
+            mixedRouteGasModel
+          ).then((result) => {
+            metric.putMetric(
+              `SwapRouteFromChain_Mixed_GetRoutesThenQuotes_Load`,
+              Date.now() - beforeGetRoutesThenQuotes,
+              MetricLoggerUnit.Milliseconds
+            );
 
-                return result;
-              })
+            return result;
+          })
         )
       );
     }
@@ -1763,30 +1607,20 @@ export class AlphaRouter
     return tradeType === TradeType.EXACT_INPUT ? 'ExactIn' : 'ExactOut';
   }
 
-  private tokenPairSymbolTradeTypeChainId(
-    tokenIn: Token,
-    tokenOut: Token,
-    tradeType: TradeType
-  ) {
-    return `${tokenIn.symbol}/${tokenOut.symbol}/${this.tradeTypeStr(
-      tradeType
-    )}/${this.chainId}`;
+  private tokenPairSymbolTradeTypeChainId(tokenIn: Token, tokenOut: Token, tradeType: TradeType) {
+    return `${tokenIn.symbol}/${tokenOut.symbol}/${this.tradeTypeStr(tradeType)}/${this.chainId}`;
   }
 
-  private determineCurrencyInOutFromTradeType(
-    tradeType: TradeType,
-    amount: CurrencyAmount,
-    quoteCurrency: Currency
-  ) {
+  private determineCurrencyInOutFromTradeType(tradeType: TradeType, amount: CurrencyAmount, quoteCurrency: Currency) {
     if (tradeType === TradeType.EXACT_INPUT) {
       return {
         currencyIn: amount.currency,
-        currencyOut: quoteCurrency,
+        currencyOut: quoteCurrency
       };
     } else {
       return {
         currencyIn: quoteCurrency,
-        currencyOut: amount.currency,
+        currencyOut: amount.currency
       };
     }
   }
@@ -1812,9 +1646,10 @@ export class AlphaRouter
     amountToken: Token,
     quoteToken: Token,
     providerConfig?: ProviderConfig
-  ): Promise<
-    [IGasModel<V3RouteWithValidQuote>, IGasModel<MixedRouteWithValidQuote>]
-  > {
+  ): Promise<[
+    IGasModel<V3RouteWithValidQuote>,
+    IGasModel<MixedRouteWithValidQuote>
+  ]> {
     const beforeGasModel = Date.now();
 
     const usdPoolPromise = getHighestLiquidityV3USDPool(
@@ -1823,32 +1658,27 @@ export class AlphaRouter
       providerConfig
     );
     const nativeCurrency = WRAPPED_NATIVE_CURRENCY[this.chainId];
-    const nativeQuoteTokenV3PoolPromise = !quoteToken.equals(nativeCurrency)
-      ? getHighestLiquidityV3NativePool(
-          quoteToken,
-          this.v3PoolProvider,
-          providerConfig
-        )
-      : Promise.resolve(null);
-    const nativeAmountTokenV3PoolPromise = !amountToken.equals(nativeCurrency)
-      ? getHighestLiquidityV3NativePool(
-          amountToken,
-          this.v3PoolProvider,
-          providerConfig
-        )
-      : Promise.resolve(null);
+    const nativeQuoteTokenV3PoolPromise = !quoteToken.equals(nativeCurrency) ? getHighestLiquidityV3NativePool(
+      quoteToken,
+      this.v3PoolProvider,
+      providerConfig
+    ) : Promise.resolve(null);
+    const nativeAmountTokenV3PoolPromise = !amountToken.equals(nativeCurrency) ? getHighestLiquidityV3NativePool(
+      amountToken,
+      this.v3PoolProvider,
+      providerConfig
+    ) : Promise.resolve(null);
 
-    const [usdPool, nativeQuoteTokenV3Pool, nativeAmountTokenV3Pool] =
-      await Promise.all([
-        usdPoolPromise,
-        nativeQuoteTokenV3PoolPromise,
-        nativeAmountTokenV3PoolPromise,
-      ]);
+    const [usdPool, nativeQuoteTokenV3Pool, nativeAmountTokenV3Pool] = await Promise.all([
+      usdPoolPromise,
+      nativeQuoteTokenV3PoolPromise,
+      nativeAmountTokenV3PoolPromise
+    ]);
 
     const pools: LiquidityCalculationPools = {
       usdPool: usdPool,
       nativeQuoteTokenV3Pool: nativeQuoteTokenV3Pool,
-      nativeAmountTokenV3Pool: nativeAmountTokenV3Pool,
+      nativeAmountTokenV3Pool: nativeAmountTokenV3Pool
     };
 
     const v3GasModelPromise = this.v3GasModelFactory.buildGasModel({
@@ -1859,23 +1689,22 @@ export class AlphaRouter
       quoteToken,
       v2poolProvider: this.v2PoolProvider,
       l2GasDataProvider: this.l2GasDataProvider,
-      providerConfig: providerConfig,
+      providerConfig: providerConfig
     });
 
-    const mixedRouteGasModelPromise =
-      this.mixedRouteGasModelFactory.buildGasModel({
-        chainId: this.chainId,
-        gasPriceWei,
-        pools,
-        amountToken,
-        quoteToken,
-        v2poolProvider: this.v2PoolProvider,
-        providerConfig: providerConfig,
-      });
+    const mixedRouteGasModelPromise = this.mixedRouteGasModelFactory.buildGasModel({
+      chainId: this.chainId,
+      gasPriceWei,
+      pools,
+      amountToken,
+      quoteToken,
+      v2poolProvider: this.v2PoolProvider,
+      providerConfig: providerConfig
+    });
 
     const [v3GasModel, mixedRouteGasModel] = await Promise.all([
       v3GasModelPromise,
-      mixedRouteGasModelPromise,
+      mixedRouteGasModelPromise
     ]);
 
     metric.putMetric(
@@ -2138,8 +1967,7 @@ export class AlphaRouter
     quote: CurrencyAmount
   ): Promise<boolean> {
     try {
-      const neededBalance =
-        tradeType === TradeType.EXACT_INPUT ? amount : quote;
+      const neededBalance = tradeType === TradeType.EXACT_INPUT ? amount : quote;
       let balance;
       if (neededBalance.currency.isNative) {
         balance = await this.provider.getBalance(fromAddress);

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -138,7 +138,7 @@ import {
 } from './gas-models/gas-model';
 import { MixedRouteHeuristicGasModelFactory } from './gas-models/mixedRoute/mixed-route-heuristic-gas-model';
 import { V2HeuristicGasModelFactory } from './gas-models/v2/v2-heuristic-gas-model';
-import { WRAPPED_NATIVE_OVERHEAD } from './gas-models/v3/gas-costs';
+import { NATIVE_OVERHEAD } from './gas-models/v3/gas-costs';
 import { V3HeuristicGasModelFactory } from './gas-models/v3/v3-heuristic-gas-model';
 import { GetQuotesResult, MixedQuoter, V2Quoter, V3Quoter } from './quoters';
 
@@ -1005,10 +1005,7 @@ export class AlphaRouter
       quoteToken,
       {
         blockNumber,
-        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(
-          amount.currency,
-          quoteCurrency
-        ),
+        additionalGasOverhead: NATIVE_OVERHEAD(amount.currency, quoteCurrency),
       }
     );
 

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1009,7 +1009,7 @@ export class AlphaRouter
       quoteToken,
       {
         blockNumber,
-        additionalGasOverhead: NATIVE_OVERHEAD(amount.currency, quoteCurrency),
+        additionalGasOverhead: NATIVE_OVERHEAD(this.chainId, amount.currency, quoteCurrency),
       }
     );
 

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -2,7 +2,13 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { BaseProvider, JsonRpcProvider } from '@ethersproject/providers';
 import DEFAULT_TOKEN_LIST from '@uniswap/default-token-list';
 import { Protocol, SwapRouter, Trade } from '@uniswap/router-sdk';
-import { ChainId, Currency, Fraction, Token, TradeType } from '@uniswap/sdk-core';
+import {
+  ChainId,
+  Currency,
+  Fraction,
+  Token,
+  TradeType,
+} from '@uniswap/sdk-core';
 import { TokenList } from '@uniswap/token-lists';
 import { Pool, Position, SqrtPriceMath, TickMath } from '@uniswap/v3-sdk';
 import retry from 'async-retry';
@@ -40,12 +46,24 @@ import {
   V2SubgraphProviderWithFallBacks,
   V3SubgraphProviderWithFallBacks,
 } from '../../providers';
-import { CachingTokenListProvider, ITokenListProvider } from '../../providers/caching-token-list-provider';
-import { GasPrice, IGasPriceProvider } from '../../providers/gas-price-provider';
+import {
+  CachingTokenListProvider,
+  ITokenListProvider,
+} from '../../providers/caching-token-list-provider';
+import {
+  GasPrice,
+  IGasPriceProvider,
+} from '../../providers/gas-price-provider';
 import { ProviderConfig } from '../../providers/provider';
 import { ITokenProvider, TokenProvider } from '../../providers/token-provider';
-import { ITokenValidatorProvider, TokenValidatorProvider, } from '../../providers/token-validator-provider';
-import { IV2PoolProvider, V2PoolProvider } from '../../providers/v2/pool-provider';
+import {
+  ITokenValidatorProvider,
+  TokenValidatorProvider,
+} from '../../providers/token-validator-provider';
+import {
+  IV2PoolProvider,
+  V2PoolProvider,
+} from '../../providers/v2/pool-provider';
 import {
   ArbitrumGasData,
   ArbitrumGasDataProvider,
@@ -53,15 +71,28 @@ import {
   OptimismGasData,
   OptimismGasDataProvider,
 } from '../../providers/v3/gas-data-provider';
-import { IV3PoolProvider, V3PoolProvider } from '../../providers/v3/pool-provider';
+import {
+  IV3PoolProvider,
+  V3PoolProvider,
+} from '../../providers/v3/pool-provider';
 import { IV3SubgraphProvider } from '../../providers/v3/subgraph-provider';
 import { Erc20__factory } from '../../types/other/factories/Erc20__factory';
 import { SWAP_ROUTER_02_ADDRESSES, WRAPPED_NATIVE_CURRENCY } from '../../util';
 import { CurrencyAmount } from '../../util/amounts';
-import { ID_TO_CHAIN_ID, ID_TO_NETWORK_NAME, V2_SUPPORTED } from '../../util/chains';
-import { getHighestLiquidityV3NativePool, getHighestLiquidityV3USDPool } from '../../util/gas-factory-helpers';
+import {
+  ID_TO_CHAIN_ID,
+  ID_TO_NETWORK_NAME,
+  V2_SUPPORTED,
+} from '../../util/chains';
+import {
+  getHighestLiquidityV3NativePool,
+  getHighestLiquidityV3USDPool,
+} from '../../util/gas-factory-helpers';
 import { log } from '../../util/log';
-import { buildSwapMethodParameters, buildTrade } from '../../util/methodParameters';
+import {
+  buildSwapMethodParameters,
+  buildTrade,
+} from '../../util/methodParameters';
 import { metric, MetricLoggerUnit } from '../../util/metric';
 import { UNSUPPORTED_TOKENS } from '../../util/unsupported-tokens';
 import {
@@ -80,7 +111,10 @@ import {
   V3Route,
 } from '../router';
 
-import { DEFAULT_ROUTING_CONFIG_BY_CHAIN, ETH_GAS_STATION_API_URL } from './config';
+import {
+  DEFAULT_ROUTING_CONFIG_BY_CHAIN,
+  ETH_GAS_STATION_API_URL,
+} from './config';
 import {
   MixedRouteWithValidQuote,
   RouteWithValidQuote,
@@ -100,10 +134,11 @@ import {
   IGasModel,
   IOnChainGasModelFactory,
   IV2GasModelFactory,
-  LiquidityCalculationPools
+  LiquidityCalculationPools,
 } from './gas-models/gas-model';
 import { MixedRouteHeuristicGasModelFactory } from './gas-models/mixedRoute/mixed-route-heuristic-gas-model';
 import { V2HeuristicGasModelFactory } from './gas-models/v2/v2-heuristic-gas-model';
+import { WRAPPED_NATIVE_OVERHEAD } from './gas-models/v3/gas-costs';
 import { V3HeuristicGasModelFactory } from './gas-models/v3/v3-heuristic-gas-model';
 import { GetQuotesResult, MixedQuoter, V2Quoter, V3Quoter } from './quoters';
 
@@ -343,8 +378,10 @@ export type AlphaRouterConfig = {
 };
 
 export class AlphaRouter
-  implements IRouter<AlphaRouterConfig>,
-    ISwapToRatio<AlphaRouterConfig, SwapAndAddConfig> {
+  implements
+    IRouter<AlphaRouterConfig>,
+    ISwapToRatio<AlphaRouterConfig, SwapAndAddConfig>
+{
   protected chainId: ChainId;
   protected provider: BaseProvider;
   protected multicall2Provider: UniswapMulticallProvider;
@@ -634,7 +671,9 @@ export class AlphaRouter
         new LegacyGasPriceProvider(this.provider as JsonRpcProvider)
       );
     } else {
-      gasPriceProviderInstance = new ETHGasStationInfoProvider(ETH_GAS_STATION_API_URL);
+      gasPriceProviderInstance = new ETHGasStationInfoProvider(
+        ETH_GAS_STATION_API_URL
+      );
     }
 
     this.gasPriceProvider =
@@ -914,7 +953,12 @@ export class AlphaRouter
     swapConfig?: SwapOptions,
     partialRoutingConfig: Partial<AlphaRouterConfig> = {}
   ): Promise<SwapRoute | null> {
-    const { currencyIn, currencyOut } = this.determineCurrencyInOutFromTradeType(tradeType, amount, quoteCurrency);
+    const { currencyIn, currencyOut } =
+      this.determineCurrencyInOutFromTradeType(
+        tradeType,
+        amount,
+        quoteCurrency
+      );
 
     const tokenIn = currencyIn.wrapped;
     const tokenOut = currencyOut.wrapped;
@@ -923,7 +967,10 @@ export class AlphaRouter
     metric.setProperty('pair', `${tokenIn.symbol}/${tokenOut.symbol}`);
     metric.setProperty('tokenIn', tokenIn.address);
     metric.setProperty('tokenOut', tokenOut.address);
-    metric.setProperty('tradeType', tradeType === TradeType.EXACT_INPUT ? 'ExactIn' : 'ExactOut');
+    metric.setProperty(
+      'tradeType',
+      tradeType === TradeType.EXACT_INPUT ? 'ExactIn' : 'ExactOut'
+    );
 
     metric.putMetric(
       `QuoteRequestedForChain${this.chainId}`,
@@ -933,7 +980,8 @@ export class AlphaRouter
 
     // Get a block number to specify in all our calls. Ensures data we fetch from chain is
     // from the same block.
-    const blockNumber = partialRoutingConfig.blockNumber ?? this.getBlockNumberPromise();
+    const blockNumber =
+      partialRoutingConfig.blockNumber ?? this.getBlockNumberPromise();
 
     const routingConfig: AlphaRouterConfig = _.merge(
       {
@@ -955,12 +1003,20 @@ export class AlphaRouter
       gasPriceWei,
       amount.currency.wrapped,
       quoteToken,
-      { blockNumber }
+      {
+        blockNumber,
+        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(
+          amount.currency,
+          quoteCurrency
+        ),
+      }
     );
 
     // Create a Set to sanitize the protocols input, a Set of undefined becomes an empty set,
     // Then create an Array from the values of that Set.
-    const protocols: Protocol[] = Array.from(new Set(routingConfig.protocols).values());
+    const protocols: Protocol[] = Array.from(
+      new Set(routingConfig.protocols).values()
+    );
 
     const cacheMode = await this.routeCachingProvider?.getCacheMode(
       this.chainId,
@@ -999,9 +1055,13 @@ export class AlphaRouter
           cacheMode,
           amount: amount.toExact(),
           chainId: this.chainId,
-          tradeType: this.tradeTypeStr(tradeType)
+          tradeType: this.tradeTypeStr(tradeType),
         },
-        `GetCachedRoute miss ${cacheMode} for ${this.tokenPairSymbolTradeTypeChainId(tokenIn, tokenOut, tradeType)}`
+        `GetCachedRoute miss ${cacheMode} for ${this.tokenPairSymbolTradeTypeChainId(
+          tokenIn,
+          tokenOut,
+          tradeType
+        )}`
       );
     } else if (cachedRoutes) {
       metric.putMetric(
@@ -1018,13 +1078,18 @@ export class AlphaRouter
           cacheMode,
           amount: amount.toExact(),
           chainId: this.chainId,
-          tradeType: this.tradeTypeStr(tradeType)
+          tradeType: this.tradeTypeStr(tradeType),
         },
-        `GetCachedRoute hit ${cacheMode} for ${this.tokenPairSymbolTradeTypeChainId(tokenIn, tokenOut, tradeType)}`
+        `GetCachedRoute hit ${cacheMode} for ${this.tokenPairSymbolTradeTypeChainId(
+          tokenIn,
+          tokenOut,
+          tradeType
+        )}`
       );
     }
 
-    let swapRouteFromCachePromise: Promise<BestSwapRoute | null> = Promise.resolve(null);
+    let swapRouteFromCachePromise: Promise<BestSwapRoute | null> =
+      Promise.resolve(null);
     if (cachedRoutes) {
       swapRouteFromCachePromise = this.getSwapRouteFromCache(
         cachedRoutes,
@@ -1039,7 +1104,8 @@ export class AlphaRouter
       );
     }
 
-    let swapRouteFromChainPromise: Promise<BestSwapRoute | null> = Promise.resolve(null);
+    let swapRouteFromChainPromise: Promise<BestSwapRoute | null> =
+      Promise.resolve(null);
     if (!cachedRoutes || cacheMode !== CacheMode.Livemode) {
       swapRouteFromChainPromise = this.getSwapRouteFromChain(
         amount,
@@ -1057,27 +1123,46 @@ export class AlphaRouter
 
     const [swapRouteFromCache, swapRouteFromChain] = await Promise.all([
       swapRouteFromCachePromise,
-      swapRouteFromChainPromise
+      swapRouteFromChainPromise,
     ]);
 
     let swapRouteRaw: BestSwapRoute | null;
     if (cacheMode === CacheMode.Livemode && swapRouteFromCache) {
-      log.info(`CacheMode is ${cacheMode}, and we are using swapRoute from cache`);
+      log.info(
+        `CacheMode is ${cacheMode}, and we are using swapRoute from cache`
+      );
       swapRouteRaw = swapRouteFromCache;
     } else {
-      log.info(`CacheMode is ${cacheMode}, and we are using materialized swapRoute`);
+      log.info(
+        `CacheMode is ${cacheMode}, and we are using materialized swapRoute`
+      );
       swapRouteRaw = swapRouteFromChain;
     }
 
-    if (cacheMode === CacheMode.Tapcompare && swapRouteFromCache && swapRouteFromChain) {
-      const quoteDiff = swapRouteFromChain.quote.subtract(swapRouteFromCache.quote);
-      const quoteGasAdjustedDiff = swapRouteFromChain.quoteGasAdjusted.subtract(swapRouteFromCache.quoteGasAdjusted);
-      const gasUsedDiff = swapRouteFromChain.estimatedGasUsed.sub(swapRouteFromCache.estimatedGasUsed);
+    if (
+      cacheMode === CacheMode.Tapcompare &&
+      swapRouteFromCache &&
+      swapRouteFromChain
+    ) {
+      const quoteDiff = swapRouteFromChain.quote.subtract(
+        swapRouteFromCache.quote
+      );
+      const quoteGasAdjustedDiff = swapRouteFromChain.quoteGasAdjusted.subtract(
+        swapRouteFromCache.quoteGasAdjusted
+      );
+      const gasUsedDiff = swapRouteFromChain.estimatedGasUsed.sub(
+        swapRouteFromCache.estimatedGasUsed
+      );
 
       // Only log if quoteDiff is different from 0, or if quoteGasAdjustedDiff and gasUsedDiff are both different from 0
-      if (!quoteDiff.equalTo(0) || !(quoteGasAdjustedDiff.equalTo(0) || gasUsedDiff.eq(0))) {
+      if (
+        !quoteDiff.equalTo(0) ||
+        !(quoteGasAdjustedDiff.equalTo(0) || gasUsedDiff.eq(0))
+      ) {
         // Calculates the percentage of the difference with respect to the quoteFromChain (not from cache)
-        const misquotePercent = quoteGasAdjustedDiff.divide(swapRouteFromChain.quoteGasAdjusted).multiply(100);
+        const misquotePercent = quoteGasAdjustedDiff
+          .divide(swapRouteFromChain.quoteGasAdjusted)
+          .multiply(100);
 
         metric.putMetric(
           `TapcompareCachedRoute_quoteGasAdjustedDiffPercent`,
@@ -1090,8 +1175,10 @@ export class AlphaRouter
             quoteFromChain: swapRouteFromChain.quote.toExact(),
             quoteFromCache: swapRouteFromCache.quote.toExact(),
             quoteDiff: quoteDiff.toExact(),
-            quoteGasAdjustedFromChain: swapRouteFromChain.quoteGasAdjusted.toExact(),
-            quoteGasAdjustedFromCache: swapRouteFromCache.quoteGasAdjusted.toExact(),
+            quoteGasAdjustedFromChain:
+              swapRouteFromChain.quoteGasAdjusted.toExact(),
+            quoteGasAdjustedFromCache:
+              swapRouteFromCache.quoteGasAdjusted.toExact(),
             quoteGasAdjustedDiff: quoteGasAdjustedDiff.toExact(),
             gasUsedFromChain: swapRouteFromChain.estimatedGasUsed.toString(),
             gasUsedFromCache: swapRouteFromCache.estimatedGasUsed.toString(),
@@ -1100,8 +1187,12 @@ export class AlphaRouter
             routesFromCache: swapRouteFromCache.routes.toString(),
             amount: amount.toExact(),
             originalAmount: cachedRoutes?.originalAmount,
-            pair: this.tokenPairSymbolTradeTypeChainId(tokenIn, tokenOut, tradeType),
-            blockNumber
+            pair: this.tokenPairSymbolTradeTypeChainId(
+              tokenIn,
+              tokenOut,
+              tradeType
+            ),
+            blockNumber,
           },
           `Comparing quotes between Chain and Cache for ${this.tokenPairSymbolTradeTypeChainId(
             tokenIn,
@@ -1146,31 +1237,37 @@ export class AlphaRouter
       if (routesToCache) {
         // Attempt to insert the entry in cache. This is fire and forget promise.
         // The catch method will prevent any exception from blocking the normal code execution.
-        this.routeCachingProvider.setCachedRoute(routesToCache, amount).then((success) => {
-          const status = success ? 'success' : 'rejected';
-          metric.putMetric(
-            `SetCachedRoute_${status}`,
-            1,
-            MetricLoggerUnit.Count
-          );
-        }).catch((reason) => {
-          log.error(
-            {
-              reason: reason,
-              tokenPair: this.tokenPairSymbolTradeTypeChainId(tokenIn, tokenOut, tradeType),
-            },
-            `SetCachedRoute failure`
-          );
+        this.routeCachingProvider
+          .setCachedRoute(routesToCache, amount)
+          .then((success) => {
+            const status = success ? 'success' : 'rejected';
+            metric.putMetric(
+              `SetCachedRoute_${status}`,
+              1,
+              MetricLoggerUnit.Count
+            );
+          })
+          .catch((reason) => {
+            log.error(
+              {
+                reason: reason,
+                tokenPair: this.tokenPairSymbolTradeTypeChainId(
+                  tokenIn,
+                  tokenOut,
+                  tradeType
+                ),
+              },
+              `SetCachedRoute failure`
+            );
 
-          metric.putMetric(
-            `SetCachedRoute_failure`,
-            1,
-            MetricLoggerUnit.Count
-          );
-        });
+            metric.putMetric(
+              `SetCachedRoute_failure`,
+              1,
+              MetricLoggerUnit.Count
+            );
+          });
       }
     }
-
 
     metric.putMetric(
       `QuoteFoundForChain${this.chainId}`,
@@ -1269,18 +1366,21 @@ export class AlphaRouter
     );
     const quotePromises: Promise<GetQuotesResult>[] = [];
 
-    const v3Routes = cachedRoutes.routes.filter((route) => route.protocol === Protocol.V3);
-    const v2Routes = cachedRoutes.routes.filter((route) => route.protocol === Protocol.V2);
-    const mixedRoutes = cachedRoutes.routes.filter((route) => route.protocol === Protocol.MIXED);
+    const v3Routes = cachedRoutes.routes.filter(
+      (route) => route.protocol === Protocol.V3
+    );
+    const v2Routes = cachedRoutes.routes.filter(
+      (route) => route.protocol === Protocol.V2
+    );
+    const mixedRoutes = cachedRoutes.routes.filter(
+      (route) => route.protocol === Protocol.MIXED
+    );
 
     let percents: number[];
     let amounts: CurrencyAmount[];
     if (cachedRoutes.routes.length > 1) {
       // If we have more than 1 route, we will quote the different percents for it, following the regular process
-      [percents, amounts] = this.getAmountDistribution(
-        amount,
-        routingConfig
-      );
+      [percents, amounts] = this.getAmountDistribution(amount, routingConfig);
     } else if (cachedRoutes.routes.length == 1) {
       [percents, amounts] = [[100], [amount]];
     } else {
@@ -1289,92 +1389,119 @@ export class AlphaRouter
     }
 
     if (v3Routes.length > 0) {
-      const v3RoutesFromCache: V3Route[] = v3Routes.map((cachedRoute) => cachedRoute.route as V3Route);
-      metric.putMetric('SwapRouteFromCache_V3_GetQuotes_Request', 1, MetricLoggerUnit.Count);
+      const v3RoutesFromCache: V3Route[] = v3Routes.map(
+        (cachedRoute) => cachedRoute.route as V3Route
+      );
+      metric.putMetric(
+        'SwapRouteFromCache_V3_GetQuotes_Request',
+        1,
+        MetricLoggerUnit.Count
+      );
 
       const beforeGetQuotes = Date.now();
 
       quotePromises.push(
-        this.v3Quoter.getQuotes(
-          v3RoutesFromCache,
-          amounts,
-          percents,
-          quoteToken,
-          tradeType,
-          routingConfig,
-          undefined,
-          v3GasModel
-        ).then((result) => {
-          metric.putMetric(
-            `SwapRouteFromCache_V3_GetQuotes_Load`,
-            Date.now() - beforeGetQuotes,
-            MetricLoggerUnit.Milliseconds
-          );
+        this.v3Quoter
+          .getQuotes(
+            v3RoutesFromCache,
+            amounts,
+            percents,
+            quoteToken,
+            tradeType,
+            routingConfig,
+            undefined,
+            v3GasModel
+          )
+          .then((result) => {
+            metric.putMetric(
+              `SwapRouteFromCache_V3_GetQuotes_Load`,
+              Date.now() - beforeGetQuotes,
+              MetricLoggerUnit.Milliseconds
+            );
 
-          return result;
-        })
+            return result;
+          })
       );
     }
 
     if (v2Routes.length > 0) {
-      const v2RoutesFromCache: V2Route[] = v2Routes.map((cachedRoute) => cachedRoute.route as V2Route);
-      metric.putMetric('SwapRouteFromCache_V2_GetQuotes_Request', 1, MetricLoggerUnit.Count);
+      const v2RoutesFromCache: V2Route[] = v2Routes.map(
+        (cachedRoute) => cachedRoute.route as V2Route
+      );
+      metric.putMetric(
+        'SwapRouteFromCache_V2_GetQuotes_Request',
+        1,
+        MetricLoggerUnit.Count
+      );
 
       const beforeGetQuotes = Date.now();
 
       quotePromises.push(
-        this.v2Quoter.refreshRoutesThenGetQuotes(
-          cachedRoutes.tokenIn,
-          cachedRoutes.tokenOut,
-          v2RoutesFromCache,
-          amounts,
-          percents,
-          quoteToken,
-          tradeType,
-          routingConfig,
-          gasPriceWei
-        ).then((result) => {
-          metric.putMetric(
-            `SwapRouteFromCache_V2_GetQuotes_Load`,
-            Date.now() - beforeGetQuotes,
-            MetricLoggerUnit.Milliseconds
-          );
+        this.v2Quoter
+          .refreshRoutesThenGetQuotes(
+            cachedRoutes.tokenIn,
+            cachedRoutes.tokenOut,
+            v2RoutesFromCache,
+            amounts,
+            percents,
+            quoteToken,
+            tradeType,
+            routingConfig,
+            gasPriceWei
+          )
+          .then((result) => {
+            metric.putMetric(
+              `SwapRouteFromCache_V2_GetQuotes_Load`,
+              Date.now() - beforeGetQuotes,
+              MetricLoggerUnit.Milliseconds
+            );
 
-          return result;
-        })
+            return result;
+          })
       );
     }
 
     if (mixedRoutes.length > 0) {
-      const mixedRoutesFromCache: MixedRoute[] = mixedRoutes.map((cachedRoute) => cachedRoute.route as MixedRoute);
-      metric.putMetric('SwapRouteFromCache_Mixed_GetQuotes_Request', 1, MetricLoggerUnit.Count);
+      const mixedRoutesFromCache: MixedRoute[] = mixedRoutes.map(
+        (cachedRoute) => cachedRoute.route as MixedRoute
+      );
+      metric.putMetric(
+        'SwapRouteFromCache_Mixed_GetQuotes_Request',
+        1,
+        MetricLoggerUnit.Count
+      );
 
       const beforeGetQuotes = Date.now();
 
       quotePromises.push(
-        this.mixedQuoter.getQuotes(
-          mixedRoutesFromCache,
-          amounts,
-          percents,
-          quoteToken,
-          tradeType,
-          routingConfig,
-          undefined,
-          mixedRouteGasModel
-        ).then((result) => {
-          metric.putMetric(
-            `SwapRouteFromCache_Mixed_GetQuotes_Load`,
-            Date.now() - beforeGetQuotes,
-            MetricLoggerUnit.Milliseconds
-          );
+        this.mixedQuoter
+          .getQuotes(
+            mixedRoutesFromCache,
+            amounts,
+            percents,
+            quoteToken,
+            tradeType,
+            routingConfig,
+            undefined,
+            mixedRouteGasModel
+          )
+          .then((result) => {
+            metric.putMetric(
+              `SwapRouteFromCache_Mixed_GetQuotes_Load`,
+              Date.now() - beforeGetQuotes,
+              MetricLoggerUnit.Milliseconds
+            );
 
-          return result;
-        })
+            return result;
+          })
       );
     }
 
     const getQuotesResults = await Promise.all(quotePromises);
-    const allRoutesWithValidQuotes = _.flatMap(getQuotesResults, (quoteResult) => quoteResult.routesWithValidQuotes);
+    const allRoutesWithValidQuotes = _.flatMap(
+      getQuotesResults,
+      (quoteResult) => quoteResult.routesWithValidQuotes
+    );
 
     return getBestSwapRoute(
       amount,
@@ -1411,13 +1538,17 @@ export class AlphaRouter
     const v3ProtocolSpecified = protocols.includes(Protocol.V3);
     const v2ProtocolSpecified = protocols.includes(Protocol.V2);
     const v2SupportedInChain = V2_SUPPORTED.includes(this.chainId);
-    const shouldQueryMixedProtocol = protocols.includes(Protocol.MIXED) || (noProtocolsSpecified && v2SupportedInChain);
-    const mixedProtocolAllowed = [ChainId.MAINNET, ChainId.GOERLI].includes(this.chainId) &&
+    const shouldQueryMixedProtocol =
+      protocols.includes(Protocol.MIXED) ||
+      (noProtocolsSpecified && v2SupportedInChain);
+    const mixedProtocolAllowed =
+      [ChainId.MAINNET, ChainId.GOERLI].includes(this.chainId) &&
       tradeType === TradeType.EXACT_INPUT;
 
     const beforeGetCandidates = Date.now();
 
-    let v3CandidatePoolsPromise: Promise<V3CandidatePools | undefined> = Promise.resolve(undefined);
+    let v3CandidatePoolsPromise: Promise<V3CandidatePools | undefined> =
+      Promise.resolve(undefined);
     if (
       v3ProtocolSpecified ||
       noProtocolsSpecified ||
@@ -1434,12 +1565,17 @@ export class AlphaRouter
         routingConfig,
         chainId: this.chainId,
       }).then((candidatePools) => {
-        metric.putMetric('GetV3CandidatePools', Date.now() - beforeGetCandidates, MetricLoggerUnit.Milliseconds);
+        metric.putMetric(
+          'GetV3CandidatePools',
+          Date.now() - beforeGetCandidates,
+          MetricLoggerUnit.Milliseconds
+        );
         return candidatePools;
       });
     }
 
-    let v2CandidatePoolsPromise: Promise<V2CandidatePools | undefined> = Promise.resolve(undefined);
+    let v2CandidatePoolsPromise: Promise<V2CandidatePools | undefined> =
+      Promise.resolve(undefined);
     if (
       (v2SupportedInChain && (v2ProtocolSpecified || noProtocolsSpecified)) ||
       (shouldQueryMixedProtocol && mixedProtocolAllowed)
@@ -1458,7 +1594,11 @@ export class AlphaRouter
         routingConfig,
         chainId: this.chainId,
       }).then((candidatePools) => {
-        metric.putMetric('GetV2CandidatePools', Date.now() - beforeGetCandidates, MetricLoggerUnit.Milliseconds);
+        metric.putMetric(
+          'GetV2CandidatePools',
+          Date.now() - beforeGetCandidates,
+          MetricLoggerUnit.Milliseconds
+        );
         return candidatePools;
       });
     }
@@ -1469,30 +1609,36 @@ export class AlphaRouter
     if (v3ProtocolSpecified || noProtocolsSpecified) {
       log.info({ protocols, tradeType }, 'Routing across V3');
 
-      metric.putMetric('SwapRouteFromChain_V3_GetRoutesThenQuotes_Request', 1, MetricLoggerUnit.Count);
+      metric.putMetric(
+        'SwapRouteFromChain_V3_GetRoutesThenQuotes_Request',
+        1,
+        MetricLoggerUnit.Count
+      );
       const beforeGetRoutesThenQuotes = Date.now();
 
       quotePromises.push(
         v3CandidatePoolsPromise.then((v3CandidatePools) =>
-          this.v3Quoter.getRoutesThenQuotes(
-            tokenIn,
-            tokenOut,
-            amounts,
-            percents,
-            quoteToken,
-            v3CandidatePools!,
-            tradeType,
-            routingConfig,
-            v3GasModel
-          ).then((result) => {
-            metric.putMetric(
-              `SwapRouteFromChain_V3_GetRoutesThenQuotes_Load`,
-              Date.now() - beforeGetRoutesThenQuotes,
-              MetricLoggerUnit.Milliseconds
-            );
+          this.v3Quoter
+            .getRoutesThenQuotes(
+              tokenIn,
+              tokenOut,
+              amounts,
+              percents,
+              quoteToken,
+              v3CandidatePools!,
+              tradeType,
+              routingConfig,
+              v3GasModel
+            )
+            .then((result) => {
+              metric.putMetric(
+                `SwapRouteFromChain_V3_GetRoutesThenQuotes_Load`,
+                Date.now() - beforeGetRoutesThenQuotes,
+                MetricLoggerUnit.Milliseconds
+              );
 
-            return result;
-          })
+              return result;
+            })
         )
       );
     }
@@ -1501,31 +1647,37 @@ export class AlphaRouter
     if (v2SupportedInChain && (v2ProtocolSpecified || noProtocolsSpecified)) {
       log.info({ protocols, tradeType }, 'Routing across V2');
 
-      metric.putMetric('SwapRouteFromChain_V2_GetRoutesThenQuotes_Request', 1, MetricLoggerUnit.Count);
+      metric.putMetric(
+        'SwapRouteFromChain_V2_GetRoutesThenQuotes_Request',
+        1,
+        MetricLoggerUnit.Count
+      );
       const beforeGetRoutesThenQuotes = Date.now();
 
       quotePromises.push(
         v2CandidatePoolsPromise.then((v2CandidatePools) =>
-          this.v2Quoter.getRoutesThenQuotes(
-            tokenIn,
-            tokenOut,
-            amounts,
-            percents,
-            quoteToken,
-            v2CandidatePools!,
-            tradeType,
-            routingConfig,
-            undefined,
-            gasPriceWei
-          ).then((result) => {
-            metric.putMetric(
-              `SwapRouteFromChain_V2_GetRoutesThenQuotes_Load`,
-              Date.now() - beforeGetRoutesThenQuotes,
-              MetricLoggerUnit.Milliseconds
-            );
+          this.v2Quoter
+            .getRoutesThenQuotes(
+              tokenIn,
+              tokenOut,
+              amounts,
+              percents,
+              quoteToken,
+              v2CandidatePools!,
+              tradeType,
+              routingConfig,
+              undefined,
+              gasPriceWei
+            )
+            .then((result) => {
+              metric.putMetric(
+                `SwapRouteFromChain_V2_GetRoutesThenQuotes_Load`,
+                Date.now() - beforeGetRoutesThenQuotes,
+                MetricLoggerUnit.Milliseconds
+              );
 
-            return result;
-          })
+              return result;
+            })
         )
       );
     }
@@ -1536,30 +1688,37 @@ export class AlphaRouter
     if (shouldQueryMixedProtocol && mixedProtocolAllowed) {
       log.info({ protocols, tradeType }, 'Routing across MixedRoutes');
 
-      metric.putMetric('SwapRouteFromChain_Mixed_GetRoutesThenQuotes_Request', 1, MetricLoggerUnit.Count);
+      metric.putMetric(
+        'SwapRouteFromChain_Mixed_GetRoutesThenQuotes_Request',
+        1,
+        MetricLoggerUnit.Count
+      );
       const beforeGetRoutesThenQuotes = Date.now();
 
       quotePromises.push(
-        Promise.all([v3CandidatePoolsPromise, v2CandidatePoolsPromise]).then(([v3CandidatePools, v2CandidatePools]) =>
-          this.mixedQuoter.getRoutesThenQuotes(
-            tokenIn,
-            tokenOut,
-            amounts,
-            percents,
-            quoteToken,
-            [v3CandidatePools!, v2CandidatePools!],
-            tradeType,
-            routingConfig,
-            mixedRouteGasModel
-          ).then((result) => {
-            metric.putMetric(
-              `SwapRouteFromChain_Mixed_GetRoutesThenQuotes_Load`,
-              Date.now() - beforeGetRoutesThenQuotes,
-              MetricLoggerUnit.Milliseconds
-            );
+        Promise.all([v3CandidatePoolsPromise, v2CandidatePoolsPromise]).then(
+          ([v3CandidatePools, v2CandidatePools]) =>
+            this.mixedQuoter
+              .getRoutesThenQuotes(
+                tokenIn,
+                tokenOut,
+                amounts,
+                percents,
+                quoteToken,
+                [v3CandidatePools!, v2CandidatePools!],
+                tradeType,
+                routingConfig,
+                mixedRouteGasModel
+              )
+              .then((result) => {
+                metric.putMetric(
+                  `SwapRouteFromChain_Mixed_GetRoutesThenQuotes_Load`,
+                  Date.now() - beforeGetRoutesThenQuotes,
+                  MetricLoggerUnit.Milliseconds
+                );
 
-            return result;
-          })
+                return result;
+              })
         )
       );
     }
@@ -1602,20 +1761,30 @@ export class AlphaRouter
     return tradeType === TradeType.EXACT_INPUT ? 'ExactIn' : 'ExactOut';
   }
 
-  private tokenPairSymbolTradeTypeChainId(tokenIn: Token, tokenOut: Token, tradeType: TradeType) {
-    return `${tokenIn.symbol}/${tokenOut.symbol}/${this.tradeTypeStr(tradeType)}/${this.chainId}`;
+  private tokenPairSymbolTradeTypeChainId(
+    tokenIn: Token,
+    tokenOut: Token,
+    tradeType: TradeType
+  ) {
+    return `${tokenIn.symbol}/${tokenOut.symbol}/${this.tradeTypeStr(
+      tradeType
+    )}/${this.chainId}`;
   }
 
-  private determineCurrencyInOutFromTradeType(tradeType: TradeType, amount: CurrencyAmount, quoteCurrency: Currency) {
+  private determineCurrencyInOutFromTradeType(
+    tradeType: TradeType,
+    amount: CurrencyAmount,
+    quoteCurrency: Currency
+  ) {
     if (tradeType === TradeType.EXACT_INPUT) {
       return {
         currencyIn: amount.currency,
-        currencyOut: quoteCurrency
+        currencyOut: quoteCurrency,
       };
     } else {
       return {
         currencyIn: quoteCurrency,
-        currencyOut: amount.currency
+        currencyOut: amount.currency,
       };
     }
   }
@@ -1641,10 +1810,9 @@ export class AlphaRouter
     amountToken: Token,
     quoteToken: Token,
     providerConfig?: ProviderConfig
-  ): Promise<[
-    IGasModel<V3RouteWithValidQuote>,
-    IGasModel<MixedRouteWithValidQuote>
-  ]> {
+  ): Promise<
+    [IGasModel<V3RouteWithValidQuote>, IGasModel<MixedRouteWithValidQuote>]
+  > {
     const beforeGasModel = Date.now();
 
     const usdPoolPromise = getHighestLiquidityV3USDPool(
@@ -1653,27 +1821,32 @@ export class AlphaRouter
       providerConfig
     );
     const nativeCurrency = WRAPPED_NATIVE_CURRENCY[this.chainId];
-    const nativeQuoteTokenV3PoolPromise = !quoteToken.equals(nativeCurrency) ? getHighestLiquidityV3NativePool(
-      quoteToken,
-      this.v3PoolProvider,
-      providerConfig
-    ) : Promise.resolve(null);
-    const nativeAmountTokenV3PoolPromise = !amountToken.equals(nativeCurrency) ? getHighestLiquidityV3NativePool(
-      amountToken,
-      this.v3PoolProvider,
-      providerConfig
-    ) : Promise.resolve(null);
+    const nativeQuoteTokenV3PoolPromise = !quoteToken.equals(nativeCurrency)
+      ? getHighestLiquidityV3NativePool(
+          quoteToken,
+          this.v3PoolProvider,
+          providerConfig
+        )
+      : Promise.resolve(null);
+    const nativeAmountTokenV3PoolPromise = !amountToken.equals(nativeCurrency)
+      ? getHighestLiquidityV3NativePool(
+          amountToken,
+          this.v3PoolProvider,
+          providerConfig
+        )
+      : Promise.resolve(null);
 
-    const [usdPool, nativeQuoteTokenV3Pool, nativeAmountTokenV3Pool] = await Promise.all([
-      usdPoolPromise,
-      nativeQuoteTokenV3PoolPromise,
-      nativeAmountTokenV3PoolPromise
-    ]);
+    const [usdPool, nativeQuoteTokenV3Pool, nativeAmountTokenV3Pool] =
+      await Promise.all([
+        usdPoolPromise,
+        nativeQuoteTokenV3PoolPromise,
+        nativeAmountTokenV3PoolPromise,
+      ]);
 
     const pools: LiquidityCalculationPools = {
       usdPool: usdPool,
       nativeQuoteTokenV3Pool: nativeQuoteTokenV3Pool,
-      nativeAmountTokenV3Pool: nativeAmountTokenV3Pool
+      nativeAmountTokenV3Pool: nativeAmountTokenV3Pool,
     };
 
     const v3GasModelPromise = this.v3GasModelFactory.buildGasModel({
@@ -1684,22 +1857,23 @@ export class AlphaRouter
       quoteToken,
       v2poolProvider: this.v2PoolProvider,
       l2GasDataProvider: this.l2GasDataProvider,
-      providerConfig: providerConfig
+      providerConfig: providerConfig,
     });
 
-    const mixedRouteGasModelPromise = this.mixedRouteGasModelFactory.buildGasModel({
-      chainId: this.chainId,
-      gasPriceWei,
-      pools,
-      amountToken,
-      quoteToken,
-      v2poolProvider: this.v2PoolProvider,
-      providerConfig: providerConfig
-    });
+    const mixedRouteGasModelPromise =
+      this.mixedRouteGasModelFactory.buildGasModel({
+        chainId: this.chainId,
+        gasPriceWei,
+        pools,
+        amountToken,
+        quoteToken,
+        v2poolProvider: this.v2PoolProvider,
+        providerConfig: providerConfig,
+      });
 
     const [v3GasModel, mixedRouteGasModel] = await Promise.all([
       v3GasModelPromise,
-      mixedRouteGasModelPromise
+      mixedRouteGasModelPromise,
     ]);
 
     metric.putMetric(
@@ -1962,7 +2136,8 @@ export class AlphaRouter
     quote: CurrencyAmount
   ): Promise<boolean> {
     try {
-      const neededBalance = tradeType === TradeType.EXACT_INPUT ? amount : quote;
+      const neededBalance =
+        tradeType === TradeType.EXACT_INPUT ? amount : quote;
       let balance;
       if (neededBalance.currency.isNative) {
         balance = await this.provider.getBalance(fromAddress);

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -106,6 +106,7 @@ import { MixedRouteHeuristicGasModelFactory } from './gas-models/mixedRoute/mixe
 import { V2HeuristicGasModelFactory } from './gas-models/v2/v2-heuristic-gas-model';
 import { V3HeuristicGasModelFactory } from './gas-models/v3/v3-heuristic-gas-model';
 import { GetQuotesResult, MixedQuoter, V2Quoter, V3Quoter } from './quoters';
+import { NATIVE_OVERHEAD } from './gas-models/v3/gas-costs';
 
 export type AlphaRouterParams = {
   /**

--- a/src/routers/alpha-router/gas-models/gas-model.ts
+++ b/src/routers/alpha-router/gas-models/gas-model.ts
@@ -37,7 +37,11 @@ import {
   WBTC_GOERLI,
 } from '../../../providers/token-provider';
 import { IV2PoolProvider } from '../../../providers/v2/pool-provider';
-import { ArbitrumGasData, IL2GasDataProvider, OptimismGasData, } from '../../../providers/v3/gas-data-provider';
+import {
+  ArbitrumGasData,
+  IL2GasDataProvider,
+  OptimismGasData,
+} from '../../../providers/v3/gas-data-provider';
 import { CurrencyAmount } from '../../../util/amounts';
 import {
   MixedRouteWithValidQuote,
@@ -45,7 +49,6 @@ import {
   V2RouteWithValidQuote,
   V3RouteWithValidQuote,
 } from '../entities/route-with-valid-quote';
-
 
 // When adding new usd gas tokens, ensure the tokens are ordered
 // from tokens with highest decimals to lowest decimals. For example,
@@ -101,10 +104,10 @@ export type BuildV2GasModelFactoryType = {
 };
 
 export type LiquidityCalculationPools = {
-  usdPool: Pool
-  nativeQuoteTokenV3Pool: Pool | null
-  nativeAmountTokenV3Pool: Pool | null
-}
+  usdPool: Pool;
+  nativeQuoteTokenV3Pool: Pool | null;
+  nativeAmountTokenV3Pool: Pool | null;
+};
 
 /**
  * Contains functions for generating gas estimates for given routes.
@@ -148,6 +151,7 @@ export abstract class IV2GasModelFactory {
     gasPriceWei,
     poolProvider,
     token,
+    providerConfig,
   }: BuildV2GasModelFactoryType): Promise<IGasModel<V2RouteWithValidQuote>>;
 }
 

--- a/src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model.ts
@@ -14,7 +14,6 @@ import {
   IV2GasModelFactory,
   usdGasTokensByChain,
 } from '../gas-model';
-import { WRAPPED_NATIVE_OVERHEAD } from '../v3/gas-costs';
 
 // Constant cost for doing any swap regardless of pools.
 export const BASE_SWAP_COST = BigNumber.from(135000); // 115000, bumped up by 20_000 @eric 7/8/2022
@@ -120,10 +119,6 @@ export class V2HeuristicGasModelFactory extends IV2GasModelFactory {
           chainId,
           {
             ...providerConfig,
-            additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(
-              routeWithValidQuote.amount.currency,
-              routeWithValidQuote.quoteToken
-            ),
           }
         );
 

--- a/src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model.ts
@@ -3,6 +3,7 @@ import { ChainId, Token } from '@uniswap/sdk-core';
 import { Pair } from '@uniswap/v2-sdk';
 import _ from 'lodash';
 
+import { ProviderConfig } from '../../../../providers/provider';
 import { IV2PoolProvider } from '../../../../providers/v2/pool-provider';
 import { log, WRAPPED_NATIVE_CURRENCY } from '../../../../util';
 import { CurrencyAmount } from '../../../../util/amounts';
@@ -13,7 +14,7 @@ import {
   IV2GasModelFactory,
   usdGasTokensByChain,
 } from '../gas-model';
-import { ProviderConfig } from '../../../../providers/provider';
+import { WRAPPED_NATIVE_OVERHEAD } from '../v3/gas-costs';
 
 // Constant cost for doing any swap regardless of pools.
 export const BASE_SWAP_COST = BigNumber.from(135000); // 115000, bumped up by 20_000 @eric 7/8/2022
@@ -48,7 +49,7 @@ export class V2HeuristicGasModelFactory extends IV2GasModelFactory {
     gasPriceWei,
     poolProvider,
     token,
-    providerConfig
+    providerConfig,
   }: BuildV2GasModelFactoryType): Promise<IGasModel<V2RouteWithValidQuote>> {
     if (token.equals(WRAPPED_NATIVE_CURRENCY[chainId]!)) {
       const usdPool: Pair = await this.getHighestLiquidityUSDPool(
@@ -62,7 +63,8 @@ export class V2HeuristicGasModelFactory extends IV2GasModelFactory {
           const { gasCostInEth, gasUse } = this.estimateGas(
             routeWithValidQuote,
             gasPriceWei,
-            chainId
+            chainId,
+            providerConfig
           );
 
           const ethToken0 =
@@ -115,7 +117,14 @@ export class V2HeuristicGasModelFactory extends IV2GasModelFactory {
         const { gasCostInEth, gasUse } = this.estimateGas(
           routeWithValidQuote,
           gasPriceWei,
-          chainId
+          chainId,
+          {
+            ...providerConfig,
+            additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(
+              routeWithValidQuote.amount.currency,
+              routeWithValidQuote.quoteToken
+            ),
+          }
         );
 
         if (!ethPool) {
@@ -186,10 +195,15 @@ export class V2HeuristicGasModelFactory extends IV2GasModelFactory {
   private estimateGas(
     routeWithValidQuote: V2RouteWithValidQuote,
     gasPriceWei: BigNumber,
-    chainId: ChainId
+    chainId: ChainId,
+    providerConfig?: ProviderConfig
   ) {
     const hops = routeWithValidQuote.route.pairs.length;
-    const gasUse = BASE_SWAP_COST.add(COST_PER_EXTRA_HOP.mul(hops - 1));
+    let gasUse = BASE_SWAP_COST.add(COST_PER_EXTRA_HOP.mul(hops - 1));
+
+    if (providerConfig?.additionalGasOverhead) {
+      gasUse = gasUse.add(providerConfig.additionalGasOverhead);
+    }
 
     const totalGasCostWei = gasPriceWei.mul(gasUse);
 
@@ -207,11 +221,14 @@ export class V2HeuristicGasModelFactory extends IV2GasModelFactory {
     chainId: ChainId,
     token: Token,
     poolProvider: IV2PoolProvider,
-    providerConfig?: ProviderConfig,
+    providerConfig?: ProviderConfig
   ): Promise<Pair | null> {
     const weth = WRAPPED_NATIVE_CURRENCY[chainId]!;
 
-    const poolAccessor = await poolProvider.getPools([[weth, token]], providerConfig);
+    const poolAccessor = await poolProvider.getPools(
+      [[weth, token]],
+      providerConfig
+    );
     const pool = poolAccessor.getPool(weth, token);
 
     if (!pool || pool.reserve0.equalTo(0) || pool.reserve1.equalTo(0)) {
@@ -234,7 +251,7 @@ export class V2HeuristicGasModelFactory extends IV2GasModelFactory {
   private async getHighestLiquidityUSDPool(
     chainId: ChainId,
     poolProvider: IV2PoolProvider,
-    providerConfig?: ProviderConfig,
+    providerConfig?: ProviderConfig
   ): Promise<Pair> {
     const usdTokens = usdGasTokensByChain[chainId];
 

--- a/src/routers/alpha-router/gas-models/v3/gas-costs.ts
+++ b/src/routers/alpha-router/gas-models/v3/gas-costs.ts
@@ -121,20 +121,32 @@ export const TOKEN_OVERHEAD = (id: ChainId, route: V3Route): BigNumber => {
 };
 
 // TODO: change per chain
-export const NATIVE_WRAP_OVERHEAD = BigNumber.from(27938);
-export const NATIVE_UNWRAP_OVERHEAD = BigNumber.from(36000);
+export const NATIVE_WRAP_OVERHEAD = (id: ChainId): BigNumber => {
+  switch (id) {
+    default:
+      return BigNumber.from(27938);
+  }
+};
+
+export const NATIVE_UNWRAP_OVERHEAD = (id: ChainId): BigNumber => {
+  switch (id) {
+    default:
+      return BigNumber.from(36000);
+  }
+};
 
 export const NATIVE_OVERHEAD = (
+  chainId: ChainId,
   amount: Currency,
   quote: Currency
 ): BigNumber => {
   if (amount.isNative) {
     // need to wrap eth in
-    return BigNumber.from(27938);
+    return NATIVE_WRAP_OVERHEAD(chainId);
   }
   if (quote.isNative) {
     // need to unwrap eth out
-    return BigNumber.from(36000);
+    return NATIVE_UNWRAP_OVERHEAD(chainId);
   }
   return BigNumber.from(0);
 };

--- a/src/routers/alpha-router/gas-models/v3/gas-costs.ts
+++ b/src/routers/alpha-router/gas-models/v3/gas-costs.ts
@@ -120,6 +120,10 @@ export const TOKEN_OVERHEAD = (id: ChainId, route: V3Route): BigNumber => {
   return overhead;
 };
 
+// TODO: change per chain
+export const NATIVE_WRAP_OVERHEAD = BigNumber.from(27938);
+export const NATIVE_UNWRAP_OVERHEAD = BigNumber.from(36000);
+
 export const WRAPPED_NATIVE_OVERHEAD = (
   amount: Currency,
   quote: Currency

--- a/src/routers/alpha-router/gas-models/v3/gas-costs.ts
+++ b/src/routers/alpha-router/gas-models/v3/gas-costs.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber';
-import { ChainId, Token } from '@uniswap/sdk-core';
+import { ChainId, Currency, Token } from '@uniswap/sdk-core';
 import { AAVE_MAINNET, LIDO_MAINNET } from '../../../../providers';
 
 import { V3Route } from '../../../router';
@@ -118,4 +118,19 @@ export const TOKEN_OVERHEAD = (id: ChainId, route: V3Route): BigNumber => {
   }
 
   return overhead;
+};
+
+export const WRAPPED_NATIVE_OVERHEAD = (
+  amount: Currency,
+  quote: Currency
+): BigNumber => {
+  if (amount.isNative) {
+    // need to wrap eth in
+    return BigNumber.from(27938);
+  }
+  if (quote.isNative) {
+    // need to unwrap eth out
+    return BigNumber.from(36000);
+  }
+  return BigNumber.from(0);
 };

--- a/src/routers/alpha-router/gas-models/v3/gas-costs.ts
+++ b/src/routers/alpha-router/gas-models/v3/gas-costs.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { ChainId, Currency, Token } from '@uniswap/sdk-core';
-import { AAVE_MAINNET, LIDO_MAINNET } from '../../../../providers';
 
+import { AAVE_MAINNET, LIDO_MAINNET } from '../../../../providers';
 import { V3Route } from '../../../router';
 
 // Cost for crossing an uninitialized tick.

--- a/src/routers/alpha-router/gas-models/v3/gas-costs.ts
+++ b/src/routers/alpha-router/gas-models/v3/gas-costs.ts
@@ -124,7 +124,7 @@ export const TOKEN_OVERHEAD = (id: ChainId, route: V3Route): BigNumber => {
 export const NATIVE_WRAP_OVERHEAD = BigNumber.from(27938);
 export const NATIVE_UNWRAP_OVERHEAD = BigNumber.from(36000);
 
-export const WRAPPED_NATIVE_OVERHEAD = (
+export const NATIVE_OVERHEAD = (
   amount: Currency,
   quote: Currency
 ): BigNumber => {

--- a/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
@@ -8,6 +8,7 @@ import {
   SwapType,
   WRAPPED_NATIVE_CURRENCY,
 } from '../../../..';
+import { ProviderConfig } from '../../../../providers/provider';
 import {
   ArbitrumGasData,
   OptimismGasData,
@@ -26,7 +27,6 @@ import {
   IOnChainGasModelFactory,
 } from '../gas-model';
 
-import { ProviderConfig } from '../../../../providers/provider';
 import {
   BASE_SWAP_COST,
   COST_PER_HOP,

--- a/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
@@ -399,11 +399,7 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
       .add(tokenOverhead)
       .add(tickGasUse)
       .add(uninitializedTickGasUse)
-      .add(
-        providerConfig?.additionalGasOverhead
-          ? providerConfig.additionalGasOverhead
-          : BigNumber.from(0)
-      );
+      .add(providerConfig?.additionalGasOverhead ?? BigNumber.from(0));
 
     const baseGasCostWei = gasPriceWei.mul(baseGasUse);
 

--- a/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
@@ -3,15 +3,30 @@ import { ChainId, Percent, Price, TradeType } from '@uniswap/sdk-core';
 import { Pool } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
-import { SwapOptionsUniversalRouter, SwapType, WRAPPED_NATIVE_CURRENCY, } from '../../../..';
-import { ArbitrumGasData, OptimismGasData, } from '../../../../providers/v3/gas-data-provider';
+import {
+  SwapOptionsUniversalRouter,
+  SwapType,
+  WRAPPED_NATIVE_CURRENCY,
+} from '../../../..';
+import {
+  ArbitrumGasData,
+  OptimismGasData,
+} from '../../../../providers/v3/gas-data-provider';
 import { CurrencyAmount } from '../../../../util/amounts';
 import { getL2ToL1GasUsed } from '../../../../util/gas-factory-helpers';
 import { log } from '../../../../util/log';
-import { buildSwapMethodParameters, buildTrade, } from '../../../../util/methodParameters';
+import {
+  buildSwapMethodParameters,
+  buildTrade,
+} from '../../../../util/methodParameters';
 import { V3RouteWithValidQuote } from '../../entities/route-with-valid-quote';
-import { BuildOnChainGasModelFactoryType, IGasModel, IOnChainGasModelFactory, } from '../gas-model';
+import {
+  BuildOnChainGasModelFactoryType,
+  IGasModel,
+  IOnChainGasModelFactory,
+} from '../gas-model';
 
+import { ProviderConfig } from '../../../../providers/provider';
 import {
   BASE_SWAP_COST,
   COST_PER_HOP,
@@ -51,6 +66,7 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
     amountToken,
     quoteToken,
     l2GasDataProvider,
+    providerConfig,
   }: BuildOnChainGasModelFactoryType): Promise<
     IGasModel<V3RouteWithValidQuote>
   > {
@@ -155,7 +171,8 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
         const { totalGasCostNativeCurrency, baseGasUse } = this.estimateGas(
           routeWithValidQuote,
           gasPriceWei,
-          chainId
+          chainId,
+          providerConfig
         );
 
         const token0 = usdPool.token0.address == nativeCurrency.address;
@@ -205,7 +222,8 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
       const { totalGasCostNativeCurrency, baseGasUse } = this.estimateGas(
         routeWithValidQuote,
         gasPriceWei,
-        chainId
+        chainId,
+        providerConfig
       );
 
       let gasCostInTermsOfQuoteToken: CurrencyAmount | null = null;
@@ -349,7 +367,8 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
   private estimateGas(
     routeWithValidQuote: V3RouteWithValidQuote,
     gasPriceWei: BigNumber,
-    chainId: ChainId
+    chainId: ChainId,
+    providerConfig?: ProviderConfig
   ) {
     const totalInitializedTicksCrossed = BigNumber.from(
       Math.max(1, _.sum(routeWithValidQuote.initializedTicksCrossedList))
@@ -379,7 +398,12 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
       .add(hopsGasUse)
       .add(tokenOverhead)
       .add(tickGasUse)
-      .add(uninitializedTickGasUse);
+      .add(uninitializedTickGasUse)
+      .add(
+        providerConfig?.additionalGasOverhead
+          ? providerConfig.additionalGasOverhead
+          : BigNumber.from(0)
+      );
 
     const baseGasCostWei = gasPriceWei.mul(baseGasUse);
 

--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -160,6 +160,10 @@ export class V2Quoter extends BaseQuoter<V2CandidatePools, V2Route> {
       gasPriceWei,
       poolProvider: this.v2PoolProvider,
       token: quoteToken,
+      providerConfig: {
+        // TODO: implement wrap overhead for v2 routes
+        additionalGasOverhead: BigNumber.from(0),
+      },
     });
 
     metric.putMetric(

--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -160,10 +160,7 @@ export class V2Quoter extends BaseQuoter<V2CandidatePools, V2Route> {
       gasPriceWei,
       poolProvider: this.v2PoolProvider,
       token: quoteToken,
-      providerConfig: {
-        // TODO: implement wrap overhead for v2 routes
-        additionalGasOverhead: BigNumber.from(0),
-      },
+      // TODO: implement wrap overhead for v2 routes
     });
 
     metric.putMetric(

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -9,6 +9,7 @@ import {
 } from '@uniswap/sdk-core';
 import { Pair } from '@uniswap/v2-sdk/dist/entities';
 import { FeeAmount, Pool } from '@uniswap/v3-sdk';
+import JSBI from 'jsbi';
 import _ from 'lodash';
 
 import { IV2PoolProvider } from '../providers';
@@ -28,7 +29,6 @@ import {
 } from '../routers';
 import { log, WRAPPED_NATIVE_CURRENCY } from '../util';
 
-import JSBI from 'jsbi';
 import { buildTrade } from './methodParameters';
 
 export async function getV2NativePool(

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -6,6 +6,7 @@ import _ from 'lodash';
 
 import { RouteWithValidQuote } from '../routers/alpha-router';
 import { MixedRoute, V2Route, V3Route } from '../routers/router';
+
 import { V3_CORE_FACTORY_ADDRESSES } from './addresses';
 
 import { CurrencyAmount } from '.';

--- a/test/test-util/mock-data.ts
+++ b/test/test-util/mock-data.ts
@@ -200,6 +200,11 @@ export const USDC_DAI = new Pair(
   CurrencyAmount.fromRawAmount(DAI, 10000000000)
 );
 
+export const WETH_DAI = new Pair(
+  CurrencyAmount.fromRawAmount(DAI, 10000000000),
+  CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[1]!, 10000000000)
+);
+
 export const WBTC_WETH = new Pair(
   CurrencyAmount.fromRawAmount(WBTC, 10000000000),
   CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[1]!, 10000000000)

--- a/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
+++ b/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
@@ -1,64 +1,28 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Protocol } from '@uniswap/router-sdk';
 import { ChainId, TradeType } from '@uniswap/sdk-core';
-import { Pool } from '@uniswap/v3-sdk';
-import sinon from 'sinon';
-import { DAI_MAINNET, USDC_MAINNET, V3Route, V3RouteWithValidQuote } from '../../../../../../build/main';
+import {
+  DAI_MAINNET,
+  USDC_MAINNET,
+  V3Route,
+  V3RouteWithValidQuote,
+} from '../../../../../../build/main';
 import {
   CachedRoutes,
   CurrencyAmount,
   DAI_MAINNET as DAI,
-  IGasModel,
   USDC_MAINNET as USDC,
-  V3PoolProvider
+  V3RouteWithValidQuoteParams,
 } from '../../../../../../src';
+import { USDC_DAI_MEDIUM } from '../../../../../test-util/mock-data';
 import {
-  buildMockV3PoolAccessor,
-  DAI_USDT_LOW,
-  USDC_DAI_LOW,
-  USDC_DAI_MEDIUM,
-  USDC_WETH_LOW,
-  WETH9_USDT_LOW
-} from '../../../../../test-util/mock-data';
+  getMockedV3GasModel,
+  getMockedV3PoolProvider,
+} from '../../../../routers/alpha-router/gas-models/test-util/mocked-dependencies';
 
-export function getMockedV3GasModel(): IGasModel<V3RouteWithValidQuote> {
-  const mockV3GasModel = {
-    estimateGasCost: sinon.stub(),
-  };
-
-  mockV3GasModel.estimateGasCost.callsFake((r) => {
-    return {
-      gasEstimate: BigNumber.from(10000),
-      gasCostInToken: CurrencyAmount.fromRawAmount(r.quoteToken, 0),
-      gasCostInUSD: CurrencyAmount.fromRawAmount(USDC, 0),
-    };
-  });
-
-  return mockV3GasModel;
-}
-
-export function getMockedV3PoolProvider(): V3PoolProvider {
-  const mockV3PoolProvider = sinon.createStubInstance(V3PoolProvider);
-
-  const v3MockPools = [
-    USDC_DAI_LOW,
-    USDC_DAI_MEDIUM,
-    USDC_WETH_LOW,
-    WETH9_USDT_LOW,
-    DAI_USDT_LOW,
-  ];
-
-  mockV3PoolProvider.getPools.resolves(buildMockV3PoolAccessor(v3MockPools));
-  mockV3PoolProvider.getPoolAddress.callsFake((tA, tB, fee) => ({
-    poolAddress: Pool.getAddress(tA, tB, fee),
-    token0: tA,
-    token1: tB,
-  }));
-
-  return mockV3PoolProvider;
-}
-
-export function getV3RouteWithValidQuoteStub(): V3RouteWithValidQuote {
+export function getV3RouteWithValidQuoteStub(
+  overrides?: Partial<V3RouteWithValidQuoteParams>
+): V3RouteWithValidQuote {
   const route = new V3Route([USDC_DAI_MEDIUM], USDC_MAINNET, DAI_MAINNET);
 
   return new V3RouteWithValidQuote({
@@ -66,17 +30,20 @@ export function getV3RouteWithValidQuoteStub(): V3RouteWithValidQuote {
     rawQuote: BigNumber.from(100),
     sqrtPriceX96AfterList: [BigNumber.from(1)],
     initializedTicksCrossedList: [1],
-    quoterGasEstimate: BigNumber.from(100000),
+    quoterGasEstimate: BigNumber.from(100000), // unused
     percent: 100,
     route,
     gasModel: getMockedV3GasModel(),
     quoteToken: DAI,
     tradeType: TradeType.EXACT_INPUT,
     v3PoolProvider: getMockedV3PoolProvider(),
+    ...overrides,
   });
 }
 
-export function getCachedRoutesStub(blockNumber: number): CachedRoutes | undefined {
+export function getCachedRoutesStub(
+  blockNumber: number
+): CachedRoutes | undefined {
   return CachedRoutes.fromRoutesWithValidQuotes(
     [getV3RouteWithValidQuoteStub()],
     ChainId.MAINNET,

--- a/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
+++ b/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
@@ -11,14 +11,23 @@ import {
   CachedRoutes,
   CurrencyAmount,
   DAI_MAINNET as DAI,
+  MixedRoute,
+  MixedRouteWithValidQuote,
+  MixedRouteWithValidQuoteParams,
   USDC_MAINNET as USDC,
   V2Route,
   V2RouteWithValidQuote,
   V2RouteWithValidQuoteParams,
   V3RouteWithValidQuoteParams,
 } from '../../../../../../src';
-import { USDC_DAI, USDC_DAI_MEDIUM } from '../../../../../test-util/mock-data';
 import {
+  USDC_DAI,
+  USDC_DAI_MEDIUM,
+  USDC_WETH_MEDIUM,
+  WETH_DAI,
+} from '../../../../../test-util/mock-data';
+import {
+  getMockedMixedGasModel,
   getMockedV2GasModel,
   getMockedV2PoolProvider,
   getMockedV3GasModel,
@@ -60,6 +69,33 @@ export function getV3RouteWithValidQuoteStub(
     quoteToken: DAI,
     tradeType: TradeType.EXACT_INPUT,
     v3PoolProvider: getMockedV3PoolProvider(),
+    ...overrides,
+  });
+}
+
+export function getMixedRouteWithValidQuoteStub(
+  overrides?: Partial<MixedRouteWithValidQuoteParams>
+): MixedRouteWithValidQuote {
+  const route = new MixedRoute(
+    // v3 USDC -> WETH , v2 WETH -> DAI
+    [USDC_WETH_MEDIUM, WETH_DAI],
+    USDC_MAINNET,
+    DAI_MAINNET
+  );
+
+  return new MixedRouteWithValidQuote({
+    amount: CurrencyAmount.fromRawAmount(USDC, 100),
+    rawQuote: BigNumber.from(100),
+    sqrtPriceX96AfterList: [BigNumber.from(1)],
+    initializedTicksCrossedList: [1],
+    quoterGasEstimate: BigNumber.from(100000), // unused
+    percent: 100,
+    route,
+    mixedRouteGasModel: getMockedMixedGasModel(),
+    quoteToken: DAI,
+    tradeType: TradeType.EXACT_INPUT,
+    v3PoolProvider: getMockedV3PoolProvider(),
+    v2PoolProvider: getMockedV2PoolProvider(),
     ...overrides,
   });
 }

--- a/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
+++ b/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
@@ -12,13 +12,36 @@ import {
   CurrencyAmount,
   DAI_MAINNET as DAI,
   USDC_MAINNET as USDC,
+  V2Route,
+  V2RouteWithValidQuote,
+  V2RouteWithValidQuoteParams,
   V3RouteWithValidQuoteParams,
 } from '../../../../../../src';
-import { USDC_DAI_MEDIUM } from '../../../../../test-util/mock-data';
+import { USDC_DAI, USDC_DAI_MEDIUM } from '../../../../../test-util/mock-data';
 import {
+  getMockedV2GasModel,
+  getMockedV2PoolProvider,
   getMockedV3GasModel,
   getMockedV3PoolProvider,
 } from '../../../../routers/alpha-router/gas-models/test-util/mocked-dependencies';
+
+export function getV2RouteWithValidQuoteStub(
+  overrides?: Partial<V2RouteWithValidQuoteParams>
+): V2RouteWithValidQuote {
+  const route = new V2Route([USDC_DAI], USDC_MAINNET, DAI_MAINNET);
+
+  return new V2RouteWithValidQuote({
+    amount: CurrencyAmount.fromRawAmount(USDC, 100),
+    rawQuote: BigNumber.from(100),
+    percent: 100,
+    route,
+    gasModel: getMockedV2GasModel(),
+    quoteToken: DAI,
+    tradeType: TradeType.EXACT_INPUT,
+    v2PoolProvider: getMockedV2PoolProvider(),
+    ...overrides,
+  });
+}
 
 export function getV3RouteWithValidQuoteStub(
   overrides?: Partial<V3RouteWithValidQuoteParams>

--- a/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
@@ -181,7 +181,11 @@ describe('mixed route gas model tests', () => {
       v2poolProvider: mockedV2PoolProvider,
       l2GasDataProvider: undefined,
       providerConfig: {
-        additionalGasOverhead: NATIVE_OVERHEAD(amountToken, quoteToken),
+        additionalGasOverhead: NATIVE_OVERHEAD(
+          chainId,
+          amountToken,
+          quoteToken
+        ),
       },
     });
 
@@ -198,8 +202,9 @@ describe('mixed route gas model tests', () => {
     });
 
     const { gasEstimate } = mixedGasModel.estimateGasCost(mixedRouteWithQuote);
-    const expectedGasCost =
-      calculateGasEstimate(mixedRouteWithQuote).add(NATIVE_WRAP_OVERHEAD);
+    const expectedGasCost = calculateGasEstimate(mixedRouteWithQuote).add(
+      NATIVE_WRAP_OVERHEAD(chainId)
+    );
 
     expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
   });
@@ -224,7 +229,11 @@ describe('mixed route gas model tests', () => {
       v2poolProvider: mockedV2PoolProvider,
       l2GasDataProvider: undefined,
       providerConfig: {
-        additionalGasOverhead: NATIVE_OVERHEAD(amountToken, quoteToken),
+        additionalGasOverhead: NATIVE_OVERHEAD(
+          chainId,
+          amountToken,
+          quoteToken
+        ),
       },
     });
 
@@ -242,7 +251,7 @@ describe('mixed route gas model tests', () => {
 
     const { gasEstimate } = mixedGasModel.estimateGasCost(mixedRouteWithQuote);
     const expectedGasCost = calculateGasEstimate(mixedRouteWithQuote).add(
-      NATIVE_UNWRAP_OVERHEAD
+      NATIVE_UNWRAP_OVERHEAD(chainId)
     );
 
     expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());

--- a/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
@@ -44,7 +44,7 @@ import {
   getMockedV3PoolProvider,
 } from './test-util/mocked-dependencies';
 
-describe('mixed route gas model', () => {
+describe('mixed route gas model tests', () => {
   const gasPriceWei = BigNumber.from(1000000000);
   const chainId = 1;
   const mixedGasModelFactory = new MixedRouteHeuristicGasModelFactory();

--- a/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
@@ -1,0 +1,252 @@
+import { partitionMixedRouteByProtocol } from '@uniswap/router-sdk';
+import { Currency, CurrencyAmount, Ether, Token } from '@uniswap/sdk-core';
+import { Pair } from '@uniswap/v2-sdk';
+import { Pool } from '@uniswap/v3-sdk';
+import { BigNumber } from 'ethers';
+import _ from 'lodash';
+import {
+  DAI_MAINNET,
+  LiquidityCalculationPools,
+  MixedRoute,
+  MixedRouteWithValidQuote,
+  USDC_MAINNET,
+  V3PoolProvider,
+  WRAPPED_NATIVE_CURRENCY,
+} from '../../../../../src';
+import { ProviderConfig } from '../../../../../src/providers/provider';
+import { MixedRouteHeuristicGasModelFactory } from '../../../../../src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model';
+import {
+  BASE_SWAP_COST as BASE_SWAP_COST_V2,
+  COST_PER_EXTRA_HOP as COST_PER_EXTRA_HOP_V2,
+} from '../../../../../src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model';
+import {
+  BASE_SWAP_COST,
+  COST_PER_HOP,
+  COST_PER_INIT_TICK,
+  COST_PER_UNINIT_TICK,
+  NATIVE_UNWRAP_OVERHEAD,
+  NATIVE_WRAP_OVERHEAD,
+  WRAPPED_NATIVE_OVERHEAD,
+} from '../../../../../src/routers/alpha-router/gas-models/v3/gas-costs';
+import {
+  getHighestLiquidityV3NativePool,
+  getHighestLiquidityV3USDPool,
+} from '../../../../../src/util/gas-factory-helpers';
+import {
+  USDC_DAI,
+  USDC_DAI_MEDIUM,
+  USDC_WETH_MEDIUM,
+  WETH_DAI,
+} from '../../../../test-util/mock-data';
+import { getMixedRouteWithValidQuoteStub } from '../../../providers/caching/route/test-util/mocked-dependencies';
+import {
+  getMockedV2PoolProvider,
+  getMockedV3PoolProvider,
+} from './test-util/mocked-dependencies';
+
+describe('mixed route gas model', () => {
+  const gasPriceWei = BigNumber.from(1000000000);
+  const chainId = 1;
+  const mixedGasModelFactory = new MixedRouteHeuristicGasModelFactory();
+
+  const mockedV3PoolProvider = getMockedV3PoolProvider();
+  const mockedV2PoolProvider = getMockedV2PoolProvider();
+
+  // helper function to get pools for building gas model
+  async function getPools(
+    amountToken: Token,
+    quoteToken: Token,
+    v3PoolProvider: V3PoolProvider,
+    providerConfig: ProviderConfig
+  ): Promise<LiquidityCalculationPools> {
+    const usdPoolPromise = getHighestLiquidityV3USDPool(
+      chainId,
+      v3PoolProvider,
+      providerConfig
+    );
+    const nativeCurrency = WRAPPED_NATIVE_CURRENCY[chainId];
+    const nativeQuoteTokenV3PoolPromise = !quoteToken.equals(nativeCurrency)
+      ? getHighestLiquidityV3NativePool(
+          quoteToken,
+          v3PoolProvider,
+          providerConfig
+        )
+      : Promise.resolve(null);
+    const nativeAmountTokenV3PoolPromise = !amountToken.equals(nativeCurrency)
+      ? getHighestLiquidityV3NativePool(
+          amountToken,
+          v3PoolProvider,
+          providerConfig
+        )
+      : Promise.resolve(null);
+
+    const [usdPool, nativeQuoteTokenV3Pool, nativeAmountTokenV3Pool] =
+      await Promise.all([
+        usdPoolPromise,
+        nativeQuoteTokenV3PoolPromise,
+        nativeAmountTokenV3PoolPromise,
+      ]);
+
+    const pools: LiquidityCalculationPools = {
+      usdPool: usdPool,
+      nativeQuoteTokenV3Pool: nativeQuoteTokenV3Pool,
+      nativeAmountTokenV3Pool: nativeAmountTokenV3Pool,
+    };
+    return pools;
+  }
+
+  function calculateGasEstimate(routeWithValidQuote: MixedRouteWithValidQuote) {
+    // copied from mixed route heuristic gas model
+    let baseGasUse = BigNumber.from(0);
+
+    const route = routeWithValidQuote.route;
+
+    const res = partitionMixedRouteByProtocol(route);
+    res.map((section: (Pair | Pool)[]) => {
+      if (section.every((pool) => pool instanceof Pool)) {
+        baseGasUse = baseGasUse.add(BASE_SWAP_COST(chainId));
+        baseGasUse = baseGasUse.add(COST_PER_HOP(chainId).mul(section.length));
+      } else if (section.every((pool) => pool instanceof Pair)) {
+        baseGasUse = baseGasUse.add(BASE_SWAP_COST_V2);
+        baseGasUse = baseGasUse.add(
+          /// same behavior in v2 heuristic gas model factory
+          COST_PER_EXTRA_HOP_V2.mul(section.length - 1)
+        );
+      }
+    });
+
+    const totalInitializedTicksCrossed = BigNumber.from(
+      Math.max(1, _.sum(routeWithValidQuote.initializedTicksCrossedList))
+    );
+
+    const tickGasUse = COST_PER_INIT_TICK(chainId).mul(
+      totalInitializedTicksCrossed
+    );
+    const uninitializedTickGasUse = COST_PER_UNINIT_TICK.mul(0);
+
+    // base estimate gas used based on chainId estimates for hops and ticks gas useage
+    baseGasUse = baseGasUse.add(tickGasUse).add(uninitializedTickGasUse);
+    return baseGasUse;
+  }
+
+  it('returns correct gas estimate for a mixed route | hops: 2 | ticks 1', async () => {
+    const amountToken = USDC_MAINNET;
+    const quoteToken = DAI_MAINNET;
+
+    const pools = await getPools(
+      amountToken,
+      quoteToken,
+      mockedV3PoolProvider,
+      {}
+    );
+
+    const mixedGasModel = await mixedGasModelFactory.buildGasModel({
+      chainId: chainId,
+      gasPriceWei,
+      pools,
+      amountToken,
+      quoteToken,
+      v2poolProvider: mockedV2PoolProvider,
+      providerConfig: {},
+    });
+
+    const mixedRouteWithQuote = getMixedRouteWithValidQuoteStub({
+      mixedRouteGasModel: mixedGasModel,
+      initializedTicksCrossedList: [1],
+    });
+
+    const { gasEstimate } = mixedGasModel.estimateGasCost(mixedRouteWithQuote);
+    const expectedGasCost = calculateGasEstimate(mixedRouteWithQuote);
+
+    expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
+  });
+
+  it('applies overhead when token in is native eth', async () => {
+    const amountToken = Ether.onChain(1) as Currency;
+    const quoteToken = DAI_MAINNET;
+
+    const pools = await getPools(
+      amountToken.wrapped,
+      quoteToken,
+      mockedV3PoolProvider,
+      {}
+    );
+
+    const mixedGasModel = await mixedGasModelFactory.buildGasModel({
+      chainId: chainId,
+      gasPriceWei,
+      pools,
+      amountToken: amountToken.wrapped,
+      quoteToken,
+      v2poolProvider: mockedV2PoolProvider,
+      l2GasDataProvider: undefined,
+      providerConfig: {
+        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken),
+      },
+    });
+
+    const mixedRouteWithQuote = getMixedRouteWithValidQuoteStub({
+      amount: CurrencyAmount.fromRawAmount(amountToken, 1),
+      mixedRouteGasModel: mixedGasModel,
+      route: new MixedRoute(
+        [USDC_WETH_MEDIUM, USDC_DAI],
+        WRAPPED_NATIVE_CURRENCY[1],
+        DAI_MAINNET
+      ),
+      quoteToken: DAI_MAINNET,
+      initializedTicksCrossedList: [1],
+    });
+
+    const { gasEstimate } = mixedGasModel.estimateGasCost(mixedRouteWithQuote);
+    const expectedGasCost =
+      calculateGasEstimate(mixedRouteWithQuote).add(NATIVE_WRAP_OVERHEAD);
+
+    expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
+  });
+
+  it('applies overhead when token out is native eth', async () => {
+    const amountToken = USDC_MAINNET;
+    const quoteToken = Ether.onChain(1) as Currency;
+
+    const pools = await getPools(
+      amountToken,
+      quoteToken.wrapped,
+      mockedV3PoolProvider,
+      {}
+    );
+
+    const mixedGasModel = await mixedGasModelFactory.buildGasModel({
+      chainId: chainId,
+      gasPriceWei,
+      pools,
+      amountToken,
+      quoteToken: quoteToken.wrapped,
+      v2poolProvider: mockedV2PoolProvider,
+      l2GasDataProvider: undefined,
+      providerConfig: {
+        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken),
+      },
+    });
+
+    const mixedRouteWithQuote = getMixedRouteWithValidQuoteStub({
+      amount: CurrencyAmount.fromRawAmount(amountToken, 100),
+      mixedRouteGasModel: mixedGasModel,
+      route: new MixedRoute(
+        [USDC_DAI_MEDIUM, WETH_DAI],
+        USDC_MAINNET,
+        WRAPPED_NATIVE_CURRENCY[1]
+      ),
+      quoteToken: WRAPPED_NATIVE_CURRENCY[1],
+      initializedTicksCrossedList: [1],
+    });
+
+    const { gasEstimate } = mixedGasModel.estimateGasCost(mixedRouteWithQuote);
+    const expectedGasCost = calculateGasEstimate(mixedRouteWithQuote).add(
+      NATIVE_UNWRAP_OVERHEAD
+    );
+
+    expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
+  });
+
+  // TODO: splits, multiple hops, token overheads, gasCostInToken, gasCostInUSD
+});

--- a/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
@@ -24,9 +24,9 @@ import {
   COST_PER_HOP,
   COST_PER_INIT_TICK,
   COST_PER_UNINIT_TICK,
+  NATIVE_OVERHEAD,
   NATIVE_UNWRAP_OVERHEAD,
   NATIVE_WRAP_OVERHEAD,
-  WRAPPED_NATIVE_OVERHEAD,
 } from '../../../../../src/routers/alpha-router/gas-models/v3/gas-costs';
 import {
   getHighestLiquidityV3NativePool,
@@ -181,7 +181,7 @@ describe('mixed route gas model tests', () => {
       v2poolProvider: mockedV2PoolProvider,
       l2GasDataProvider: undefined,
       providerConfig: {
-        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken),
+        additionalGasOverhead: NATIVE_OVERHEAD(amountToken, quoteToken),
       },
     });
 
@@ -224,7 +224,7 @@ describe('mixed route gas model tests', () => {
       v2poolProvider: mockedV2PoolProvider,
       l2GasDataProvider: undefined,
       providerConfig: {
-        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken),
+        additionalGasOverhead: NATIVE_OVERHEAD(amountToken, quoteToken),
       },
     });
 

--- a/test/unit/routers/alpha-router/gas-models/test-util/mocked-dependencies.ts
+++ b/test/unit/routers/alpha-router/gas-models/test-util/mocked-dependencies.ts
@@ -6,6 +6,7 @@ import { V3RouteWithValidQuote } from '../../../../../../build/main';
 import {
   CurrencyAmount,
   IGasModel,
+  MixedRouteWithValidQuote,
   USDC_MAINNET as USDC,
   V2PoolProvider,
   V2RouteWithValidQuote,
@@ -26,6 +27,22 @@ import {
   WETH9_USDT_LOW,
   WETH_USDT,
 } from '../../../../../test-util/mock-data';
+
+export function getMockedMixedGasModel(): IGasModel<MixedRouteWithValidQuote> {
+  const mockMixedGasModel = {
+    estimateGasCost: sinon.stub(),
+  };
+
+  mockMixedGasModel.estimateGasCost.callsFake((r) => {
+    return {
+      gasEstimate: BigNumber.from(10000),
+      gasCostInToken: CurrencyAmount.fromRawAmount(r.quoteToken, 0),
+      gasCostInUSD: CurrencyAmount.fromRawAmount(USDC, 0),
+    };
+  });
+
+  return mockMixedGasModel;
+}
 
 export function getMockedV3GasModel(): IGasModel<V3RouteWithValidQuote> {
   const mockV3GasModel = {

--- a/test/unit/routers/alpha-router/gas-models/test-util/mocked-dependencies.ts
+++ b/test/unit/routers/alpha-router/gas-models/test-util/mocked-dependencies.ts
@@ -8,6 +8,7 @@ import {
   IGasModel,
   USDC_MAINNET as USDC,
   V2PoolProvider,
+  V2RouteWithValidQuote,
   V3PoolProvider,
 } from '../../../../../../src';
 import {
@@ -64,9 +65,32 @@ export function getMockedV3PoolProvider(): V3PoolProvider {
   return mockV3PoolProvider;
 }
 
+export function getMockedV2GasModel(): IGasModel<V2RouteWithValidQuote> {
+  const mockV2GasModel = {
+    estimateGasCost: sinon.stub(),
+  };
+
+  mockV2GasModel.estimateGasCost.callsFake((r) => {
+    return {
+      gasEstimate: BigNumber.from(10000),
+      gasCostInToken: CurrencyAmount.fromRawAmount(r.quoteToken, 0),
+      gasCostInUSD: CurrencyAmount.fromRawAmount(USDC, 0),
+    };
+  });
+
+  return mockV2GasModel;
+}
+
 export function getMockedV2PoolProvider(): V2PoolProvider {
   const mockV2PoolProvider = sinon.createStubInstance(V2PoolProvider);
-  const v2MockPools = [DAI_USDT, USDC_WETH, WETH_USDT, USDC_DAI, WBTC_WETH];
+  const v2MockPools = [
+    DAI_USDT,
+    USDC_WETH,
+    WETH_USDT,
+    USDC_DAI,
+    WBTC_WETH,
+    // WETH_DAI,
+  ];
   mockV2PoolProvider.getPools.resolves(buildMockV2PoolAccessor(v2MockPools));
   mockV2PoolProvider.getPoolAddress.callsFake((tA, tB) => ({
     poolAddress: Pair.getAddress(tA, tB),

--- a/test/unit/routers/alpha-router/gas-models/test-util/mocked-dependencies.ts
+++ b/test/unit/routers/alpha-router/gas-models/test-util/mocked-dependencies.ts
@@ -100,14 +100,7 @@ export function getMockedV2GasModel(): IGasModel<V2RouteWithValidQuote> {
 
 export function getMockedV2PoolProvider(): V2PoolProvider {
   const mockV2PoolProvider = sinon.createStubInstance(V2PoolProvider);
-  const v2MockPools = [
-    DAI_USDT,
-    USDC_WETH,
-    WETH_USDT,
-    USDC_DAI,
-    WBTC_WETH,
-    // WETH_DAI,
-  ];
+  const v2MockPools = [DAI_USDT, USDC_WETH, WETH_USDT, USDC_DAI, WBTC_WETH];
   mockV2PoolProvider.getPools.resolves(buildMockV2PoolAccessor(v2MockPools));
   mockV2PoolProvider.getPoolAddress.callsFake((tA, tB) => ({
     poolAddress: Pair.getAddress(tA, tB),

--- a/test/unit/routers/alpha-router/gas-models/test-util/mocked-dependencies.ts
+++ b/test/unit/routers/alpha-router/gas-models/test-util/mocked-dependencies.ts
@@ -1,0 +1,77 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { Pair } from '@uniswap/v2-sdk';
+import { Pool } from '@uniswap/v3-sdk';
+import sinon from 'sinon';
+import { V3RouteWithValidQuote } from '../../../../../../build/main';
+import {
+  CurrencyAmount,
+  IGasModel,
+  USDC_MAINNET as USDC,
+  V2PoolProvider,
+  V3PoolProvider,
+} from '../../../../../../src';
+import {
+  buildMockV2PoolAccessor,
+  buildMockV3PoolAccessor,
+  DAI_USDT,
+  DAI_USDT_LOW,
+  USDC_DAI,
+  USDC_DAI_LOW,
+  USDC_DAI_MEDIUM,
+  USDC_USDT_MEDIUM,
+  USDC_WETH,
+  USDC_WETH_LOW,
+  WBTC_WETH,
+  WETH9_USDT_LOW,
+  WETH_USDT,
+} from '../../../../../test-util/mock-data';
+
+export function getMockedV3GasModel(): IGasModel<V3RouteWithValidQuote> {
+  const mockV3GasModel = {
+    estimateGasCost: sinon.stub(),
+  };
+
+  mockV3GasModel.estimateGasCost.callsFake((r) => {
+    return {
+      gasEstimate: BigNumber.from(10000),
+      gasCostInToken: CurrencyAmount.fromRawAmount(r.quoteToken, 0),
+      gasCostInUSD: CurrencyAmount.fromRawAmount(USDC, 0),
+    };
+  });
+
+  return mockV3GasModel;
+}
+
+export function getMockedV3PoolProvider(): V3PoolProvider {
+  const mockV3PoolProvider = sinon.createStubInstance(V3PoolProvider);
+
+  const v3MockPools = [
+    USDC_DAI_LOW,
+    USDC_DAI_MEDIUM,
+    USDC_WETH_LOW,
+    WETH9_USDT_LOW,
+    DAI_USDT_LOW,
+    USDC_USDT_MEDIUM,
+  ];
+
+  mockV3PoolProvider.getPools.resolves(buildMockV3PoolAccessor(v3MockPools));
+  mockV3PoolProvider.getPoolAddress.callsFake((tA, tB, fee) => ({
+    poolAddress: Pool.getAddress(tA, tB, fee),
+    token0: tA,
+    token1: tB,
+  }));
+
+  return mockV3PoolProvider;
+}
+
+export function getMockedV2PoolProvider(): V2PoolProvider {
+  const mockV2PoolProvider = sinon.createStubInstance(V2PoolProvider);
+  const v2MockPools = [DAI_USDT, USDC_WETH, WETH_USDT, USDC_DAI, WBTC_WETH];
+  mockV2PoolProvider.getPools.resolves(buildMockV2PoolAccessor(v2MockPools));
+  mockV2PoolProvider.getPoolAddress.callsFake((tA, tB) => ({
+    poolAddress: Pair.getAddress(tA, tB),
+    token0: tA,
+    token1: tB,
+  }));
+  return mockV2PoolProvider;
+}

--- a/test/unit/routers/alpha-router/gas-models/v2-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/v2-gas-model.test.ts
@@ -1,0 +1,81 @@
+import { Currency, Ether } from '@uniswap/sdk-core';
+import { BigNumber } from 'ethers';
+import { DAI_MAINNET, V2Route } from '../../../../../src';
+import {
+  BASE_SWAP_COST,
+  COST_PER_EXTRA_HOP,
+  V2HeuristicGasModelFactory,
+} from '../../../../../src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model';
+import {
+  NATIVE_WRAP_OVERHEAD,
+  WRAPPED_NATIVE_OVERHEAD,
+} from '../../../../../src/routers/alpha-router/gas-models/v3/gas-costs';
+import { WETH_DAI } from '../../../../test-util/mock-data';
+import { getV2RouteWithValidQuoteStub } from '../../../providers/caching/route/test-util/mocked-dependencies';
+import { getMockedV2PoolProvider } from './test-util/mocked-dependencies';
+
+describe('v2 gas model', () => {
+  const gasPriceWei = BigNumber.from(1000000000);
+  const chainId = 1;
+  const v2GasModelFactory = new V2HeuristicGasModelFactory();
+
+  const mockedV2PoolProvider = getMockedV2PoolProvider();
+
+  it('returns correct gas estimate for a v2 route | hops: 1', async () => {
+    const quoteToken = DAI_MAINNET;
+
+    const v2GasModel = await v2GasModelFactory.buildGasModel({
+      chainId: chainId,
+      gasPriceWei,
+      poolProvider: mockedV2PoolProvider,
+      token: quoteToken,
+      providerConfig: {},
+    });
+
+    const v2RouteWithQuote = getV2RouteWithValidQuoteStub({
+      gasModel: v2GasModel,
+    });
+
+    const { gasEstimate } = v2GasModel.estimateGasCost(v2RouteWithQuote);
+
+    const hops = v2RouteWithQuote.route.pairs.length;
+    let expectedGasCost = BASE_SWAP_COST.add(COST_PER_EXTRA_HOP.mul(hops - 1));
+
+    expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
+  });
+
+  it('applies overhead when token in is native eth', async () => {
+    const amountToken = Ether.onChain(1) as Currency;
+    const quoteToken = DAI_MAINNET;
+
+    const v2GasModel = await v2GasModelFactory.buildGasModel({
+      chainId: chainId,
+      gasPriceWei,
+      poolProvider: mockedV2PoolProvider,
+      token: quoteToken,
+      providerConfig: {
+        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken),
+      },
+    });
+
+    expect(
+      WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken).eq(NATIVE_WRAP_OVERHEAD)
+    ).toBe(true);
+
+    const v2RouteWithQuote = getV2RouteWithValidQuoteStub({
+      route: new V2Route([WETH_DAI], amountToken.wrapped, quoteToken),
+      gasModel: v2GasModel,
+    });
+
+    const { gasEstimate } = v2GasModel.estimateGasCost(v2RouteWithQuote);
+
+    const hops = v2RouteWithQuote.route.pairs.length;
+    let expectedGasCost = BASE_SWAP_COST.add(
+      COST_PER_EXTRA_HOP.mul(hops - 1)
+    ).add(NATIVE_WRAP_OVERHEAD);
+
+    expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
+  });
+
+  // TODO: splits, multiple hops, token overheads, gasCostInToken, gasCostInUSD
+});

--- a/test/unit/routers/alpha-router/gas-models/v2-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/v2-gas-model.test.ts
@@ -14,7 +14,7 @@ import { WETH_DAI } from '../../../../test-util/mock-data';
 import { getV2RouteWithValidQuoteStub } from '../../../providers/caching/route/test-util/mocked-dependencies';
 import { getMockedV2PoolProvider } from './test-util/mocked-dependencies';
 
-describe('v2 gas model', () => {
+describe('v2 gas model tests', () => {
   const gasPriceWei = BigNumber.from(1000000000);
   const chainId = 1;
   const v2GasModelFactory = new V2HeuristicGasModelFactory();

--- a/test/unit/routers/alpha-router/gas-models/v2-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/v2-gas-model.test.ts
@@ -7,8 +7,8 @@ import {
   V2HeuristicGasModelFactory,
 } from '../../../../../src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model';
 import {
+  NATIVE_OVERHEAD,
   NATIVE_WRAP_OVERHEAD,
-  WRAPPED_NATIVE_OVERHEAD,
 } from '../../../../../src/routers/alpha-router/gas-models/v3/gas-costs';
 import { WETH_DAI } from '../../../../test-util/mock-data';
 import { getV2RouteWithValidQuoteStub } from '../../../providers/caching/route/test-util/mocked-dependencies';
@@ -54,12 +54,12 @@ describe('v2 gas model tests', () => {
       poolProvider: mockedV2PoolProvider,
       token: quoteToken,
       providerConfig: {
-        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken),
+        additionalGasOverhead: NATIVE_OVERHEAD(amountToken, quoteToken),
       },
     });
 
     expect(
-      WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken).eq(NATIVE_WRAP_OVERHEAD)
+      NATIVE_OVERHEAD(amountToken, quoteToken).eq(NATIVE_WRAP_OVERHEAD)
     ).toBe(true);
 
     const v2RouteWithQuote = getV2RouteWithValidQuoteStub({

--- a/test/unit/routers/alpha-router/gas-models/v2-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/v2-gas-model.test.ts
@@ -54,12 +54,18 @@ describe('v2 gas model tests', () => {
       poolProvider: mockedV2PoolProvider,
       token: quoteToken,
       providerConfig: {
-        additionalGasOverhead: NATIVE_OVERHEAD(amountToken, quoteToken),
+        additionalGasOverhead: NATIVE_OVERHEAD(
+          chainId,
+          amountToken,
+          quoteToken
+        ),
       },
     });
 
     expect(
-      NATIVE_OVERHEAD(amountToken, quoteToken).eq(NATIVE_WRAP_OVERHEAD)
+      NATIVE_OVERHEAD(chainId, amountToken, quoteToken).eq(
+        NATIVE_WRAP_OVERHEAD(chainId)
+      )
     ).toBe(true);
 
     const v2RouteWithQuote = getV2RouteWithValidQuoteStub({
@@ -72,7 +78,7 @@ describe('v2 gas model tests', () => {
     const hops = v2RouteWithQuote.route.pairs.length;
     let expectedGasCost = BASE_SWAP_COST.add(
       COST_PER_EXTRA_HOP.mul(hops - 1)
-    ).add(NATIVE_WRAP_OVERHEAD);
+    ).add(NATIVE_WRAP_OVERHEAD(chainId));
 
     expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
   });

--- a/test/unit/routers/alpha-router/gas-models/v3-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/v3-gas-model.test.ts
@@ -43,6 +43,7 @@ describe('v3 gas model', () => {
   const mockedV3PoolProvider = getMockedV3PoolProvider();
   const mockedV2PoolProvider = getMockedV2PoolProvider();
 
+  // helper function to get pools for building gas model
   async function getPools(
     amountToken: Token,
     quoteToken: Token,

--- a/test/unit/routers/alpha-router/gas-models/v3-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/v3-gas-model.test.ts
@@ -35,7 +35,7 @@ import {
   getMockedV3PoolProvider,
 } from './test-util/mocked-dependencies';
 
-describe('v3 gas model', () => {
+describe('v3 gas model tests', () => {
   const gasPriceWei = BigNumber.from(1000000000);
   const chainId = 1;
   const v3GasModelFactory = new V3HeuristicGasModelFactory();

--- a/test/unit/routers/alpha-router/gas-models/v3-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/v3-gas-model.test.ts
@@ -1,0 +1,303 @@
+import { Currency, CurrencyAmount, Ether, Token } from '@uniswap/sdk-core';
+import { BigNumber } from 'ethers';
+import _ from 'lodash';
+import {
+  DAI_MAINNET,
+  LiquidityCalculationPools,
+  USDC_MAINNET,
+  V3HeuristicGasModelFactory,
+  V3PoolProvider,
+  V3Route,
+  WRAPPED_NATIVE_CURRENCY,
+} from '../../../../../src';
+import { ProviderConfig } from '../../../../../src/providers/provider';
+import {
+  BASE_SWAP_COST,
+  COST_PER_HOP,
+  COST_PER_INIT_TICK,
+  NATIVE_UNWRAP_OVERHEAD,
+  NATIVE_WRAP_OVERHEAD,
+  SINGLE_HOP_OVERHEAD,
+  WRAPPED_NATIVE_OVERHEAD,
+} from '../../../../../src/routers/alpha-router/gas-models/v3/gas-costs';
+import {
+  getHighestLiquidityV3NativePool,
+  getHighestLiquidityV3USDPool,
+} from '../../../../../src/util/gas-factory-helpers';
+import {
+  DAI_USDT_LOW,
+  USDC_USDT_MEDIUM,
+  USDC_WETH_MEDIUM,
+} from '../../../../test-util/mock-data';
+import { getV3RouteWithValidQuoteStub } from '../../../providers/caching/route/test-util/mocked-dependencies';
+import {
+  getMockedV2PoolProvider,
+  getMockedV3PoolProvider,
+} from './test-util/mocked-dependencies';
+
+describe('v3 gas model', () => {
+  const gasPriceWei = BigNumber.from(1000000000);
+  const chainId = 1;
+  const v3GasModelFactory = new V3HeuristicGasModelFactory();
+
+  const mockedV3PoolProvider = getMockedV3PoolProvider();
+  const mockedV2PoolProvider = getMockedV2PoolProvider();
+
+  async function getPools(
+    amountToken: Token,
+    quoteToken: Token,
+    v3PoolProvider: V3PoolProvider,
+    providerConfig: ProviderConfig
+  ): Promise<LiquidityCalculationPools> {
+    const usdPoolPromise = getHighestLiquidityV3USDPool(
+      chainId,
+      v3PoolProvider,
+      providerConfig
+    );
+    const nativeCurrency = WRAPPED_NATIVE_CURRENCY[chainId];
+    const nativeQuoteTokenV3PoolPromise = !quoteToken.equals(nativeCurrency)
+      ? getHighestLiquidityV3NativePool(
+          quoteToken,
+          v3PoolProvider,
+          providerConfig
+        )
+      : Promise.resolve(null);
+    const nativeAmountTokenV3PoolPromise = !amountToken.equals(nativeCurrency)
+      ? getHighestLiquidityV3NativePool(
+          amountToken,
+          v3PoolProvider,
+          providerConfig
+        )
+      : Promise.resolve(null);
+
+    const [usdPool, nativeQuoteTokenV3Pool, nativeAmountTokenV3Pool] =
+      await Promise.all([
+        usdPoolPromise,
+        nativeQuoteTokenV3PoolPromise,
+        nativeAmountTokenV3PoolPromise,
+      ]);
+
+    const pools: LiquidityCalculationPools = {
+      usdPool: usdPool,
+      nativeQuoteTokenV3Pool: nativeQuoteTokenV3Pool,
+      nativeAmountTokenV3Pool: nativeAmountTokenV3Pool,
+    };
+    return pools;
+  }
+
+  it('returns correct gas estimate for a v3 route | hops: 1 | ticks 1', async () => {
+    const amountToken = USDC_MAINNET;
+    const quoteToken = DAI_MAINNET;
+
+    const pools = await getPools(
+      amountToken,
+      quoteToken,
+      mockedV3PoolProvider,
+      {}
+    );
+
+    const v3GasModel = await v3GasModelFactory.buildGasModel({
+      chainId: chainId,
+      gasPriceWei,
+      pools,
+      amountToken,
+      quoteToken,
+      v2poolProvider: mockedV2PoolProvider,
+      l2GasDataProvider: undefined,
+      providerConfig: {},
+    });
+
+    const v3RouteWithQuote = getV3RouteWithValidQuoteStub({
+      gasModel: v3GasModel,
+      initializedTicksCrossedList: [1],
+    });
+
+    const totalInitializedTicksCrossed = BigNumber.from(
+      Math.max(1, _.sum(v3RouteWithQuote.initializedTicksCrossedList))
+    );
+
+    const gasOverheadFromTicks = COST_PER_INIT_TICK(chainId).mul(
+      totalInitializedTicksCrossed
+    );
+
+    const { gasEstimate } = v3GasModel.estimateGasCost(v3RouteWithQuote);
+
+    const expectedGasCost = BASE_SWAP_COST(chainId)
+      .add(COST_PER_HOP(chainId))
+      .add(SINGLE_HOP_OVERHEAD(chainId))
+      .add(gasOverheadFromTicks);
+
+    expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
+  });
+
+  it('returns correct gas estimate for a v3 route | hops: 2 | ticks 1', async () => {
+    const amountToken = USDC_MAINNET;
+    const quoteToken = DAI_MAINNET;
+
+    const pools = await getPools(
+      amountToken,
+      quoteToken,
+      mockedV3PoolProvider,
+      {}
+    );
+
+    const v3GasModel = await v3GasModelFactory.buildGasModel({
+      chainId: chainId,
+      gasPriceWei,
+      pools,
+      amountToken,
+      quoteToken,
+      v2poolProvider: mockedV2PoolProvider,
+      l2GasDataProvider: undefined,
+      providerConfig: {},
+    });
+
+    const v3RouteWithQuote = getV3RouteWithValidQuoteStub({
+      gasModel: v3GasModel,
+      route: new V3Route(
+        [USDC_USDT_MEDIUM, DAI_USDT_LOW],
+        USDC_MAINNET,
+        DAI_MAINNET
+      ),
+      sqrtPriceX96AfterList: [BigNumber.from(100), BigNumber.from(100)],
+      initializedTicksCrossedList: [0, 1],
+    });
+
+    const totalInitializedTicksCrossed = BigNumber.from(
+      Math.max(1, _.sum(v3RouteWithQuote.initializedTicksCrossedList))
+    );
+
+    const gasOverheadFromHops = COST_PER_HOP(chainId).mul(
+      v3RouteWithQuote.route.pools.length
+    );
+    const gasOverheadFromTicks = COST_PER_INIT_TICK(chainId).mul(
+      totalInitializedTicksCrossed
+    );
+
+    const { gasEstimate } = v3GasModel.estimateGasCost(v3RouteWithQuote);
+
+    const expectedGasCost = BASE_SWAP_COST(chainId)
+      .add(gasOverheadFromHops)
+      .add(gasOverheadFromTicks);
+
+    expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
+  });
+
+  it('applies overhead when token in is native eth', async () => {
+    const amountToken = Ether.onChain(1) as Currency;
+    const quoteToken = USDC_MAINNET;
+
+    const pools = await getPools(
+      amountToken.wrapped,
+      quoteToken,
+      mockedV3PoolProvider,
+      {}
+    );
+
+    const v3GasModel = await v3GasModelFactory.buildGasModel({
+      chainId: chainId,
+      gasPriceWei,
+      pools,
+      amountToken: amountToken.wrapped,
+      quoteToken,
+      v2poolProvider: mockedV2PoolProvider,
+      l2GasDataProvider: undefined,
+      providerConfig: {
+        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken),
+      },
+    });
+
+    const v3RouteWithQuote = getV3RouteWithValidQuoteStub({
+      amount: CurrencyAmount.fromRawAmount(amountToken, 1),
+      gasModel: v3GasModel,
+      route: new V3Route(
+        [USDC_WETH_MEDIUM],
+        WRAPPED_NATIVE_CURRENCY[1],
+        USDC_MAINNET
+      ),
+      quoteToken: USDC_MAINNET,
+      initializedTicksCrossedList: [1],
+    });
+
+    const totalInitializedTicksCrossed = BigNumber.from(
+      Math.max(1, _.sum(v3RouteWithQuote.initializedTicksCrossedList))
+    );
+
+    const gasOverheadFromHops = COST_PER_HOP(chainId).mul(
+      v3RouteWithQuote.route.pools.length
+    );
+    const gasOverheadFromTicks = COST_PER_INIT_TICK(chainId).mul(
+      totalInitializedTicksCrossed
+    );
+
+    const { gasEstimate } = v3GasModel.estimateGasCost(v3RouteWithQuote);
+
+    const expectedGasCost = BASE_SWAP_COST(chainId)
+      .add(gasOverheadFromHops)
+      .add(gasOverheadFromTicks)
+      .add(SINGLE_HOP_OVERHEAD(chainId))
+      .add(NATIVE_WRAP_OVERHEAD);
+
+    expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
+  });
+
+  it('applies overhead when token out is native eth', async () => {
+    const amountToken = USDC_MAINNET;
+    const quoteToken = Ether.onChain(1) as Currency;
+
+    const pools = await getPools(
+      amountToken,
+      quoteToken.wrapped,
+      mockedV3PoolProvider,
+      {}
+    );
+
+    const v3GasModel = await v3GasModelFactory.buildGasModel({
+      chainId: chainId,
+      gasPriceWei,
+      pools,
+      amountToken,
+      quoteToken: quoteToken.wrapped,
+      v2poolProvider: mockedV2PoolProvider,
+      l2GasDataProvider: undefined,
+      providerConfig: {
+        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken),
+      },
+    });
+
+    const v3RouteWithQuote = getV3RouteWithValidQuoteStub({
+      amount: CurrencyAmount.fromRawAmount(amountToken, 100),
+      gasModel: v3GasModel,
+      route: new V3Route(
+        [USDC_WETH_MEDIUM],
+        USDC_MAINNET,
+        WRAPPED_NATIVE_CURRENCY[1]
+      ),
+      quoteToken: WRAPPED_NATIVE_CURRENCY[1],
+      initializedTicksCrossedList: [1],
+    });
+
+    const totalInitializedTicksCrossed = BigNumber.from(
+      Math.max(1, _.sum(v3RouteWithQuote.initializedTicksCrossedList))
+    );
+
+    const gasOverheadFromHops = COST_PER_HOP(chainId).mul(
+      v3RouteWithQuote.route.pools.length
+    );
+    const gasOverheadFromTicks = COST_PER_INIT_TICK(chainId).mul(
+      totalInitializedTicksCrossed
+    );
+
+    const { gasEstimate } = v3GasModel.estimateGasCost(v3RouteWithQuote);
+
+    const expectedGasCost = BASE_SWAP_COST(chainId)
+      .add(gasOverheadFromHops)
+      .add(gasOverheadFromTicks)
+      .add(SINGLE_HOP_OVERHEAD(chainId))
+      .add(NATIVE_UNWRAP_OVERHEAD);
+
+    expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
+  });
+
+  // TODO: splits, multiple hops, token overheads, gasCostInToken, gasCostInUSD
+});

--- a/test/unit/routers/alpha-router/gas-models/v3-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/v3-gas-model.test.ts
@@ -204,7 +204,11 @@ describe('v3 gas model tests', () => {
       v2poolProvider: mockedV2PoolProvider,
       l2GasDataProvider: undefined,
       providerConfig: {
-        additionalGasOverhead: NATIVE_OVERHEAD(amountToken, quoteToken),
+        additionalGasOverhead: NATIVE_OVERHEAD(
+          chainId,
+          amountToken,
+          quoteToken
+        ),
       },
     });
 
@@ -237,7 +241,7 @@ describe('v3 gas model tests', () => {
       .add(gasOverheadFromHops)
       .add(gasOverheadFromTicks)
       .add(SINGLE_HOP_OVERHEAD(chainId))
-      .add(NATIVE_WRAP_OVERHEAD);
+      .add(NATIVE_WRAP_OVERHEAD(chainId));
 
     expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
   });
@@ -262,7 +266,11 @@ describe('v3 gas model tests', () => {
       v2poolProvider: mockedV2PoolProvider,
       l2GasDataProvider: undefined,
       providerConfig: {
-        additionalGasOverhead: NATIVE_OVERHEAD(amountToken, quoteToken),
+        additionalGasOverhead: NATIVE_OVERHEAD(
+          chainId,
+          amountToken,
+          quoteToken
+        ),
       },
     });
 
@@ -295,7 +303,7 @@ describe('v3 gas model tests', () => {
       .add(gasOverheadFromHops)
       .add(gasOverheadFromTicks)
       .add(SINGLE_HOP_OVERHEAD(chainId))
-      .add(NATIVE_UNWRAP_OVERHEAD);
+      .add(NATIVE_UNWRAP_OVERHEAD(chainId));
 
     expect(gasEstimate.toNumber()).toEqual(expectedGasCost.toNumber());
   });

--- a/test/unit/routers/alpha-router/gas-models/v3-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/v3-gas-model.test.ts
@@ -15,10 +15,10 @@ import {
   BASE_SWAP_COST,
   COST_PER_HOP,
   COST_PER_INIT_TICK,
+  NATIVE_OVERHEAD,
   NATIVE_UNWRAP_OVERHEAD,
   NATIVE_WRAP_OVERHEAD,
   SINGLE_HOP_OVERHEAD,
-  WRAPPED_NATIVE_OVERHEAD,
 } from '../../../../../src/routers/alpha-router/gas-models/v3/gas-costs';
 import {
   getHighestLiquidityV3NativePool,
@@ -204,7 +204,7 @@ describe('v3 gas model tests', () => {
       v2poolProvider: mockedV2PoolProvider,
       l2GasDataProvider: undefined,
       providerConfig: {
-        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken),
+        additionalGasOverhead: NATIVE_OVERHEAD(amountToken, quoteToken),
       },
     });
 
@@ -262,7 +262,7 @@ describe('v3 gas model tests', () => {
       v2poolProvider: mockedV2PoolProvider,
       l2GasDataProvider: undefined,
       providerConfig: {
-        additionalGasOverhead: WRAPPED_NATIVE_OVERHEAD(amountToken, quoteToken),
+        additionalGasOverhead: NATIVE_OVERHEAD(amountToken, quoteToken),
       },
     });
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds an optional parameter `additionalGasOverhead` to ProviderConfig parameter of `buildGasModel` which applies a specified overhead to the gas estimate.

We were not previously accounting for the additional gas cost in trading ETH on V2/V3 pools as it must be wrapped/unwrapped into WETH every swap. This is very important for UniswapX as this is making it harder for X orders to beat out classic if our gas estimate is incorrect.

I also went ahead and added some very basic unit tests to the gas models.

I think my local prettier setup might be wrong, causing the large diff... I ran the prettier command but that changed like 30 files lol so maybe another PR.

TODO: 
- implement for V2 routes, that factory is set up differently than the v3 one and thus we unfortunately don't have access to the original amount/quote tokens, only the wrapped versions, which won't work for detecting if the trade starts or ends in a native token. I think we should address this in a fast follow / or in a larger refactor of the gas heuristic logic.
- change the gas overhead values for chains that don't have canonical WETH9 deployment, but there shouldn't be a huge difference


