### PR TITLE
fix base token lower casing for comparison

### DIFF
--- a/src/providers/token-fee-fetcher.ts
+++ b/src/providers/token-fee-fetcher.ts
@@ -79,7 +79,7 @@ export class OnChainTokenFeeFetcher implements ITokenFeeFetcher {
     const tokenToResult: TokenFeeMap = {};
 
     const addressesWithoutBaseToken = addresses.filter(
-      (address) => address !== this.BASE_TOKEN
+      (address) => address.toLowerCase() !== this.BASE_TOKEN.toLowerCase()
     );
     const functionParams = addressesWithoutBaseToken.map((address) => [
       address,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
I noticed that after shipping https://github.com/Uniswap/smart-order-router/pull/410, somehow there were still `SameToken` error. I was test trying some ETH => BITBOY quote last night in prod, and noticed that some quote still doesn't have FOT tax. For example this [quote](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20like*20*27ccd67598-fe11-40a8-9dad-b71e16261dd9*27*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*2020~queryId~'4581644f827fdc11-97aba52d-448dcfb-79a561f7-a05a61144d92d3e65dd4d~source~(~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-Ro-RoutingLambdaF7AD8A1A-erFTueZgLnZ1~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-R-RoutingLambda2C4DF0900-Bbcx5MI4vlM6))) is a cache hit from pool provider, and `V2DynamoCache` cache entry doesn't have FOT tax after my own inspection. Correspondingly, I see `SameToken` still being thrown from [FeeOnTransferDetector](https://etherscan.io/address/0x19C97dc2a25845C7f9d1d519c8C2d4809c58b43f#code).

- **What is the new behavior (if this is a feature change)?**
By fixing the lower casing, this should fix the `SameToken` error.

- **Other information**:
