### PR TITLE
logging more around fot tax

### DIFF
--- a/src/providers/token-fee-fetcher.ts
+++ b/src/providers/token-fee-fetcher.ts
@@ -4,7 +4,7 @@ import { ChainId } from '@uniswap/sdk-core';
 
 import { TokenFeeDetector__factory } from '../types/other/factories/TokenFeeDetector__factory';
 import { TokenFeeDetector } from '../types/other/TokenFeeDetector';
-import { log, WRAPPED_NATIVE_CURRENCY } from '../util';
+import { log, metric, MetricLoggerUnit, WRAPPED_NATIVE_CURRENCY } from '../util';
 
 import { ProviderConfig } from './provider';
 
@@ -93,12 +93,18 @@ export class OnChainTokenFeeFetcher implements ITokenFeeFetcher {
               blockTag: providerConfig?.blockNumber,
             }
           );
+
+          metric.putMetric("TokenFeeFetcherFetchFeesSuccess", 1, MetricLoggerUnit.Count)
+
           return { address, ...feeResult };
         } catch (err) {
           log.error(
             { err },
             `Error calling validate on-chain for token ${address}`
           );
+
+          metric.putMetric("TokenFeeFetcherFetchFeesFailure", 1, MetricLoggerUnit.Count)
+
           // in case of FOT token fee fetch failure, we return null
           // so that they won't get returned from the token-fee-fetcher
           // and thus no fee will be applied, and the cache won't cache on FOT tokens with failed fee fetching

--- a/src/providers/token-properties-provider.ts
+++ b/src/providers/token-properties-provider.ts
@@ -91,6 +91,14 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
       const cachedValue = tokenProperties[address];
       if (cachedValue) {
         metric.putMetric("TokenPropertiesProviderBatchGetCacheHit", 1, MetricLoggerUnit.Count)
+        const tokenFee = cachedValue.tokenFeeResult;
+        const tokenFeeResultExists: BigNumber | undefined = tokenFee && (tokenFee.buyFeeBps || tokenFee.sellFeeBps)
+
+        if (tokenFeeResultExists) {
+          metric.putMetric(`TokenPropertiesProviderCacheHitTokenFeeResultExists${tokenFeeResultExists}`, 1, MetricLoggerUnit.Count)
+        } else {
+          metric.putMetric(`TokenPropertiesProviderCacheHitTokenFeeResultNotExists`, 1, MetricLoggerUnit.Count)
+        }
 
         tokenToResult[address] = cachedValue;
       } else if (
@@ -127,7 +135,7 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
             // so that we can accurately log the token fee for a particular quote request (without breaching metrics dimensionality limit)
             // in the form of metrics.
             // if we log as logging, given prod traffic volume, the logging volume will be high.
-            metric.putMetric(`TokenPropertiesProviderTokenFeeResultExists${tokenFeeResultExists}`, 1, MetricLoggerUnit.Count)
+            metric.putMetric(`TokenPropertiesProviderTokenFeeResultCacheMissExists${tokenFeeResultExists}`, 1, MetricLoggerUnit.Count)
             const tokenResultForAddress = tokenToResult[address];
 
             if (tokenResultForAddress) {
@@ -146,7 +154,7 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
               }
             );
           } else {
-            metric.putMetric(`TokenPropertiesProviderTokenFeeResultNotExists`, 1, MetricLoggerUnit.Count)
+            metric.putMetric(`TokenPropertiesProviderTokenFeeResultCacheMissNotExists`, 1, MetricLoggerUnit.Count)
             return Promise.resolve(true);
           }
         })

--- a/src/providers/token-validator-provider.ts
+++ b/src/providers/token-validator-provider.ts
@@ -90,7 +90,7 @@ export class TokenValidatorProvider implements ITokenValidatorProvider {
             this.CACHE_KEY(this.chainId, address)
           ))!;
 
-        metric.putMetric("TokenValidatorProviderValidateCacheHit", 1, MetricLoggerUnit.Count)
+        metric.putMetric(`TokenValidatorProviderValidateCacheHitResult${tokenToResult[address.toLowerCase()]}`, 1, MetricLoggerUnit.Count)
       } else {
         addresses.push(address);
       }
@@ -164,8 +164,7 @@ export class TokenValidatorProvider implements ITokenValidatorProvider {
         tokenToResult[token.address.toLowerCase()]!
       );
 
-      metric.putMetric("TokenValidatorProviderValidateCacheMiss", 1, MetricLoggerUnit.Count)
-      metric.putMetric(`TokenValidatorProviderValidateResult${validationResult}`, 1, MetricLoggerUnit.Count)
+      metric.putMetric(`TokenValidatorProviderValidateCacheMissResult${validationResult}`, 1, MetricLoggerUnit.Count)
     }
 
     return {

--- a/src/providers/token-validator-provider.ts
+++ b/src/providers/token-validator-provider.ts
@@ -165,7 +165,7 @@ export class TokenValidatorProvider implements ITokenValidatorProvider {
       );
 
       metric.putMetric("TokenValidatorProviderValidateCacheMiss", 1, MetricLoggerUnit.Count)
-      metric.putMetric(`TokenValidatorProviderValidateResult${tokenToResult[token.address.toLowerCase()]?.toString()}`, 1, MetricLoggerUnit.Count)
+      metric.putMetric(`TokenValidatorProviderValidateResult${validationResult}`, 1, MetricLoggerUnit.Count)
     }
 
     return {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Observability

- **What is the current behavior?** (You can also link to an open issue here)
We see sporadic FOT quote without FOT tax. We have a theory, but we need to improve logging and metrics to be sure.

- **What is the new behavior (if this is a feature change)?**
Add more logging and metrics.

Those new metrics together will tell us that when the FOT tax is not returned for FOT token, it will tell us:

1. if it's due to the token-validator contract call failure, then `TokenValidatorProviderValidateFailed` will increment and shows up in the log insights within the same request id. Also the logs containining 'Failed to validate token' will definitively show up now, vs at 10% chance previously.
2. if token-validator contract call succeeds, but somehow contract returns incorrect validation result, then `TokenValidatorProviderValidateSuccess` will show up, and `TokenValidatorProviderValidateCacheMissResult0` will show up as well. Note only `TokenValidatorProviderValidateCacheMissResult1` indicates it's FOT token.
3. If token-validator has cache hit, and didn't call contract, but cache value was not FOT by mistake, then `TokenValidatorProviderValidateCacheHitResult0` shows up, but none of `TokenPropertiesProviderCacheHitTokenFeeResultExists${feeBps}` & `TokenPropertiesProviderCacheHitTokenFeeResultNotExists` & `TokenPropertiesProviderTokenFeeResultCacheMissExists${feeBps}` & `TokenPropertiesProviderTokenFeeResultCacheMissNotExists`. Note only `TokenValidatorProviderValidateCacheHitResult1` indicates it's FOT token.
4. If token-fee-fetcher contract call fails, then `TokenFeeFetcherFetchFeesFailure` will show up.
5. If token-fee-fetcher contract call succeeds, but it doesn't return any fee, then `TokenPropertiesProviderTokenFeeResultCacheMissNotExists` will show up.
6. If token-fee-fetcher contract call succeeds, but somehow incorrectly returns 0 bps for FOT tax, then `TokenPropertiesProviderTokenFeeResultCacheMissExists0` will show up.
7. If token-fee-fetcher has cache hit, and didn't call contract, but cache value does not contain FOT tax by mistake, then `TokenPropertiesProviderCacheHitTokenFeeResultNotExists` will show up.

We think 1 is what's happening in beta, but we can use those metrics 

- **Other information**:
Below is a screenshot of AWS log insights having successful token validator contract call and token fee contract call, with both cache misses:
<img width="1218" alt="Screenshot 2023-09-22 at 11 08 51 AM" src="https://github.com/Uniswap/smart-order-router/assets/91580504/248a2b33-28a0-49de-afc4-8ec29baae590">
