### PR TITLE
feat: use tenderly quick simulation

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -47,6 +47,22 @@ export type TenderlyResponseSwapRouter02 = {
   simulation_results: [SimulationResult, SimulationResult];
 };
 
+type SimulationRequest = {
+  network_id: ChainId;
+  estimate_gas: boolean;
+  input: string;
+  to: string;
+  value: string;
+  from: string;
+  simulation_type: 'quick' | 'full' | 'abi';
+  block_number?: number;
+};
+
+type SimulationBody = {
+  simulations: SimulationRequest[];
+  estimate_gas: boolean;
+};
+
 const TENDERLY_BATCH_SIMULATE_API = (
   tenderlyBaseUrl: string,
   tenderlyUser: string,
@@ -215,7 +231,7 @@ export class TenderlySimulator extends Simulator {
           Math.floor(new Date().getTime() / 1000) + 10000000,
         ]);
 
-      const approvePermit2 = {
+      const approvePermit2: SimulationRequest = {
         network_id: chainId,
         estimate_gas: true,
         input: approvePermit2Calldata,
@@ -225,7 +241,7 @@ export class TenderlySimulator extends Simulator {
         simulation_type: 'quick'
       };
 
-      const approveUniversalRouter = {
+      const approveUniversalRouter: SimulationRequest = {
         network_id: chainId,
         estimate_gas: true,
         input: approveUniversalRouterCallData,
@@ -235,7 +251,7 @@ export class TenderlySimulator extends Simulator {
         simulation_type: 'quick'
       };
 
-      const swap = {
+      const swap: SimulationRequest = {
         network_id: chainId,
         input: calldata,
         estimate_gas: true,
@@ -250,7 +266,7 @@ export class TenderlySimulator extends Simulator {
         simulation_type: 'quick'
       };
 
-      const body = {
+      const body: SimulationBody = {
         simulations: [approvePermit2, approveUniversalRouter, swap],
         estimate_gas: true,
       };

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -47,19 +47,25 @@ export type TenderlyResponseSwapRouter02 = {
   simulation_results: [SimulationResult, SimulationResult];
 };
 
-type SimulationRequest = {
+enum TenderlySimulationType {
+  QUICK = 'quick',
+  FULL = 'full',
+  ABI = 'abi',
+}
+
+type TenderlySimulationRequest = {
   network_id: ChainId;
   estimate_gas: boolean;
   input: string;
   to: string;
   value: string;
   from: string;
-  simulation_type: 'quick' | 'full' | 'abi';
+  simulation_type: TenderlySimulationType;
   block_number?: number;
 };
 
-type SimulationBody = {
-  simulations: SimulationRequest[];
+type TenderlySimulationBody = {
+  simulations: TenderlySimulationRequest[];
   estimate_gas: boolean;
 };
 
@@ -231,27 +237,27 @@ export class TenderlySimulator extends Simulator {
           Math.floor(new Date().getTime() / 1000) + 10000000,
         ]);
 
-      const approvePermit2: SimulationRequest = {
+      const approvePermit2: TenderlySimulationRequest = {
         network_id: chainId,
         estimate_gas: true,
         input: approvePermit2Calldata,
         to: tokenIn.address,
         value: '0',
         from: fromAddress,
-        simulation_type: 'quick'
+        simulation_type: TenderlySimulationType.QUICK
       };
 
-      const approveUniversalRouter: SimulationRequest = {
+      const approveUniversalRouter: TenderlySimulationRequest = {
         network_id: chainId,
         estimate_gas: true,
         input: approveUniversalRouterCallData,
         to: PERMIT2_ADDRESS,
         value: '0',
         from: fromAddress,
-        simulation_type: 'quick'
+        simulation_type: TenderlySimulationType.QUICK
       };
 
-      const swap: SimulationRequest = {
+      const swap: TenderlySimulationRequest = {
         network_id: chainId,
         input: calldata,
         estimate_gas: true,
@@ -263,10 +269,10 @@ export class TenderlySimulator extends Simulator {
           chainId == ChainId.ARBITRUM_ONE && blockNumber
             ? blockNumber - 5
             : undefined,
-        simulation_type: 'quick'
+        simulation_type: TenderlySimulationType.QUICK
       };
 
-      const body: SimulationBody = {
+      const body: TenderlySimulationBody = {
         simulations: [approvePermit2, approveUniversalRouter, swap],
         estimate_gas: true,
       };

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -222,6 +222,7 @@ export class TenderlySimulator extends Simulator {
         to: tokenIn.address,
         value: '0',
         from: fromAddress,
+        simulation_type: 'quick'
       };
 
       const approveUniversalRouter = {
@@ -231,6 +232,7 @@ export class TenderlySimulator extends Simulator {
         to: PERMIT2_ADDRESS,
         value: '0',
         from: fromAddress,
+        simulation_type: 'quick'
       };
 
       const swap = {
@@ -245,6 +247,7 @@ export class TenderlySimulator extends Simulator {
           chainId == ChainId.ARBITRUM_ONE && blockNumber
             ? blockNumber - 5
             : undefined,
+        simulation_type: 'quick'
       };
 
       const body = {

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -51,7 +51,7 @@ enum TenderlySimulationType {
   QUICK = 'quick',
   FULL = 'full',
   ABI = 'abi',
-}
+} 
 
 type TenderlySimulationRequest = {
   network_id: ChainId;


### PR DESCRIPTION
Tenderly has new support for quick and accurate gas estimations (https://blog.tenderly.co/how-tenderly-enables-most-accurate-ethereum-gas-estimation/), we can enable this by passing `simulation_type` as `quick` in the simulation bodies.
