### PR TITLE
Fix: cli tenderly base url

### DIFF
--- a/cli/base-command.ts
+++ b/cli/base-command.ts
@@ -301,7 +301,7 @@ export abstract class BaseCommand extends Command {
       const portionProvider = new PortionProvider();
       const tenderlySimulator = new TenderlySimulator(
         chainId,
-        'http://api.tenderly.co',
+        'https://api.tenderly.co',
         process.env.TENDERLY_USER!,
         process.env.TENDERLY_PROJECT!,
         process.env.TENDERLY_ACCESS_KEY!,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
SOR CLI still uses the deprecated Tenderly HTTP endpoint. It's going to be inaccessible.

- **What is the new behavior (if this is a feature change)?**
Fix it to use HTTPS

- **Other information**:
Replicated https://github.com/Uniswap/smart-order-router/pull/426
