### PR TITLE
Feature: expose tenderly saveIfFail flag through alpha-router

### DIFF
--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -17,6 +17,11 @@ export type ProviderConfig = {
    * Flag for token properties provider to enable fetching fee-on-transfer tokens.
    */
   enableFeeOnTransferFeeFetching?: boolean;
+  /**
+   * Tenderly natively support save simulation failures if failed,
+   * we need this as a pass-through flag to enable/disable this feature.
+   */
+  saveTenderlySimulationIfFailed?: boolean;
 };
 
 export type LocalCacheEntry<T> = {

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -51,7 +51,7 @@ enum TenderlySimulationType {
   QUICK = 'quick',
   FULL = 'full',
   ABI = 'abi',
-} 
+}
 
 type TenderlySimulationRequest = {
   network_id: ChainId;
@@ -62,6 +62,7 @@ type TenderlySimulationRequest = {
   from: string;
   simulation_type: TenderlySimulationType;
   block_number?: number;
+  save_if_fails?: boolean;
 };
 
 type TenderlySimulationBody = {
@@ -244,7 +245,8 @@ export class TenderlySimulator extends Simulator {
         to: tokenIn.address,
         value: '0',
         from: fromAddress,
-        simulation_type: TenderlySimulationType.QUICK
+        simulation_type: TenderlySimulationType.QUICK,
+        save_if_fails: providerConfig?.saveTenderlySimulationIfFailed,
       };
 
       const approveUniversalRouter: TenderlySimulationRequest = {
@@ -254,7 +256,8 @@ export class TenderlySimulator extends Simulator {
         to: PERMIT2_ADDRESS,
         value: '0',
         from: fromAddress,
-        simulation_type: TenderlySimulationType.QUICK
+        simulation_type: TenderlySimulationType.QUICK,
+        save_if_fails: providerConfig?.saveTenderlySimulationIfFailed,
       };
 
       const swap: TenderlySimulationRequest = {
@@ -269,7 +272,8 @@ export class TenderlySimulator extends Simulator {
           chainId == ChainId.ARBITRUM_ONE && blockNumber
             ? blockNumber - 5
             : undefined,
-        simulation_type: TenderlySimulationType.QUICK
+        simulation_type: TenderlySimulationType.QUICK,
+        save_if_fails: providerConfig?.saveTenderlySimulationIfFailed,
       };
 
       const body: TenderlySimulationBody = {

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -358,6 +358,11 @@ export type AlphaRouterConfig = {
    * Flag for token properties provider to enable fetching fee-on-transfer tokens.
    */
   enableFeeOnTransferFeeFetching?: boolean;
+  /**
+   * Tenderly natively support save simulation failures if failed,
+   * we need this as a pass-through flag to enable/disable this feature.
+   */
+  saveTenderlySimulationIfFailed?: boolean;
 };
 
 export class AlphaRouter
@@ -1288,7 +1293,7 @@ export class AlphaRouter
         this.l2GasDataProvider
           ? await this.l2GasDataProvider!.getGasData()
           : undefined,
-        { blockNumber }
+          providerConfig
       );
       metric.putMetric(
         'SimulateTransaction',

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -177,6 +177,7 @@ describe('alpha router integration', () => {
     // @ts-ignore[TS7053] - complaining about switch being non exhaustive
     ...DEFAULT_ROUTING_CONFIG_BY_CHAIN[ChainId.MAINNET],
     protocols: [Protocol.V3, Protocol.V2],
+    saveTenderlySimulationIfFailed: true, // save tenderly simulation on integ-test runs, easier for debugging
   };
 
   const executeSwap = async (


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
If the integ-test failes because of tenderly simulation failure, we don't have an audit trail of tenderly simulation call stack.

- **What is the new behavior (if this is a feature change)?**
Expose tenderly saveIfFailed flag and pass down to the tenderly request object.

- **Other information**:
