### PR TITLE
add hits cached routes boolean flag

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1213,7 +1213,7 @@ export class AlphaRouter
       trade,
       methodParameters,
       blockNumber: BigNumber.from(await blockNumber),
-      hitsCachedRoute: swapRouteFromChain === null,
+      hitsCachedRoute: !swapRouteFromChain && swapRouteFromCache !== null ,
     };
 
     if (

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1213,7 +1213,7 @@ export class AlphaRouter
       trade,
       methodParameters,
       blockNumber: BigNumber.from(await blockNumber),
-      hitsCachedRoute: !swapRouteFromChain && swapRouteFromCache !== null ,
+      hitsCachedRoute: !swapRouteFromChain && swapRouteFromCache !== null,
     };
 
     if (

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1213,6 +1213,7 @@ export class AlphaRouter
       trade,
       methodParameters,
       blockNumber: BigNumber.from(await blockNumber),
+      hitsCachedRoute: swapRouteFromChain === null,
     };
 
     if (
@@ -1239,7 +1240,7 @@ export class AlphaRouter
           ? await this.l2GasDataProvider!.getGasData()
           : undefined,
         { blockNumber }
-      );
+    );
       metric.putMetric(
         'SimulateTransaction',
         Date.now() - beforeSimulate,

--- a/src/routers/router.ts
+++ b/src/routers/router.ts
@@ -89,6 +89,11 @@ export type SwapRoute = {
    * 2 if simulation was successful (simulated gas estimates are returned)
    */
   simulationStatus?: SimulationStatus;
+  /**
+   * Used internally within routing-api to see how many route requests
+   * hit the cached routes. This is used further down the line for future perf optimizations.
+   */
+  hitsCachedRoute?: boolean;
 };
 
 export type MethodParameters = SDKMethodParameters & { to: string };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Telemetry

- **What is the current behavior?** (You can also link to an open issue here)
We don't have a top-level request latencies breakdown between cached routes vs non-cached routes.

- **What is the new behavior (if this is a feature change)?**
We want this visibility. The only way to know is that [smart-order-router](https://github.com/Uniswap/smart-order-router) starts returning that boolean flag.

- **Other information**:
The boolean needs to be optional, so that the response schema is backward compatible. It's a debug only flag anyway.