### PR TITLE
copy fix: arbitrum network cost estimate

### DIFF
--- a/src/providers/v3/gas-data-provider.ts
+++ b/src/providers/v3/gas-data-provider.ts
@@ -121,9 +121,10 @@ export class ArbitrumGasDataProvider
       this.provider
     );
     const gasData = await gasDataContract.getPricesInWei();
+    const perL1CalldataByte = gasData[1];
     return {
       perL2TxFee: gasData[0],
-      perL1CalldataFee: gasData[1],
+      perL1CalldataFee: perL1CalldataByte.div(16),
       perArbGasTotal: gasData[5],
     };
   }

--- a/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/v3/v3-heuristic-gas-model.ts
@@ -13,7 +13,10 @@ import {
   OptimismGasData,
 } from '../../../../providers/v3/gas-data-provider';
 import { CurrencyAmount } from '../../../../util/amounts';
-import { getL2ToL1GasUsed } from '../../../../util/gas-factory-helpers';
+import {
+  calculateArbitrumToL1FeeFromCalldata,
+  getL2ToL1GasUsed
+} from '../../../../util/gas-factory-helpers';
 import { log } from '../../../../util/log';
 import {
   buildSwapMethodParameters,
@@ -419,7 +422,6 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
     swapConfig: SwapOptionsUniversalRouter,
     gasData: ArbitrumGasData
   ): [BigNumber, BigNumber] {
-    const { perL2TxFee, perL1CalldataFee } = gasData;
 
     const route: V3RouteWithValidQuote = routes[0]!;
 
@@ -439,11 +441,6 @@ export class V3HeuristicGasModelFactory extends IOnChainGasModelFactory {
       swapConfig,
       ChainId.ARBITRUM_ONE
     ).calldata;
-    // calculates gas amounts based on bytes of calldata, use 0 as overhead.
-    const l1GasUsed = getL2ToL1GasUsed(data, BigNumber.from(0));
-    // multiply by the fee per calldata and add the flat l2 fee
-    let l1Fee = l1GasUsed.mul(perL1CalldataFee);
-    l1Fee = l1Fee.add(perL2TxFee);
-    return [l1GasUsed, l1Fee];
+    return calculateArbitrumToL1FeeFromCalldata(data, gasData);
   }
 }

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -250,12 +250,9 @@ export async function calculateGasUsed(
   const gasPriceWei = route.gasPriceWei;
   // calculate L2 to L1 security fee if relevant
   let l2toL1FeeInWei = BigNumber.from(0);
-  if ([ChainId.ARBITRUM_ONE, ChainId.ARBITRUM_GOERLI].includes(chainId)) {
-    l2toL1FeeInWei = calculateArbitrumToL1FeeFromCalldata(
-      route.methodParameters!.calldata,
-      l2GasData as ArbitrumGasData
-    )[1];
-  } else if (
+  // Arbitrum charges L2 gas for L1 calldata posting costs.
+  // See https://github.com/Uniswap/smart-order-router/pull/464/files#r1441376802
+  if (
     [
       ChainId.OPTIMISM,
       ChainId.OPTIMISM_GOERLI,

--- a/test/unit/providers/v3/gas-data-provider.test.ts
+++ b/test/unit/providers/v3/gas-data-provider.test.ts
@@ -1,0 +1,29 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { ArbitrumGasDataProvider } from '../../../../src/providers/v3/gas-data-provider';
+import { BaseProvider } from '@ethersproject/providers';
+import sinon from 'sinon';
+
+class MockProvider extends BaseProvider {
+  _isProvider: boolean = true
+}
+
+describe('arbitrum gas data provider', () => {
+
+  let mockProvider: sinon.SinonStubbedInstance<MockProvider>;
+  let arbGasDataProvider: ArbitrumGasDataProvider;
+
+  beforeAll(() => {
+    mockProvider = sinon.createStubInstance(MockProvider)
+    mockProvider._isProvider = true
+    mockProvider.call.resolves("0x00000000000000000000000000000000000000000000000000003eb61132144000000000000000000000000000000000000000000000000000000072ac022fb0000000000000000000000000000000000000000000000000000001d1a94a20000000000000000000000000000000000000000000000000000000000005f5e10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005f5e100");
+    arbGasDataProvider = new ArbitrumGasDataProvider(42161, mockProvider)
+  });
+
+  test('get correct gas data', async () => {
+    await expect(arbGasDataProvider.getGasData()).resolves.toMatchObject({
+      perArbGasTotal: BigNumber.from('0x05f5e100'),
+      perL1CalldataFee: BigNumber.from('0x072ac022fb'),
+      perL2TxFee: BigNumber.from('0x3eb611321440'),
+    });
+  });
+});


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  This PR fixes 2 bugs that causes inflated network cost (gas fee) estimate for Arbitrum.

- **What is the current behavior?** (You can also link to an open issue here)
  Smart Order Router is inflating the Arbitrum fee due to double counting L1 fee and a incorrect unit conversion

- **What is the new behavior (if this is a feature change)?**
  1. Removed double counting of L1 fee in calculateGasUsed logic
  2. Converted per byte fee into per gas fee by dividing 16 

- **Other information**:
See discussions in https://github.com/Uniswap/smart-order-router/pull/464 for original PR. This PR is created because it runs within [https://github.com/Uniswap/smart-order-router](https://github.com/Uniswap/smart-order-router), which contains all the repo secrets to successfully run all the tests.

