### PR TITLE
Only quote the 100% amount when there's only 1 route

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -104,9 +104,9 @@ import {
 } from './gas-models/gas-model';
 import { MixedRouteHeuristicGasModelFactory } from './gas-models/mixedRoute/mixed-route-heuristic-gas-model';
 import { V2HeuristicGasModelFactory } from './gas-models/v2/v2-heuristic-gas-model';
+import { NATIVE_OVERHEAD } from './gas-models/v3/gas-costs';
 import { V3HeuristicGasModelFactory } from './gas-models/v3/v3-heuristic-gas-model';
 import { GetQuotesResult, MixedQuoter, V2Quoter, V3Quoter } from './quoters';
-import { NATIVE_OVERHEAD } from './gas-models/v3/gas-costs';
 
 export type AlphaRouterParams = {
   /**
@@ -1243,7 +1243,7 @@ export class AlphaRouter
           ? await this.l2GasDataProvider!.getGasData()
           : undefined,
         { blockNumber }
-    );
+      );
       metric.putMetric(
         'SimulateTransaction',
         Date.now() - beforeSimulate,
@@ -1485,6 +1485,7 @@ export class AlphaRouter
           this.v3Quoter.getRoutesThenQuotes(
             tokenIn,
             tokenOut,
+            amount,
             amounts,
             percents,
             quoteToken,
@@ -1517,6 +1518,7 @@ export class AlphaRouter
           this.v2Quoter.getRoutesThenQuotes(
             tokenIn,
             tokenOut,
+            amount,
             amounts,
             percents,
             quoteToken,
@@ -1552,6 +1554,7 @@ export class AlphaRouter
           this.mixedQuoter.getRoutesThenQuotes(
             tokenIn,
             tokenOut,
+            amount,
             amounts,
             percents,
             quoteToken,

--- a/src/routers/alpha-router/quoters/base-quoter.ts
+++ b/src/routers/alpha-router/quoters/base-quoter.ts
@@ -128,11 +128,13 @@ export abstract class BaseQuoter<
           amounts = [amount];
         }
 
-        metric.putMetric(
-          `${routesResult.routes[0]!.protocol}QuoterNumberOfRoutes`,
-          routesResult.routes.length,
-          MetricLoggerUnit.Count
-        );
+        if (routesResult.routes.length > 0) {
+          metric.putMetric(
+            `${routesResult.routes[0]?.protocol}QuoterNumberOfRoutes`,
+            routesResult.routes.length,
+            MetricLoggerUnit.Count
+          );
+        }
 
         return this.getQuotes(
           routesResult.routes,

--- a/src/routers/alpha-router/quoters/base-quoter.ts
+++ b/src/routers/alpha-router/quoters/base-quoter.ts
@@ -110,6 +110,7 @@ export abstract class BaseQuoter<
   public getRoutesThenQuotes(
     tokenIn: Token,
     tokenOut: Token,
+    amount: CurrencyAmount,
     amounts: CurrencyAmount[],
     percents: number[],
     quoteToken: Token,
@@ -120,8 +121,13 @@ export abstract class BaseQuoter<
     gasPriceWei?: BigNumber
   ): Promise<GetQuotesResult> {
     return this.getRoutes(tokenIn, tokenOut, candidatePools, tradeType, routingConfig)
-      .then((routesResult) =>
-        this.getQuotes(
+      .then((routesResult) => {
+        if (routesResult.routes.length == 1) {
+          percents = [100];
+          amounts = [amount];
+        }
+
+        return this.getQuotes(
           routesResult.routes,
           amounts,
           percents,
@@ -131,8 +137,8 @@ export abstract class BaseQuoter<
           routesResult.candidatePools,
           gasModel,
           gasPriceWei
-        )
-      );
+        );
+      });
   }
 
   protected async applyTokenValidatorToPools<T extends Pool | Pair>(

--- a/src/routers/alpha-router/quoters/base-quoter.ts
+++ b/src/routers/alpha-router/quoters/base-quoter.ts
@@ -5,7 +5,7 @@ import { Pool } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
 import { ITokenListProvider, ITokenProvider, ITokenValidatorProvider, TokenValidationResult } from '../../../providers';
-import { CurrencyAmount, log, poolToString } from '../../../util';
+import { CurrencyAmount, log, metric, MetricLoggerUnit, poolToString } from '../../../util';
 import { MixedRoute, V2Route, V3Route } from '../../router';
 import { AlphaRouterConfig } from '../alpha-router';
 import { RouteWithValidQuote } from '../entities/route-with-valid-quote';
@@ -123,9 +123,16 @@ export abstract class BaseQuoter<
     return this.getRoutes(tokenIn, tokenOut, candidatePools, tradeType, routingConfig)
       .then((routesResult) => {
         if (routesResult.routes.length == 1) {
+          metric.putMetric(`${routesResult.routes[0]!.protocol}QuoterSingleRoute`, 1, MetricLoggerUnit.Count);
           percents = [100];
           amounts = [amount];
         }
+
+        metric.putMetric(
+          `${routesResult.routes[0]!.protocol}QuoterNumberOfRoutes`,
+          routesResult.routes.length,
+          MetricLoggerUnit.Count
+        );
 
         return this.getQuotes(
           routesResult.routes,

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -1,3 +1,4 @@
+import { Protocol } from '@uniswap/router-sdk';
 import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
 import _ from 'lodash';
 
@@ -46,7 +47,7 @@ export class MixedQuoter extends BaseQuoter<[V3CandidatePools, V2CandidatePools]
     blockedTokenListProvider?: ITokenListProvider,
     tokenValidatorProvider?: ITokenValidatorProvider
   ) {
-    super(tokenProvider, chainId, blockedTokenListProvider, tokenValidatorProvider);
+    super(tokenProvider, chainId, Protocol.MIXED, blockedTokenListProvider, tokenValidatorProvider);
     this.v3SubgraphProvider = v3SubgraphProvider;
     this.v3PoolProvider = v3PoolProvider;
     this.v2SubgraphProvider = v2SubgraphProvider;

--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber';
+import { Protocol } from '@uniswap/router-sdk';
 import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
 import _ from 'lodash';
 
@@ -11,21 +12,12 @@ import {
   IV2SubgraphProvider,
   TokenValidationResult,
 } from '../../../providers';
-import {
-  CurrencyAmount,
-  log,
-  metric,
-  MetricLoggerUnit,
-  routeToString,
-} from '../../../util';
+import { CurrencyAmount, log, metric, MetricLoggerUnit, routeToString, } from '../../../util';
 import { V2Route } from '../../router';
 import { AlphaRouterConfig } from '../alpha-router';
 import { V2RouteWithValidQuote } from '../entities';
 import { computeAllV2Routes } from '../functions/compute-all-routes';
-import {
-  CandidatePoolsBySelectionCriteria,
-  V2CandidatePools,
-} from '../functions/get-candidate-pools';
+import { CandidatePoolsBySelectionCriteria, V2CandidatePools, } from '../functions/get-candidate-pools';
 import { IGasModel, IV2GasModelFactory } from '../gas-models';
 
 import { BaseQuoter } from './base-quoter';
@@ -51,6 +43,7 @@ export class V2Quoter extends BaseQuoter<V2CandidatePools, V2Route> {
     super(
       tokenProvider,
       chainId,
+      Protocol.V2,
       blockedTokenListProvider,
       tokenValidatorProvider
     );

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -1,3 +1,4 @@
+import { Protocol } from '@uniswap/router-sdk';
 import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
 import _ from 'lodash';
 
@@ -36,7 +37,7 @@ export class V3Quoter extends BaseQuoter<V3CandidatePools, V3Route> {
     blockedTokenListProvider?: ITokenListProvider,
     tokenValidatorProvider?: ITokenValidatorProvider
   ) {
-    super(tokenProvider, chainId, blockedTokenListProvider, tokenValidatorProvider);
+    super(tokenProvider, chainId, Protocol.V3, blockedTokenListProvider, tokenValidatorProvider);
     this.v3SubgraphProvider = v3SubgraphProvider;
     this.v3PoolProvider = v3PoolProvider;
     this.onChainQuoteProvider = onChainQuoteProvider;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
small optimization

- **What is the current behavior?** (You can also link to an open issue here)
currently we quote all the distribution percents even if there's only 1 route

- **What is the new behavior (if this is a feature change)?**
we will only quote the 100% amount when we have only 1 route

- **Other information**:
