### PR TITLE
Fix: integ-test mixed route longer timeout to avoid flaky test failures

### DIFF
--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -2348,6 +2348,8 @@ describe('alpha router integration', () => {
   }
 
   describe('Mixed routes', () => {
+    jest.setTimeout(1000 * 1000); // 1000s
+
     const tradeType = TradeType.EXACT_INPUT;
 
     const BOND_MAINNET = new Token(


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Sometimes mixed route BOND -> APE test can fail due to timeout

- **What is the new behavior (if this is a feature change)?**
Double BOND -> APE test timeout

- **Other information**:
