### PR TITLE
Change the Tenderly API url from http to https

### DIFF
--- a/cli/base-command.ts
+++ b/cli/base-command.ts
@@ -299,7 +299,7 @@ export abstract class BaseCommand extends Command {
 
       const tenderlySimulator = new TenderlySimulator(
         chainId,
-        'http://api.tenderly.co',
+        'https://api.tenderly.co',
         process.env.TENDERLY_USER!,
         process.env.TENDERLY_PROJECT!,
         process.env.TENDERLY_ACCESS_KEY!,


### PR DESCRIPTION
As the title suggests, changed the Tenderly URL from HTTP to HTTPS, as the former led to simulations failing.