### PR TITLE
There can ever only be 1 Token/Eth pool

### DIFF
--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -713,7 +713,8 @@ export async function getV2CandidatePools({
   let topByBaseWithTokenOutPoolsFound = 0;
 
   // Main reason we need this is for gas estimates
-  let topNEthQuoteToken = 2;
+  // There can ever only be 1 Token/ETH pool, so we will only look for 1
+  let topNEthQuoteToken = 1;
   // but, we only need it if token out is not ETH.
   if (tokenOut.symbol == 'WETH' || tokenOut.symbol == 'WETH9' || tokenOut.symbol == 'ETH') {
     // if it's eth we change the topN to 0, so we can break early from the loop.


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix
- **What is the current behavior?** (You can also link to an open issue here)
We are currently looking for 2 Token/Eth pools, but there can ever only be 1.

- **What is the new behavior (if this is a feature change)?**
look only for 1 pool

- **Other information**:
