### PR TITLE
Keep track of tokens visited and avoid visiting back a token

### DIFF
--- a/src/routers/alpha-router/functions/compute-all-routes.ts
+++ b/src/routers/alpha-router/functions/compute-all-routes.ts
@@ -82,6 +82,7 @@ export function computeAllRoutes<
     tokenOut: Token,
     currentRoute: TPool[],
     poolsUsed: boolean[],
+    tokensVisited: Set<string>,
     _previousTokenOut?: Token
   ) => {
     if (currentRoute.length > maxHops) {
@@ -112,6 +113,11 @@ export function computeAllRoutes<
         ? curPool.token1
         : curPool.token0;
 
+      if (tokensVisited.has(currentTokenOut.address.toLowerCase())) {
+        continue;
+      }
+
+      tokensVisited.add(currentTokenOut.address.toLowerCase());
       currentRoute.push(curPool);
       poolsUsed[i] = true;
       computeRoutes(
@@ -119,14 +125,16 @@ export function computeAllRoutes<
         tokenOut,
         currentRoute,
         poolsUsed,
+        tokensVisited,
         currentTokenOut
       );
       poolsUsed[i] = false;
       currentRoute.pop();
+      tokensVisited.delete(currentTokenOut.address.toLowerCase());
     }
   };
 
