### PR TITLE
add sor conditional logging on debug routing config override

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -947,6 +947,10 @@ export class AlphaRouter
       { blockNumber }
     );
 
+    if (routingConfig.debugRouting) {
+      log.warn(`Finalized routing config is ${JSON.stringify(routingConfig)}`);
+    }
+
     const gasPriceWei = await this.getGasPriceWei();
 
     const quoteToken = quoteCurrency.wrapped;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Debug routing logging

- **What is the current behavior?** (You can also link to an open issue here)
In prod, we don't have a sure way to know if the debug configs are being applied

- **What is the new behavior (if this is a feature change)?**
We want a sure way to know the finalized alpha router configs, now that both routing-api and [smart-order-router](https://github.com/Uniswap/smart-order-router) synthesize the alpha router configs quite a bit.

- **Other information**:
We only want to log finalized alpha router configs, when the upstream sends debugRoutingConfig.debugRouting = true. Otherwise we have too many logs.