### PR TITLE
fix: eth_feeHistory by passing 'latest' block number, meanwhile preserving the researcher's ability to quote against past number including gas fees

### DIFF
--- a/src/providers/caching-gas-provider.ts
+++ b/src/providers/caching-gas-provider.ts
@@ -43,7 +43,6 @@ export class CachingGasStationProvider extends IGasPriceProvider {
       return cachedGasPrice;
     }
 
-    log.info('Gas station price local cache miss.');
     const gasPrice = await this.gasPriceProvider.getGasPrice(latestBlockNumber, requestBlockNumber);
     await this.cache.set(this.GAS_KEY(this.chainId, targetBlockNumber), gasPrice);
 

--- a/src/providers/caching-gas-provider.ts
+++ b/src/providers/caching-gas-provider.ts
@@ -28,8 +28,11 @@ export class CachingGasStationProvider extends IGasPriceProvider {
     super();
   }
 
-  public override async getGasPrice(requestBlockNumber: number): Promise<GasPrice> {
-    const cachedGasPrice = await this.cache.get(this.GAS_KEY(this.chainId, requestBlockNumber));
+  public override async getGasPrice(latestBlockNumber: number, requestBlockNumber?: number): Promise<GasPrice> {
+    // If block number is specified in the request, we have to use that block number find any potential cache hits.
+    // Otherwise, we can use the latest block number.
+    const targetBlockNumber = requestBlockNumber ?? latestBlockNumber;
+    const cachedGasPrice = await this.cache.get(this.GAS_KEY(this.chainId, targetBlockNumber));
 
     if (cachedGasPrice) {
       log.info(
@@ -41,8 +44,8 @@ export class CachingGasStationProvider extends IGasPriceProvider {
     }
 
     log.info('Gas station price local cache miss.');
-    const gasPrice = await this.gasPriceProvider.getGasPrice(requestBlockNumber);
-    await this.cache.set(this.GAS_KEY(this.chainId, requestBlockNumber), gasPrice);
+    const gasPrice = await this.gasPriceProvider.getGasPrice(latestBlockNumber, requestBlockNumber);
+    await this.cache.set(this.GAS_KEY(this.chainId, targetBlockNumber), gasPrice);
 
     return gasPrice;
   }

--- a/src/providers/eip-1559-gas-price-provider.ts
+++ b/src/providers/eip-1559-gas-price-provider.ts
@@ -53,7 +53,7 @@ export class EIP1559GasPriceProvider extends IGasPriceProvider {
       // If the block number is not specified, we have to send hardcoded 'latest' to infura RPC
       // because Infura node pool is eventually consistent and may not have the latest block from our block number.
       // See https://uniswapteam.slack.com/archives/C023A7JDTJP/p1702485038251449?thread_ts=1702471203.519869&cid=C023A7JDTJP
-      requestBlockNumber ?? 'latest',
+      requestBlockNumber ? BigNumber.from(requestBlockNumber).toHexString().replace('0x0', '0x') : 'latest',
       [this.priorityFeePercentile],
     ])) as RawFeeHistoryResponse;
 

--- a/src/providers/eip-1559-gas-price-provider.ts
+++ b/src/providers/eip-1559-gas-price-provider.ts
@@ -43,14 +43,17 @@ export class EIP1559GasPriceProvider extends IGasPriceProvider {
     super();
   }
 
-  public override async getGasPrice(requestBlockNumber: number): Promise<GasPrice> {
+  public override async getGasPrice(_latestBlockNumber: number, requestBlockNumber?: number): Promise<GasPrice> {
     const feeHistoryRaw = (await this.provider.send('eth_feeHistory', [
       /**
        * @fix Use BigNumber.from(this.blocksToConsider).toHexString() after hardhat adds support
        * @see https://github.com/NomicFoundation/hardhat/issues/1585 .___.
        */
       BigNumber.from(this.blocksToConsider).toHexString().replace('0x0', '0x'),
-      BigNumber.from(requestBlockNumber).toHexString().replace('0x0', '0x'),
+      // If the block number is not specified, we have to send hardcoded 'latest' to infura RPC
+      // because Infura node pool is eventually consistent and may not have the latest block from our block number.
+      // See https://uniswapteam.slack.com/archives/C023A7JDTJP/p1702485038251449?thread_ts=1702471203.519869&cid=C023A7JDTJP
+      requestBlockNumber ?? 'latest',
       [this.priorityFeePercentile],
     ])) as RawFeeHistoryResponse;
 

--- a/src/providers/eth-gas-station-info-gas-price-provider.ts
+++ b/src/providers/eth-gas-station-info-gas-price-provider.ts
@@ -29,7 +29,7 @@ export class ETHGasStationInfoProvider extends IGasPriceProvider {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public override async getGasPrice(_requestBlockNumber: number): Promise<GasPrice> {
+  public override async getGasPrice(_latestBlockNumber: number, _requestBlockNumber?: number): Promise<GasPrice> {
     log.info(`About to get gas prices from gas station ${this.url}`);
     const response = await retry(
       async () => {

--- a/src/providers/eth-gas-station-info-gas-price-provider.ts
+++ b/src/providers/eth-gas-station-info-gas-price-provider.ts
@@ -30,7 +30,6 @@ export class ETHGasStationInfoProvider extends IGasPriceProvider {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public override async getGasPrice(_latestBlockNumber: number, _requestBlockNumber?: number): Promise<GasPrice> {
-    log.info(`About to get gas prices from gas station ${this.url}`);
     const response = await retry(
       async () => {
         return axios.get<ETHGasStationResponse>(this.url);

--- a/src/providers/gas-price-provider.ts
+++ b/src/providers/gas-price-provider.ts
@@ -8,5 +8,5 @@ export type GasPrice = {
  * Provider for getting gas prices.
  */
 export abstract class IGasPriceProvider {
-  public abstract getGasPrice(requestBlockNumber: number): Promise<GasPrice>;
+  public abstract getGasPrice(latestBlockNumber: number, requestBlockNumber?: number): Promise<GasPrice>;
 }

--- a/src/providers/legacy-gas-price-provider.ts
+++ b/src/providers/legacy-gas-price-provider.ts
@@ -1,7 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
 
-import { log } from '../util';
-
 import { GasPrice, IGasPriceProvider } from './gas-price-provider';
 
 export class LegacyGasPriceProvider extends IGasPriceProvider {
@@ -12,11 +10,6 @@ export class LegacyGasPriceProvider extends IGasPriceProvider {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public override async getGasPrice(_latestBlockNumber: number, _requestBlockNumber?: number): Promise<GasPrice> {
     const gasPriceWei = await this.provider.getGasPrice();
-    log.info(
-      { gasPriceWei },
-      `Got gas price ${gasPriceWei} using eth_gasPrice RPC`
-    );
-
     return {
       gasPriceWei,
     };

--- a/src/providers/legacy-gas-price-provider.ts
+++ b/src/providers/legacy-gas-price-provider.ts
@@ -10,7 +10,7 @@ export class LegacyGasPriceProvider extends IGasPriceProvider {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public override async getGasPrice(_requestBlockNumber: number): Promise<GasPrice> {
+  public override async getGasPrice(_latestBlockNumber: number, _requestBlockNumber?: number): Promise<GasPrice> {
     const gasPriceWei = await this.provider.getGasPrice();
     log.info(
       { gasPriceWei },

--- a/src/providers/on-chain-gas-price-provider.ts
+++ b/src/providers/on-chain-gas-price-provider.ts
@@ -27,11 +27,11 @@ export class OnChainGasPriceProvider extends IGasPriceProvider {
     super();
   }
 
-  public override async getGasPrice(requestBlockNumber: number): Promise<GasPrice> {
+  public override async getGasPrice(latestBlockNumber: number, requestBlockNumber?: number): Promise<GasPrice> {
     if (this.eipChains.includes(this.chainId)) {
-      return this.eip1559GasPriceProvider.getGasPrice(requestBlockNumber);
+      return this.eip1559GasPriceProvider.getGasPrice(latestBlockNumber, requestBlockNumber);
     }
 
-    return this.legacyGasPriceProvider.getGasPrice(requestBlockNumber);
+    return this.legacyGasPriceProvider.getGasPrice(latestBlockNumber, requestBlockNumber);
   }
 }

--- a/src/providers/static-gas-price-provider.ts
+++ b/src/providers/static-gas-price-provider.ts
@@ -6,7 +6,7 @@ import { GasPrice, IGasPriceProvider } from './gas-price-provider';
 export class StaticGasPriceProvider implements IGasPriceProvider {
   constructor(private gasPriceWei: BigNumber) {}
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async getGasPrice(_requestBlockNumber: number): Promise<GasPrice> {
+  async getGasPrice(_latestBlockNumber: number, _requestBlockNumber?: number): Promise<GasPrice> {
     return { gasPriceWei: this.gasPriceWei };
   }
 }

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -335,7 +335,13 @@ export class TenderlySimulator extends Simulator {
           url,
           body,
           opts
-        );
+        ).finally(() => {
+          metric.putMetric(
+            'TenderlySimulationLatencies',
+            Date.now() - before,
+            MetricLoggerUnit.Milliseconds
+          );
+        });
 
       const latencies = Date.now() - before;
       log.info(

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1079,7 +1079,7 @@ export class AlphaRouter
       log.warn(`Finalized routing config is ${JSON.stringify(routingConfig)}`);
     }
 
-    const gasPriceWei = await this.getGasPriceWei(await blockNumber);
+    const gasPriceWei = await this.getGasPriceWei(await blockNumber, await partialRoutingConfig.blockNumber);
 
     const quoteToken = quoteCurrency.wrapped;
     const providerConfig: ProviderConfig = {
@@ -1948,12 +1948,12 @@ export class AlphaRouter
     }
   }
 
-  private async getGasPriceWei(blockNumber: number): Promise<BigNumber> {
+  private async getGasPriceWei(latestBlockNumber: number, requestBlockNumber?: number): Promise<BigNumber> {
     // Track how long it takes to resolve this async call.
     const beforeGasTimestamp = Date.now();
 
     // Get an estimate of the gas price to use when estimating gas cost of different routes.
-    const { gasPriceWei } = await this.gasPriceProvider.getGasPrice(blockNumber);
+    const { gasPriceWei } = await this.gasPriceProvider.getGasPrice(latestBlockNumber, requestBlockNumber);
 
     metric.putMetric(
       'GasPriceLoad',


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We have some quote 5xx error, due to `eth_feeHistory failing on mainnet: request beyond head block: requested x_block_number, head y_block_number`. This is due to Infura node pool eventual consistency - not all the node in the same Infura node pool has the same block header.

- **What is the new behavior (if this is a feature change)?**
We pass in 'latest' in case quote request does not pass in the block number. This is to replace the numerical latest block number we pass to infura during `eth_feeHistory` RPC calls.

- **Other information**:
