### PR TITLE
Fix: in caching pool provider, always retrieve fot tax along with pool reserves in v2, and cache fot pool entity

### DIFF
--- a/src/providers/v2/caching-pool-provider.ts
+++ b/src/providers/v2/caching-pool-provider.ts
@@ -96,7 +96,10 @@ export class CachingV2PoolProvider implements IV2PoolProvider {
     if (poolsToGetAddresses.length > 0) {
       const poolAccessor = await this.poolProvider.getPools(
         poolsToGetTokenPairs,
-        providerConfig
+        {
+          ...providerConfig,
+          enableFeeOnTransferFeeFetching: true,
+        }
       );
       for (const address of poolsToGetAddresses) {
         const pool = poolAccessor.getPoolByAddress(address);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
There might be a race condition, where a quote request without `enableFeeOnTransferFeeFetching` flag can result in v2 caching-pool-provider to cache the pool entity without the FOT tax. Then within the same block, anothg quote request with `enableFeeOnTransferFeeFetching` flag can hit V2DynamoPair cache, that returns the cached pool entity without the FOT tax, disregard the `enableFeeOnTransferFeeFetching` flag from second quote request. I wouldn't call it a bug, but we probably have to work around to unblock mobile. Due to enableFeeOnTransferFeeFetching feature flag, there might be prod quote traffic, that hits the [caching-pool-provider](https://github.com/Uniswap/smart-order-router/blob/main/src/providers/v2/caching-pool-provider.ts#L102) cache miss path, that also passes down providerConfig.enableFeeOnTransferFeeFetching = undefined to [token-properties-provider](https://github.com/Uniswap/smart-order-router/blob/main/src/providers/token-properties-provider.ts#L59).

- **What is the new behavior (if this is a feature change)?**
For the first quote request, regardless of having `enableFeeOnTransferFeeFetching` flag or not, caching-pool-provider always retrieve the FOT tax from token-properties-provider by passing down the hardcoded `enableFeeOnTransferFeeFetching = true`. Then for the second quote request, the cached pool entity should have the FOT tax within the same block. The simplest fix is to hardcode providerConfig.enableFeeOnTransferFeeFetching = true and pass down to [token-properties-provider](https://github.com/Uniswap/smart-order-router/blob/main/src/providers/token-properties-provider.ts#L59). This guarantees cached pool entity always have FOT tax, if the reserve involves FOT. This is the first time this feature flag has embedded a opaque race condition. And assuming mobile and web actually adopted enableFeeOnTransferFeeFetching = true to 100% rollout, this wouldn't be an issue. But in order for mobile to roll out to 100%, they would press BE to fix unstable quote. (kind of a chicken-and-egg)

- **Other information**:
