### PR TITLE
Fix gas provider for Optimism Goerli

### DIFF
--- a/src/providers/v3/gas-data-provider.ts
+++ b/src/providers/v3/gas-data-provider.ts
@@ -37,7 +37,7 @@ export class OptimismGasDataProvider
     protected multicall2Provider: IMulticallProvider,
     gasPriceAddress?: string
   ) {
-    if (chainId !== ChainId.OPTIMISM && chainId !== ChainId.BASE) {
+    if (chainId !== ChainId.OPTIMISM && chainId !== ChainId.OPTIMISM_GOERLI && chainId !== ChainId.BASE) {
       throw new Error('This data provider is used only on optimism networks.');
     }
     this.gasOracleAddress = gasPriceAddress ?? OVM_GASPRICE_ADDRESS;

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -700,7 +700,7 @@ export class AlphaRouter
       swapRouterProvider ??
       new SwapRouterProvider(this.multicall2Provider, this.chainId);
 
-    if (chainId === ChainId.OPTIMISM || chainId === ChainId.BASE) {
+    if (chainId === ChainId.OPTIMISM || chainId === ChainId.OPTIMISM_GOERLI || chainId === ChainId.BASE) {
       this.l2GasDataProvider =
         optimismGasDataProvider ??
         new OptimismGasDataProvider(chainId, this.multicall2Provider);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a bug fix for using Optimism Goerli.
- **What is the current behavior?** (You can also link to an open issue here)
Currently, the `l2GasDataProvider` on the `AlphaRouter` class is left undefined when using `ChainId.OPTIMISM_GOERLI`. The following bug takes place when currently trying to get quotes on the network (example CLI usage):

```
iwooden@IsaacsMacStudio smart-order-router % ./bin/cli quote -a 10000 -c 420 -i 0xEaE90F3b07fBE00921173298FF04f416398f7101 -o 0x4200000000000000000000000000000000000006 --exactIn
    TypeError: Cannot destructure property 'l1BaseFee' of 'gasData' as it is undefined.
```
- **What is the new behavior (if this is a feature change)?**
The gas provider is properly assigned and Optimism Goerli can be used again:

```
iwooden@IsaacsMacStudio smart-order-router-fork % ./bin/cli quote -a 10000 -c 420 -i 0xEaE90F3b07fBE00921173298FF04f416398f7101 -o 0x4200000000000000000000000000000000000006 --exactIn                                                       
Best Route:
[V3] 60.00% = HAI -- 1% [0x260cCaE6bD9275cD9920f941cc3351E9668C8AAc] --> WETH, [V3] 35.00% = HAI -- 0.3% [0x3C2A9aED7715265Cb8bB354128984B2ad10AD784] --> WETH, [V3] 5.00% = HAI -- 0.05% [0x921a23487b305D99305106B45823f756C5534636] --> WETH
        Raw Quote Exact In:
                3.81
        Gas Adjusted Quote In:
                3.81

Gas Used Quote Token: 0.000053
Gas Used USD: 0.089828
Calldata: undefined
Value: undefined

  blockNumber: "15175188"
  estimatedGasUsed: "539000"
  gasPriceWei: "100000050"
Total ticks crossed: 8
```
- **Other information**:
N/A