### PR TITLE
Fix: Remove token validator provider calls from token properties provider

### DIFF
--- a/cli/base-command.ts
+++ b/cli/base-command.ts
@@ -41,7 +41,6 @@ import {
   TenderlySimulator,
   TokenPropertiesProvider,
   TokenProvider,
-  TokenValidatorProvider,
   UniswapMulticallProvider,
   V2PoolProvider,
   V3PoolProvider,
@@ -287,18 +286,12 @@ export abstract class BaseCommand extends Command {
         new V3PoolProvider(chainId, multicall2Provider),
         new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false }))
       );
-      const tokenValidatorProvider = new TokenValidatorProvider(
-        chainId,
-        multicall2Provider,
-        new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false }))
-      )
       const tokenFeeFetcher = new OnChainTokenFeeFetcher(
         chainId,
         provider
       )
       const tokenPropertiesProvider = new TokenPropertiesProvider(
         chainId,
-        tokenValidatorProvider,
         new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false })),
         tokenFeeFetcher
       )

--- a/src/providers/cache-node.ts
+++ b/src/providers/cache-node.ts
@@ -22,8 +22,12 @@ export class NodeJSCache<T> implements ICache<T> {
     return result;
   }
 
-  async set(key: string, value: T): Promise<boolean> {
-    return this.nodeCache.set(key, value);
+  async set(key: string, value: T, ttl?: number): Promise<boolean> {
+    if (ttl) {
+      return this.nodeCache.set(key, value, ttl);
+    } else {
+      return this.nodeCache.set(key, value);
+    }
   }
 
   async has(key: string): Promise<boolean> {

--- a/src/providers/cache.ts
+++ b/src/providers/cache.ts
@@ -11,7 +11,7 @@ export interface ICache<T> {
 
   batchGet(keys: Set<string>): Promise<Record<string, T | undefined>>;
 
-  set(key: string, value: T): Promise<boolean>;
+  set(key: string, value: T, ttl?: number): Promise<boolean>;
 
   has(key: string): Promise<boolean>;
 }

--- a/src/providers/token-properties-provider.ts
+++ b/src/providers/token-properties-provider.ts
@@ -118,11 +118,12 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
             // in the form of metrics.
             // if we log as logging, given prod traffic volume, the logging volume will be high.
             metric.putMetric(`TokenPropertiesProviderTokenFeeResultCacheMissExists${tokenFeeResultExists}`, 1, MetricLoggerUnit.Count)
-            const tokenResultForAddress = tokenToResult[address];
 
-            if (tokenResultForAddress) {
-              tokenResultForAddress.tokenFeeResult = tokenFee;
+            const tokenPropertiesResult = {
+              tokenFeeResult: tokenFee,
+              tokenValidationResult: TokenValidationResult.FOT,
             }
+            tokenToResult[address] = tokenPropertiesResult;
 
             metric.putMetric("TokenPropertiesProviderBatchGetCacheMiss", 1, MetricLoggerUnit.Count)
 
@@ -130,20 +131,21 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
             // at this point, we are confident that the tokens are FOT, so we can hardcode the validation result
             return this.tokenPropertiesCache.set(
               this.CACHE_KEY(this.chainId, address),
-              {
-                tokenFeeResult: tokenFee,
-                tokenValidationResult: TokenValidationResult.FOT,
-              } as TokenPropertiesResult,
+              tokenPropertiesResult,
               this.positiveCacheEntryTTL
             );
           } else {
             metric.putMetric(`TokenPropertiesProviderTokenFeeResultCacheMissNotExists`, 1, MetricLoggerUnit.Count)
+
+            const tokenPropertiesResult = {
+              tokenFeeResult: undefined,
+              tokenValidationResult: undefined,
+            }
+            tokenToResult[address] = tokenPropertiesResult;
+
             return this.tokenPropertiesCache.set(
               this.CACHE_KEY(this.chainId, address),
-              {
-                tokenFeeResult: undefined,
-                tokenValidationResult: undefined,
-              } as TokenPropertiesResult,
+              tokenPropertiesResult,
               this.negativeCacheEntryTTL
             );
           }

--- a/src/providers/token-properties-provider.ts
+++ b/src/providers/token-properties-provider.ts
@@ -21,7 +21,7 @@ export const DEFAULT_TOKEN_PROPERTIES_RESULT: TokenPropertiesResult = {
   tokenFeeResult: DEFAULT_TOKEN_FEE_RESULT,
 };
 export const POSITIVE_CACHE_ENTRY_TTL = 600; // 10 minutes in seconds
-export const NEGATIVE_CACHE_ENTRY_TTL = 10; // 10 seconds
+export const NEGATIVE_CACHE_ENTRY_TTL = 600; // 10 minutes in seconds
 
 type Address = string;
 export type TokenPropertiesResult = {

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -596,7 +596,6 @@ export class AlphaRouter
     } else {
       this.tokenPropertiesProvider = new TokenPropertiesProvider(
         this.chainId,
-        this.tokenValidatorProvider!,
         new NodeJSCache(new NodeCache({ stdTTL: 86400, useClones: false })),
         new OnChainTokenFeeFetcher(this.chainId, provider)
       )

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -68,7 +68,6 @@ import {
   WETH9,
   WNATIVE_ON,
   TokenPropertiesProvider,
-  TokenValidatorProvider,
 } from '../../../../src';
 import { OnChainTokenFeeFetcher } from '../../../../src/providers/token-fee-fetcher';
 import { DEFAULT_ROUTING_CONFIG_BY_CHAIN } from '../../../../src/routers/alpha-router/config';
@@ -484,18 +483,12 @@ describe('alpha router integration', () => {
       new V3PoolProvider(ChainId.MAINNET, multicall2Provider),
       new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false }))
     );
-    const tokenValidatorProvider = new TokenValidatorProvider(
-      ChainId.MAINNET,
-      multicall2Provider,
-      new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false }))
-    )
     const tokenFeeFetcher = new OnChainTokenFeeFetcher(
       ChainId.MAINNET,
       hardhat.provider
     )
     const tokenPropertiesProvider = new TokenPropertiesProvider(
       ChainId.MAINNET,
-      tokenValidatorProvider,
       new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false })),
       tokenFeeFetcher
     )
@@ -2708,18 +2701,12 @@ describe('quote for other networks', () => {
             new V3PoolProvider(chain, multicall2Provider),
             new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false }))
           );
-          const tokenValidatorProvider = new TokenValidatorProvider(
-            ChainId.MAINNET,
-            multicall2Provider,
-            new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false }))
-          )
           const tokenFeeFetcher = new OnChainTokenFeeFetcher(
             ChainId.MAINNET,
             hardhat.provider
           )
           const tokenPropertiesProvider = new TokenPropertiesProvider(
             ChainId.MAINNET,
-            tokenValidatorProvider,
             new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false })),
             tokenFeeFetcher
           )

--- a/test/unit/providers/cache-node.test.ts
+++ b/test/unit/providers/cache-node.test.ts
@@ -2,7 +2,8 @@ import NodeCache from 'node-cache';
 import { NodeJSCache } from '../../../build/main';
 
 describe('NodeJSCache', () => {
-  const cache = new NodeJSCache<string>(new NodeCache())
+  const underlyingCache = new NodeCache()
+  const cache = new NodeJSCache<string>(underlyingCache)
 
   it('set keys and batchGet', async () => {
     await Promise.all([
@@ -15,4 +16,17 @@ describe('NodeJSCache', () => {
     expect(batchGet['key2']).toEqual('value2');
     expect(batchGet['key3']).toBeUndefined();
   });
+
+  it('set keys with ttl', async () => {
+    const currentEpochTimeInSeconds = Math.floor(Date.now() / 1000);
+
+    await Promise.all([
+      cache.set('key1', 'value1', 600),
+      cache.set('key2', 'value2', 10)
+    ]);
+
+    // rounded milliseconds to seconds, so that the flaky test failure due to millisecond difference is avoided
+    expect(Math.floor((underlyingCache.getTtl('key1') ?? 0) / 1000)).toEqual(currentEpochTimeInSeconds + 600);
+    expect(Math.floor((underlyingCache.getTtl('key2') ?? 0) / 1000)).toEqual(currentEpochTimeInSeconds + 10);
+  })
 });

--- a/test/unit/providers/cache-node.test.ts
+++ b/test/unit/providers/cache-node.test.ts
@@ -1,5 +1,5 @@
 import NodeCache from 'node-cache';
-import { NodeJSCache } from '../../../build/main';
+import { NodeJSCache } from '../../../src';
 
 describe('NodeJSCache', () => {
   const underlyingCache = new NodeCache()


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Token validator providers can return out-of-order results for the input token addresses. Coupled with the long caching TTL across all token properties entries, it can provider very negative experiences to the clients.

- **What is the new behavior (if this is a feature change)?**
Token properties provider remove the calls to token validator providers. Also enhanced the `NodeJSCache` to accept per-entry TTL, so that token properties provider can set differentiated per-entry TTL depending on if it's positive cache or negative cache.

- **Other information**:
tested on the routing-api integ-test side via personal AWS account.