### PR TITLE
Get All Tokens From List

### DIFF
--- a/src/providers/caching-token-list-provider.ts
+++ b/src/providers/caching-token-list-provider.ts
@@ -153,7 +153,7 @@ export class CachingTokenListProvider
     const addToken = (token?: Token) => {
       if (!token) return;
       addressToToken.set(token.address.toLowerCase(), token);
-      if (!!token.symbol) {
+      if (token.symbol !== undefined) {
         symbolToToken.set(token.symbol.toLowerCase(), token);
       }
     };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
	- feature

- **What is the current behavior?** (You can also link to an open issue here)
	- `CachingTokenListProvider.getTokens` only able to fetch specific tokens by addresses

- **What is the new behavior (if this is a feature change)?**
	- if no address array is passed in to `getTokens` it will return a `TokenAccessor` containing **_all_** of the chain's tokens from the token list

- **Other information**:
	- This allows visibility into all of the chain's token from the token list which can be iterated over.