-  computeRoutes(tokenIn, tokenOut, [], poolsUsed);
+  computeRoutes(tokenIn, tokenOut, [], poolsUsed, new Set([tokenIn.address.toLowerCase()]));
 
   log.info(
     {

--- a/test/test-util/mock-data.ts
+++ b/test/test-util/mock-data.ts
@@ -190,6 +190,11 @@ export const USDC_WETH = new Pair(
   CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[1]!, 10000000000)
 );
 
+export const USDC_USDT = new Pair(
+  CurrencyAmount.fromRawAmount(USDC, 10000000000),
+  CurrencyAmount.fromRawAmount(USDT, 10000000000)
+);
+
 export const WETH_USDT = new Pair(
   CurrencyAmount.fromRawAmount(USDT, 10000000000),
   CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[1]!, 10000000000)

--- a/test/unit/routers/alpha-router/alpha-router.test.ts
+++ b/test/unit/routers/alpha-router/alpha-router.test.ts
@@ -786,7 +786,10 @@ describe('alpha router', () => {
       /// @dev so it's hard to actually force all 3 protocols since there's no concept of liquidity in these mocks
       expect(
         _.filter(swap!.route, (r) => r.protocol == Protocol.V3)
-      ).toHaveLength(2);
+      ).toHaveLength(1);
+      expect(
+        _.filter(swap!.route, (r) => r.protocol == Protocol.V2)
+      ).toHaveLength(1);
       expect(
         _.filter(swap!.route, (r) => r.protocol == Protocol.MIXED)
       ).toHaveLength(1);
@@ -2664,7 +2667,7 @@ describe('alpha router', () => {
               ROUTING_CONFIG
             );
 
-            expect(spy.calledTwice).toEqual(true);
+            expect(spy.calledOnce).toEqual(true);
 
             const [
               optimalRatioFirst,
@@ -2680,22 +2683,6 @@ describe('alpha router', () => {
             );
             expect(inputBalanceFirst).toEqual(token0Balance);
             expect(outputBalanceFirst).toEqual(token1Balance);
-
-            const [
-              optimalRatioSecond,
-              exchangeRateSecond,
-              inputBalanceSecond,
-              outputBalanceSecond,
-            ] = spy.secondCall.args;
-            expect(optimalRatioSecond.toFixed(2)).toEqual(
-              new Fraction(1, 8).toFixed(2)
-            );
-            // all other params remain the same
-            expect(exchangeRateSecond.asFraction.toFixed(6)).toEqual(
-              new Fraction(1, 1).toFixed(6)
-            );
-            expect(inputBalanceSecond).toEqual(token0Balance);
-            expect(outputBalanceSecond).toEqual(token1Balance);
           }
         );
 
@@ -2734,7 +2721,7 @@ describe('alpha router', () => {
               ROUTING_CONFIG
             );
 
-            expect(spy.calledTwice).toEqual(true);
+            expect(spy.calledOnce).toEqual(true);
 
             const [
               optimalRatioFirst,
@@ -2750,20 +2737,6 @@ describe('alpha router', () => {
             );
             expect(inputBalanceFirst).toEqual(token0Balance);
             expect(outputBalanceFirst).toEqual(token1Balance);
-
-            const [
-              optimalRatioSecond,
-              exchangeRateSecond,
-              inputBalanceSecond,
-              outputBalanceSecond,
-            ] = spy.secondCall.args;
-            expect(optimalRatioSecond).toEqual(new Fraction(0, 1));
-            // all other params remain the same
-            expect(exchangeRateSecond.asFraction.toFixed(6)).toEqual(
-              new Fraction(1, 1).toFixed(6)
-            );
-            expect(inputBalanceSecond).toEqual(token0Balance);
-            expect(outputBalanceSecond).toEqual(token1Balance);
           }
         );
       });

--- a/test/unit/routers/alpha-router/functions/compute-all-routes.test.ts
+++ b/test/unit/routers/alpha-router/functions/compute-all-routes.test.ts
@@ -9,8 +9,9 @@ import {
   WRAPPED_NATIVE_CURRENCY,
 } from '../../../../../src';
 import {
+  computeAllMixedRoutes,
   computeAllV2Routes,
-  computeAllV3Routes,
+  computeAllV3Routes
 } from '../../../../../src/routers/alpha-router/functions/compute-all-routes';
 import {
   DAI_USDT,
@@ -81,6 +82,111 @@ describe('compute all v3 routes', () => {
 
     // No way to get from USDC to WBTC in 2 hops
     const routes = computeAllV3Routes(USDC, WBTC, pools, 2);
+
+    expect(routes).toHaveLength(0);
+  });
+});
+
+describe('compute all mixed routes', () => {
+  test('succeeds to compute all routes', async () => {
+    const pools = [
+      DAI_USDT,
+      USDC_WETH,
+      WETH_USDT,
+      USDC_DAI,
+      WBTC_WETH,
+      USDC_DAI_LOW,
+      USDC_DAI_MEDIUM,
+      USDC_WETH_LOW,
+      WETH9_USDT_LOW,
+      DAI_USDT_LOW,
+    ];
+    const routes = computeAllMixedRoutes(USDC, DAI, pools, 3);
+
+    expect(routes).toHaveLength(6);
+  });
+
+  test('fails to compute all routes with 1 hop (since mixed requires at least 2 hops)', async () => {
+    const pools = [
+      DAI_USDT,
+      USDC_WETH,
+      WETH_USDT,
+      USDC_DAI,
+      WBTC_WETH,
+      USDC_DAI_LOW,
+      USDC_DAI_MEDIUM,
+      USDC_WETH_LOW,
+      WETH9_USDT_LOW,
+      DAI_USDT_LOW,
+    ];
+    const routes = computeAllMixedRoutes(USDC, DAI, pools, 1);
+
+    expect(routes).toHaveLength(0);
+  });
+
+  test('succeeds to compute all routes with 2 hops', async () => {
+    const pools = [
+      DAI_USDT,
+      USDC_WETH,
+      WETH_USDT,
+      USDC_DAI,
+      USDC_USDT,
+      WBTC_WETH,
+      USDC_DAI_LOW,
+      USDC_DAI_MEDIUM,
+      USDC_WETH_LOW,
+      WETH9_USDT_LOW,
+      DAI_USDT_LOW,
+    ];
+    const routes = computeAllMixedRoutes(USDC, DAI, pools, 2);
+
+    expect(routes).toHaveLength(1);
+  });
+
+  test('succeeds to compute all routes with 5 hops. ignoring arbitrage opportunities', async () => {
+    const pools = [
+      DAI_USDT,
+      USDC_DAI,
+      USDC_USDT,
+      USDC_WETH,
+      WETH_USDT,
+      WBTC_WETH,
+      USDC_DAI_LOW,
+      USDC_DAI_MEDIUM,
+      USDC_WETH_LOW,
+      WETH9_USDT_LOW,
+      DAI_USDT_LOW,
+    ];
+    const routes = computeAllMixedRoutes(USDC, WRAPPED_NATIVE_CURRENCY[1]!, pools, 4);
+
+    routes.forEach((route) => {
+      expect(route.pools).not.toEqual([USDC_DAI, USDC_DAI_LOW, USDC_WETH]);
+      expect(route.pools).not.toEqual([USDC_DAI, USDC_DAI_MEDIUM, USDC_WETH]);
+      expect(route.pools).not.toEqual([USDC_DAI_LOW, USDC_DAI_MEDIUM, USDC_WETH]);
+      expect(route.pools).not.toEqual([USDC_DAI_LOW, USDC_DAI, USDC_WETH]);
+      expect(route.pools).not.toEqual([USDC_DAI_MEDIUM, USDC_DAI_LOW, USDC_WETH]);
+      expect(route.pools).not.toEqual([USDC_DAI_MEDIUM, USDC_DAI, USDC_WETH]);
+    });
+
+    expect(routes).toHaveLength(10);
+  });
+
+  test('succeeds when no routes', async () => {
+    const pools = [
+      DAI_USDT,
+      WETH_USDT,
+      USDC_DAI,
+      WBTC_WETH,
+      WETH9_USDT_LOW,
+      DAI_USDT_LOW,
+      new Pair(
+        CurrencyAmount.fromRawAmount(USDT, 10),
+        CurrencyAmount.fromRawAmount(WBTC, 10)
+      ),
+    ];
+
+    // No way to get from USDC to WBTC in 2 hops
+    const routes = computeAllMixedRoutes(USDC, WBTC, pools, 2);
 
     expect(routes).toHaveLength(0);
   });

--- a/test/unit/routers/alpha-router/functions/compute-all-routes.test.ts
+++ b/test/unit/routers/alpha-router/functions/compute-all-routes.test.ts
@@ -6,6 +6,7 @@ import {
   USDC_MAINNET as USDC,
   USDT_MAINNET as USDT,
   WBTC_MAINNET as WBTC,
+  WRAPPED_NATIVE_CURRENCY,
 } from '../../../../../src';
 import {
   computeAllV2Routes,
@@ -17,6 +18,7 @@ import {
   USDC_DAI,
   USDC_DAI_LOW,
   USDC_DAI_MEDIUM,
+  USDC_USDT,
   USDC_WETH,
   USDC_WETH_LOW,
   WBTC_WETH,
@@ -51,6 +53,22 @@ describe('compute all v3 routes', () => {
     expect(routes).toHaveLength(2);
   });
 
+  test('succeeds to compute all routes with 4 hops, ignoring arbitrage opportunities', async () => {
+    const pools = [
+      USDC_DAI_LOW,
+      USDC_DAI_MEDIUM,
+      USDC_WETH_LOW,
+      WETH9_USDT_LOW,
+      DAI_USDT_LOW,
+    ];
+    const routes = computeAllV3Routes(USDC, WRAPPED_NATIVE_CURRENCY[1]!, pools, 4);
+
+    routes.forEach((route) => {
+      expect(route.pools).not.toEqual([USDC_DAI_MEDIUM, USDC_DAI_LOW, USDC_WETH_LOW]);
+    });
+    expect(routes).toHaveLength(3);
+  });
+
   test('succeeds when no routes', async () => {
     const pools = [
       USDC_DAI_LOW,
@@ -81,6 +99,17 @@ describe('compute all v2 routes', () => {
     const routes = computeAllV2Routes(USDC, DAI, pools, 1);
 
     expect(routes).toHaveLength(1);
+  });
+
+  test('succeeds to compute all routes with 5 hops. ignoring arbitrage opportunities', async () => {
+    const pools = [DAI_USDT, USDC_DAI, USDC_USDT, USDC_WETH, WETH_USDT, WBTC_WETH];
+    const routes = computeAllV2Routes(USDC, WRAPPED_NATIVE_CURRENCY[1]!, pools, 5);
+
+    routes.forEach((route) => {
+      expect(route.pairs).not.toEqual([USDC_USDT, DAI_USDT, USDC_DAI, USDC_WETH]);
+      expect(route.pairs).not.toEqual([USDC_DAI, DAI_USDT, USDC_USDT, USDC_WETH]);
+    });
+    expect(routes).toHaveLength(3);
   });
 
   test('succeeds when no routes', async () => {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
BugFix/Feature

- **What is the current behavior?** (You can also link to an open issue here)
Currently we will compute routes that represent arbitrage opportunities, when we go back to a previously seen token in the same route, this is a problem because we don't operate at the MEV level, so offering these routes to our users is not ideal, nor a good idea.

- **What is the new behavior (if this is a feature change)?**
In this new behavior we keep track of the tokens visited per route, and we avoid visiting it again.

- **Other information**:
