### PR TITLE
Fix: base token no fot fee lookup

### DIFF
--- a/src/providers/token-fee-fetcher.ts
+++ b/src/providers/token-fee-fetcher.ts
@@ -73,7 +73,8 @@ export class OnChainTokenFeeFetcher implements ITokenFeeFetcher {
   ): Promise<TokenFeeMap> {
     const tokenToResult: TokenFeeMap = {};
 
-    const functionParams = addresses.map((address) => [
+    const addressesWithoutBaseToken = addresses.filter((address) => address === this.BASE_TOKEN)
+    const functionParams = addressesWithoutBaseToken.map((address) => [
       address,
       this.BASE_TOKEN,
       this.amountToFlashBorrow,

--- a/src/providers/token-fee-fetcher.ts
+++ b/src/providers/token-fee-fetcher.ts
@@ -4,7 +4,12 @@ import { ChainId } from '@uniswap/sdk-core';
 
 import { TokenFeeDetector__factory } from '../types/other/factories/TokenFeeDetector__factory';
 import { TokenFeeDetector } from '../types/other/TokenFeeDetector';
-import { log, metric, MetricLoggerUnit, WRAPPED_NATIVE_CURRENCY } from '../util';
+import {
+  log,
+  metric,
+  MetricLoggerUnit,
+  WRAPPED_NATIVE_CURRENCY,
+} from '../util';
 
 import { ProviderConfig } from './provider';
 
@@ -73,7 +78,9 @@ export class OnChainTokenFeeFetcher implements ITokenFeeFetcher {
   ): Promise<TokenFeeMap> {
     const tokenToResult: TokenFeeMap = {};
 
-    const addressesWithoutBaseToken = addresses.filter((address) => address === this.BASE_TOKEN)
+    const addressesWithoutBaseToken = addresses.filter(
+      (address) => address === this.BASE_TOKEN
+    );
     const functionParams = addressesWithoutBaseToken.map((address) => [
       address,
       this.BASE_TOKEN,
@@ -95,7 +102,11 @@ export class OnChainTokenFeeFetcher implements ITokenFeeFetcher {
             }
           );
 
-          metric.putMetric("TokenFeeFetcherFetchFeesSuccess", 1, MetricLoggerUnit.Count)
+          metric.putMetric(
+            'TokenFeeFetcherFetchFeesSuccess',
+            1,
+            MetricLoggerUnit.Count
+          );
 
           return { address, ...feeResult };
         } catch (err) {
@@ -104,7 +115,11 @@ export class OnChainTokenFeeFetcher implements ITokenFeeFetcher {
             `Error calling validate on-chain for token ${address}`
           );
 
-          metric.putMetric("TokenFeeFetcherFetchFeesFailure", 1, MetricLoggerUnit.Count)
+          metric.putMetric(
+            'TokenFeeFetcherFetchFeesFailure',
+            1,
+            MetricLoggerUnit.Count
+          );
 
           // in case of FOT token fee fetch failure, we return null
           // so that they won't get returned from the token-fee-fetcher

--- a/src/providers/token-fee-fetcher.ts
+++ b/src/providers/token-fee-fetcher.ts
@@ -79,7 +79,7 @@ export class OnChainTokenFeeFetcher implements ITokenFeeFetcher {
     const tokenToResult: TokenFeeMap = {};
 
     const addressesWithoutBaseToken = addresses.filter(
-      (address) => address === this.BASE_TOKEN
+      (address) => address !== this.BASE_TOKEN
     );
     const functionParams = addressesWithoutBaseToken.map((address) => [
       address,

--- a/src/providers/token-properties-provider.ts
+++ b/src/providers/token-properties-provider.ts
@@ -16,7 +16,6 @@ import {
   TokenValidationResult,
 } from './token-validator-provider';
 
-
 export const DEFAULT_TOKEN_PROPERTIES_RESULT: TokenPropertiesResult = {
   tokenFeeResult: DEFAULT_TOKEN_FEE_RESULT,
 };
@@ -56,7 +55,10 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
   ): Promise<TokenPropertiesMap> {
     const tokenToResult: TokenPropertiesMap = {};
 
-    if (!providerConfig?.enableFeeOnTransferFeeFetching || this.chainId !== ChainId.MAINNET) {
+    if (
+      !providerConfig?.enableFeeOnTransferFeeFetching ||
+      this.chainId !== ChainId.MAINNET
+    ) {
       return tokenToResult;
     }
 
@@ -71,21 +73,34 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
     for (const address of addressesRaw) {
       const cachedValue = tokenProperties[address];
       if (cachedValue) {
-        metric.putMetric("TokenPropertiesProviderBatchGetCacheHit", 1, MetricLoggerUnit.Count)
+        metric.putMetric(
+          'TokenPropertiesProviderBatchGetCacheHit',
+          1,
+          MetricLoggerUnit.Count
+        );
         const tokenFee = cachedValue.tokenFeeResult;
-        const tokenFeeResultExists: BigNumber | undefined = tokenFee && (tokenFee.buyFeeBps || tokenFee.sellFeeBps)
+        const tokenFeeResultExists: BigNumber | undefined =
+          tokenFee && (tokenFee.buyFeeBps || tokenFee.sellFeeBps);
 
         if (tokenFeeResultExists) {
-          metric.putMetric(`TokenPropertiesProviderCacheHitTokenFeeResultExists${tokenFeeResultExists}`, 1, MetricLoggerUnit.Count)
+          metric.putMetric(
+            `TokenPropertiesProviderCacheHitTokenFeeResultExists${tokenFeeResultExists}`,
+            1,
+            MetricLoggerUnit.Count
+          );
         } else {
-          metric.putMetric(`TokenPropertiesProviderCacheHitTokenFeeResultNotExists`, 1, MetricLoggerUnit.Count)
+          metric.putMetric(
+            `TokenPropertiesProviderCacheHitTokenFeeResultNotExists`,
+            1,
+            MetricLoggerUnit.Count
+          );
         }
 
         tokenToResult[address] = cachedValue;
       } else if (this.allowList.has(address)) {
         tokenToResult[address] = {
-          tokenValidationResult: TokenValidationResult.UNKN
-        }
+          tokenValidationResult: TokenValidationResult.UNKN,
+        };
       } else {
         addressesToFetchFeesOnchain.push(address);
       }
@@ -109,7 +124,8 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
       await Promise.all(
         addressesToFetchFeesOnchain.map((address) => {
           const tokenFee = tokenFeeMap[address];
-          const tokenFeeResultExists: BigNumber | undefined = tokenFee && (tokenFee.buyFeeBps || tokenFee.sellFeeBps)
+          const tokenFeeResultExists: BigNumber | undefined =
+            tokenFee && (tokenFee.buyFeeBps || tokenFee.sellFeeBps);
 
           if (tokenFeeResultExists) {
             // we will leverage the metric to log the token fee result, if it exists
@@ -117,15 +133,23 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
             // so that we can accurately log the token fee for a particular quote request (without breaching metrics dimensionality limit)
             // in the form of metrics.
             // if we log as logging, given prod traffic volume, the logging volume will be high.
-            metric.putMetric(`TokenPropertiesProviderTokenFeeResultCacheMissExists${tokenFeeResultExists}`, 1, MetricLoggerUnit.Count)
+            metric.putMetric(
+              `TokenPropertiesProviderTokenFeeResultCacheMissExists${tokenFeeResultExists}`,
+              1,
+              MetricLoggerUnit.Count
+            );
 
             const tokenPropertiesResult = {
               tokenFeeResult: tokenFee,
               tokenValidationResult: TokenValidationResult.FOT,
-            }
+            };
             tokenToResult[address] = tokenPropertiesResult;
 
-            metric.putMetric("TokenPropertiesProviderBatchGetCacheMiss", 1, MetricLoggerUnit.Count)
+            metric.putMetric(
+              'TokenPropertiesProviderBatchGetCacheMiss',
+              1,
+              MetricLoggerUnit.Count
+            );
 
             // update cache concurrently
             // at this point, we are confident that the tokens are FOT, so we can hardcode the validation result
@@ -135,12 +159,16 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
               this.positiveCacheEntryTTL
             );
           } else {
-            metric.putMetric(`TokenPropertiesProviderTokenFeeResultCacheMissNotExists`, 1, MetricLoggerUnit.Count)
+            metric.putMetric(
+              `TokenPropertiesProviderTokenFeeResultCacheMissNotExists`,
+              1,
+              MetricLoggerUnit.Count
+            );
 
             const tokenPropertiesResult = {
               tokenFeeResult: undefined,
               tokenValidationResult: undefined,
-            }
+            };
             tokenToResult[address] = tokenPropertiesResult;
 
             return this.tokenPropertiesCache.set(

--- a/test/test-util/mock-data.ts
+++ b/test/test-util/mock-data.ts
@@ -416,3 +416,13 @@ export const STETH = new Token(
     BigNumber.from(0),
     BigNumber.from(0)
 )
+export const BITBOY = new Token(
+  ChainId.MAINNET,
+  '0x4a500ed6add5994569e66426588168705fcc9767',
+  8,
+  'BITBOY',
+  'BitBoy Fund',
+  false,
+  BigNumber.from(300),
+  BigNumber.from(300)
+)

--- a/test/unit/providers/token-fee-fetcher.test.ts
+++ b/test/unit/providers/token-fee-fetcher.test.ts
@@ -1,0 +1,41 @@
+import { ID_TO_PROVIDER } from '../../../src';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { ChainId, WETH9 } from '@uniswap/sdk-core';
+import {
+  ITokenFeeFetcher,
+  OnChainTokenFeeFetcher
+} from '../../../src/providers/token-fee-fetcher';
+import { BITBOY, BULLET } from '../../test-util/mock-data';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+describe('TokenFeeFetcher', () => {
+  let tokenFeeFetcher: ITokenFeeFetcher;
+
+  beforeAll(async () => {
+    const chain = ChainId.MAINNET;
+    const chainProvider = ID_TO_PROVIDER(chain);
+    const provider = new JsonRpcProvider(chainProvider, chain);
+
+    tokenFeeFetcher = new OnChainTokenFeeFetcher(chain, provider);
+  });
+
+  it('Fetch WETH and BITBOY, should only return BITBOY', async () => {
+    const tokenFeeMap = await tokenFeeFetcher.fetchFees([WETH9[ChainId.MAINNET]!.address, BITBOY.address])
+    expect(tokenFeeMap).not.toContain(WETH9[ChainId.MAINNET]!.address)
+    expect(tokenFeeMap[BITBOY.address]).toBeDefined()
+    expect(tokenFeeMap[BITBOY.address]?.buyFeeBps).toEqual(BITBOY.buyFeeBps)
+    expect(tokenFeeMap[BITBOY.address]?.sellFeeBps).toEqual(BITBOY.sellFeeBps)
+  });
+
+  it('Fetch BULLET and BITBOY, should return BOTH', async () => {
+    const tokenFeeMap = await tokenFeeFetcher.fetchFees([BULLET.address, BITBOY.address])
+    expect(tokenFeeMap[BULLET.address]).toBeDefined()
+    expect(tokenFeeMap[BULLET.address]?.buyFeeBps).toEqual(BULLET.buyFeeBps)
+    expect(tokenFeeMap[BULLET.address]?.sellFeeBps).toEqual(BULLET.sellFeeBps)
+    expect(tokenFeeMap[BITBOY.address]).toBeDefined()
+    expect(tokenFeeMap[BITBOY.address]?.buyFeeBps).toEqual(BITBOY.buyFeeBps)
+    expect(tokenFeeMap[BITBOY.address]?.sellFeeBps).toEqual(BITBOY.sellFeeBps)
+  });
+});


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

- **What is the current behavior?** (You can also link to an open issue here)
After shipping https://github.com/Uniswap/smart-order-router/pull/408, we start to see `TokenFeeFetcherFetchFeesFailure` metric showing up in prod. After investigation, this is due to [FeeOnTransferDetector](https://etherscan.io/address/0x19C97dc2a25845C7f9d1d519c8C2d4809c58b43f#code) reverted with `SameToken` error. This is possible when either tokenIn or tokenOut is ETH/WETH.

- **What is the new behavior (if this is a feature change)?**
From sor runtime, we don't pass in the address that's corresponding to the `BASE_TOKEN`.

- **Other information**:
Formatted both TokenPropertiesProvider and TokenFeeProvider files. Fix only in TokenFeeProvider.