### PR TITLE
Create a routeId in CachedRoute

### DIFF
--- a/src/providers/caching/route/model/cached-route.ts
+++ b/src/providers/caching/route/model/cached-route.ts
@@ -18,7 +18,8 @@ interface CachedRouteParams<Route extends V3Route | V2Route | MixedRoute> {
 export class CachedRoute<Route extends V3Route | V2Route | MixedRoute> {
   public readonly route: Route;
   public readonly percent: number;
-  // Helper function used to generate the routeId
+  // Hashing function copying the same implementation as Java's `hashCode`
+  // Sourced from: https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0?permalink_comment_id=4613539#gistcomment-4613539
   private hashCode = (str: string) => [...str].reduce((s, c) => Math.imul(31, s) + c.charCodeAt(0) | 0, 0);
 
   /**
@@ -45,10 +46,10 @@ export class CachedRoute<Route extends V3Route | V2Route | MixedRoute> {
   public get routePath(): string {
     if (this.protocol == Protocol.V3) {
       const route = this.route as V3Route;
-      return route.pools.map(pool => `${pool.token0.address}/${pool.token1.address}/${pool.fee}`).join('->');
+      return route.pools.map(pool => `[V3]${pool.token0.address}/${pool.token1.address}/${pool.fee}`).join('->');
     } else if (this.protocol == Protocol.V2) {
       const route = this.route as V2Route;
-      return route.path.map(token => token.address).join('->');
+      return route.pairs.map(pair => `[V2]${pair.token0.address}/${pair.token1.address}`).join('->');
     } else {
       const route = this.route as MixedRoute;
       return route.pools.map(pool => {

--- a/test/unit/providers/caching/route/model/cached-route.test.ts
+++ b/test/unit/providers/caching/route/model/cached-route.test.ts
@@ -1,7 +1,7 @@
 import { Protocol } from '@uniswap/router-sdk';
 import { DAI_MAINNET, MixedRoute, USDC_MAINNET, V2Route, V3Route } from '../../../../../../build/main';
 import { CachedRoute } from '../../../../../../src';
-import { USDC_DAI, USDC_DAI_MEDIUM } from '../../../../../test-util/mock-data';
+import { USDC_DAI, USDC_DAI_MEDIUM, WETH_DAI } from '../../../../../test-util/mock-data';
 
 describe('CachedRoute', () => {
   it('creates an instance given a route object and percent', () => {
@@ -27,10 +27,60 @@ describe('CachedRoute', () => {
     });
 
     it('is correctly MIXED when using MixedRoute', () => {
-      const route = new MixedRoute([USDC_DAI_MEDIUM], USDC_MAINNET, DAI_MAINNET);
+      const route = new MixedRoute([USDC_DAI_MEDIUM, WETH_DAI], USDC_MAINNET, DAI_MAINNET);
       const cachedRoute = new CachedRoute({ route: route, percent: 100 });
 
       expect(cachedRoute.protocol).toEqual(Protocol.MIXED);
+    });
+  });
+
+  describe('#routePath', () => {
+    it('is correctly returned when using V3Route', () => {
+      const route = new V3Route([USDC_DAI_MEDIUM], USDC_MAINNET, DAI_MAINNET);
+      const cachedRoute = new CachedRoute({ route: route, percent: 100 });
+
+      expect(cachedRoute.routePath)
+        .toEqual('0x6B175474E89094C44Da98b954EedeAC495271d0F/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/3000');
+    });
+
+    it('is correctly returned when using V2Route', () => {
+      const route = new V2Route([USDC_DAI], USDC_MAINNET, DAI_MAINNET);
+      const cachedRoute = new CachedRoute({ route: route, percent: 100 });
+
+      expect(cachedRoute.routePath)
+        .toEqual('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48->0x6B175474E89094C44Da98b954EedeAC495271d0F');
+    });
+
+    it('is correctly returned when using MixedRoute', () => {
+      const route = new MixedRoute([USDC_DAI_MEDIUM, WETH_DAI], USDC_MAINNET, DAI_MAINNET);
+      const cachedRoute = new CachedRoute({ route: route, percent: 100 });
+
+      expect(cachedRoute.routePath)
+        .toEqual(
+          '[V3]0x6B175474E89094C44Da98b954EedeAC495271d0F/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/3000->[V2]0x6B175474E89094C44Da98b954EedeAC495271d0F/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
+    });
+  });
+
+  describe('#routeId', () => {
+    it('is correctly returned when using V3Route', () => {
+      const route = new V3Route([USDC_DAI_MEDIUM], USDC_MAINNET, DAI_MAINNET);
+      const cachedRoute = new CachedRoute({ route: route, percent: 100 });
+
+      expect(cachedRoute.routeId).toEqual(1364761099);
+    });
+
+    it('is correctly returned when using V2Route', () => {
+      const route = new V2Route([USDC_DAI], USDC_MAINNET, DAI_MAINNET);
+      const cachedRoute = new CachedRoute({ route: route, percent: 100 });
+
+      expect(cachedRoute.routeId).toEqual(-1824900155);
+    });
+
+    it('is correctly returned when using MixedRoute', () => {
+      const route = new MixedRoute([USDC_DAI_MEDIUM, WETH_DAI], USDC_MAINNET, DAI_MAINNET);
+      const cachedRoute = new CachedRoute({ route: route, percent: 100 });
+
+      expect(cachedRoute.routeId).toEqual(-882458629);
     });
   });
 });

--- a/test/unit/providers/caching/route/model/cached-route.test.ts
+++ b/test/unit/providers/caching/route/model/cached-route.test.ts
@@ -40,7 +40,7 @@ describe('CachedRoute', () => {
       const cachedRoute = new CachedRoute({ route: route, percent: 100 });
 
       expect(cachedRoute.routePath)
-        .toEqual('0x6B175474E89094C44Da98b954EedeAC495271d0F/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/3000');
+        .toEqual('[V3]0x6B175474E89094C44Da98b954EedeAC495271d0F/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/3000');
     });
 
     it('is correctly returned when using V2Route', () => {
@@ -48,7 +48,7 @@ describe('CachedRoute', () => {
       const cachedRoute = new CachedRoute({ route: route, percent: 100 });
 
       expect(cachedRoute.routePath)
-        .toEqual('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48->0x6B175474E89094C44Da98b954EedeAC495271d0F');
+        .toEqual('[V2]0x6B175474E89094C44Da98b954EedeAC495271d0F/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48');
     });
 
     it('is correctly returned when using MixedRoute', () => {
@@ -66,14 +66,14 @@ describe('CachedRoute', () => {
       const route = new V3Route([USDC_DAI_MEDIUM], USDC_MAINNET, DAI_MAINNET);
       const cachedRoute = new CachedRoute({ route: route, percent: 100 });
 
-      expect(cachedRoute.routeId).toEqual(1364761099);
+      expect(cachedRoute.routeId).toEqual(610157808);
     });
 
     it('is correctly returned when using V2Route', () => {
       const route = new V2Route([USDC_DAI], USDC_MAINNET, DAI_MAINNET);
       const cachedRoute = new CachedRoute({ route: route, percent: 100 });
 
-      expect(cachedRoute.routeId).toEqual(-1824900155);
+      expect(cachedRoute.routeId).toEqual(783252763);
     });
 
     it('is correctly returned when using MixedRoute', () => {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature
- **What is the current behavior?** (You can also link to an open issue here)
no routeId exists for cached route
- **What is the new behavior (if this is a feature change)?**
this creates a route id param
- **Other information**:
