### PR TITLE
Fix: improve tenderly connection

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -304,15 +304,18 @@ export class TenderlySimulator extends Simulator {
         this.tenderlyProject
       );
 
+      metric.putMetric('TenderlySimulationUniversalRouterRequests', 1, MetricLoggerUnit.Count);
+
       const before = Date.now();
 
-      const resp = (
+      const { data: resp, status: httpStatus } = (
         await axios.post<TenderlyResponseUniversalRouter>(url, body, opts)
-      ).data;
+      );
 
       const latencies = Date.now() - before
       log.info(`Tenderly simulation universal router request body: ${body}, having latencies ${latencies} in milliseconds.`)
       metric.putMetric('TenderlySimulationUniversalRouterLatencies', Date.now() - before, MetricLoggerUnit.Milliseconds);
+      metric.putMetric('TenderlySimulationUniversalRouterResponseStatus', httpStatus);
 
       // Validate tenderly response body
       if (
@@ -396,11 +399,15 @@ export class TenderlySimulator extends Simulator {
         this.tenderlyProject
       );
 
+      metric.putMetric('TenderlySimulationSwapRouter02Requests', 1, MetricLoggerUnit.Count);
+
       const before = Date.now()
 
-      const resp = (
+      const { data: resp, status: httpStatus } = (
         await axios.post<TenderlyResponseSwapRouter02>(url, body, opts)
-      ).data;
+      );
+
+      metric.putMetric('TenderlySimulationSwapRouter02ResponseStatus', httpStatus);
 
       const latencies = Date.now() - before
       log.info(`Tenderly simulation swap router02 request body: ${body}, having latencies ${latencies} in milliseconds.`)


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently we don't have monitoring against the downstream tenderly http call success rate

- **What is the new behavior (if this is a feature change)?**
We are logging the http status from tenderly against the tenderly request count.

- **Other information**:
This was a follow-up item from the [incident](https://www.notion.so/uniswaplabs/New-tokens-swap-outages-on-Wallet-due-to-Tenderly-enforcing-HTTPS-aad4719087f0407d8a9b21f0137fd070?pvs=4#86b9072133b949a6b9e636dfcca1e76e). We cannot alert against tenderly simulation failures, because those could be genuine failures due to user wallet, market conditions, etc. However non-2xx HTTP status code returned from tenderly should be a good success rate metric.

Tested in local routing-api, and can see new metrics:
![Screenshot 2023-11-14 at 3 43 37 PM](https://github.com/Uniswap/smart-order-router/assets/91580504/57d1d6ba-9b18-4d5a-a97c-01a18807db60)
