### PR TITLE
Avoid routing through AMPL on second hop

### DIFF
--- a/src/routers/alpha-router/config.ts
+++ b/src/routers/alpha-router/config.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@uniswap/sdk-core';
 
-import { AlphaRouterConfig } from './alpha-router';
+import { AlphaRouterConfig, LowerCaseStringArray } from './alpha-router';
 
 export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (
   chainId: ChainId
@@ -71,6 +71,9 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (
           topNDirectSwaps: 1,
           topNTokenInOut: 5,
           topNSecondHop: 2,
+          tokensToAvoidOnSecondHops: new LowerCaseStringArray(
+            '0xd46ba6d942050d489dbd938a2c909a5d5039a161' // AMPL on Mainnet
+          ),
           topNWithEachBaseToken: 2,
           topNWithBaseToken: 6,
         },

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -915,7 +915,7 @@ export async function getV2CandidatePools({
   );
   const tokenOutSecondHopAddresses = topByTVLUsingTokenOut.filter((pool) => {
     // filtering second hops
-    if (tokenInAddress === pool.token0.id) {
+    if (tokenOutAddress === pool.token0.id) {
       return !tokensToAvoidOnSecondHops?.includes(pool.token1.id.toLowerCase());
     } else {
       return !tokensToAvoidOnSecondHops?.includes(pool.token0.id.toLowerCase());

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -209,6 +209,7 @@ export async function getV3CandidatePools({
       topNTokenInOut,
       topNSecondHop,
       topNSecondHopForTokenAddress,
+      tokensToAvoidOnSecondHops,
       topNWithEachBaseToken,
       topNWithBaseToken,
     },
@@ -446,6 +447,7 @@ export async function getV3CandidatePools({
         .filter((subgraphPool) => {
           return (
             !poolAddressesSoFar.has(subgraphPool.id) &&
+            !tokensToAvoidOnSecondHops?.includes(secondHopId.toLowerCase()) &&
             (subgraphPool.token0.id == secondHopId ||
               subgraphPool.token1.id == secondHopId)
           );
@@ -469,6 +471,7 @@ export async function getV3CandidatePools({
         .filter((subgraphPool) => {
           return (
             !poolAddressesSoFar.has(subgraphPool.id) &&
+            !tokensToAvoidOnSecondHops?.includes(secondHopId.toLowerCase()) &&
             (subgraphPool.token0.id == secondHopId ||
               subgraphPool.token1.id == secondHopId)
           );
@@ -625,6 +628,7 @@ export async function getV2CandidatePools({
       topNDirectSwaps,
       topNTokenInOut,
       topNSecondHop,
+      tokensToAvoidOnSecondHops,
       topNWithEachBaseToken,
       topNWithBaseToken,
     },
@@ -899,11 +903,25 @@ export async function getV2CandidatePools({
   // Filtering step for second hops
   const topByTVLUsingTokenInSecondHopsMap: Map<string, SubcategorySelectionPools<V2SubgraphPool>> = new Map();
   const topByTVLUsingTokenOutSecondHopsMap: Map<string, SubcategorySelectionPools<V2SubgraphPool>> = new Map();
-  const tokenInSecondHopAddresses = topByTVLUsingTokenIn.map((pool) =>
-    tokenInAddress == pool.token0.id ? pool.token1.id : pool.token0.id
+  const tokenInSecondHopAddresses = topByTVLUsingTokenIn.filter((pool) => {
+    // filtering second hops
+    if (tokenInAddress === pool.token0.id) {
+      return !tokensToAvoidOnSecondHops?.includes(pool.token1.id.toLowerCase());
+    } else {
+      return !tokensToAvoidOnSecondHops?.includes(pool.token0.id.toLowerCase());
+    }
+  }).map((pool) =>
+    tokenInAddress === pool.token0.id ? pool.token1.id : pool.token0.id
   );
-  const tokenOutSecondHopAddresses = topByTVLUsingTokenOut.map((pool) =>
-    tokenOutAddress == pool.token0.id ? pool.token1.id : pool.token0.id
+  const tokenOutSecondHopAddresses = topByTVLUsingTokenOut.filter((pool) => {
+    // filtering second hops
+    if (tokenInAddress === pool.token0.id) {
+      return !tokensToAvoidOnSecondHops?.includes(pool.token1.id.toLowerCase());
+    } else {
+      return !tokensToAvoidOnSecondHops?.includes(pool.token0.id.toLowerCase());
+    }
+  }).map((pool) =>
+    tokenOutAddress === pool.token0.id ? pool.token1.id : pool.token0.id
   );
 
   for (const secondHopId of tokenInSecondHopAddresses) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature/BugFix

- **What is the current behavior?** (You can also link to an open issue here)
Currently AMPL, being a rebasing token, is paired with other tokens (namely COMP) in a way that the pools are broken. The AMPL/COMP pool is not synced, so the quoter believes theres more liquidity than there really is.

- **What is the new behavior (if this is a feature change)?**
There's not an easy solution to this problem, so the approach we are taking is of ignoring all AMPL paired pools on second hops.
This feature actually supports adding more tokens to this list as needed. 

- **Other information**:
