### PR TITLE
fix for base goerli

### DIFF
--- a/src/providers/caching-token-provider.ts
+++ b/src/providers/caching-token-provider.ts
@@ -29,6 +29,7 @@ import {
   USDC_ARBITRUM_GOERLI,
   USDC_AVAX,
   USDC_BASE,
+  USDC_BASE_GOERLI,
   USDC_BNB,
   USDC_ETHEREUM_GNOSIS,
   USDC_MAINNET,
@@ -143,6 +144,10 @@ export const CACHE_SEED_TOKENS: {
   [ChainId.BASE]: {
     USDC: USDC_BASE,
     WETH: WRAPPED_NATIVE_CURRENCY[ChainId.BASE],
+  },
+  [ChainId.BASE_GOERLI]: {
+    USDC: USDC_BASE_GOERLI,
+    WETH: WRAPPED_NATIVE_CURRENCY[ChainId.BASE_GOERLI],
   },
   // Currently we do not have providers for Moonbeam mainnet or Gnosis testnet
 };

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -30,6 +30,7 @@ import {
   USDC_ARBITRUM_GOERLI,
   USDC_AVAX,
   USDC_BASE,
+  USDC_BASE_GOERLI,
   USDC_BNB,
   USDC_ETHEREUM_GNOSIS,
   USDC_MAINNET,
@@ -173,6 +174,7 @@ const baseTokensByChain: { [chainId in ChainId]?: Token[] } = {
   [ChainId.BNB]: [DAI_BNB, USDC_BNB, USDT_BNB],
   [ChainId.AVALANCHE]: [DAI_AVAX, USDC_AVAX],
   [ChainId.BASE]: [USDC_BASE],
+  [ChainId.BASE_GOERLI]: [USDC_BASE_GOERLI],
 };
 
 class SubcategorySelectionPools<SubgraphPool> {

--- a/src/routers/alpha-router/gas-models/gas-model.ts
+++ b/src/routers/alpha-router/gas-models/gas-model.ts
@@ -24,6 +24,7 @@ import {
   USDC_ARBITRUM_GOERLI,
   USDC_AVAX,
   USDC_BASE,
+  USDC_BASE_GOERLI,
   USDC_BNB,
   USDC_ETHEREUM_GNOSIS,
   USDC_GOERLI,
@@ -80,6 +81,7 @@ export const usdGasTokensByChain: { [chainId in ChainId]?: Token[] } = {
   [ChainId.BNB]: [USDT_BNB, USDC_BNB, DAI_BNB],
   [ChainId.AVALANCHE]: [DAI_AVAX, USDC_AVAX],
   [ChainId.BASE]: [USDC_BASE],
+  [ChainId.BASE_GOERLI]: [USDC_BASE_GOERLI],
 };
 
 export type L1ToL2GasCosts = {

--- a/src/routers/legacy-router/bases.ts
+++ b/src/routers/legacy-router/bases.ts
@@ -10,6 +10,7 @@ import {
   ITokenProvider,
   USDC_AVAX,
   USDC_BASE,
+  USDC_BASE_GOERLI,
   USDC_BNB,
   USDC_MAINNET,
   USDT_BNB,
@@ -65,7 +66,10 @@ export const BASES_TO_CHECK_TRADES_AGAINST = (
       DAI_AVAX,
     ],
     [ChainId.BASE]: [WRAPPED_NATIVE_CURRENCY[ChainId.BASE]!, USDC_BASE],
-    [ChainId.BASE_GOERLI]: [WRAPPED_NATIVE_CURRENCY[ChainId.BASE_GOERLI]!],
+    [ChainId.BASE_GOERLI]: [
+      WRAPPED_NATIVE_CURRENCY[ChainId.BASE_GOERLI]!,
+      USDC_BASE_GOERLI,
+    ],
   };
 };
 


### PR DESCRIPTION
- Bugfix

- Currently `getHighestLiquidityV3USDPool` will fail on Base Goerli (ChainId: 84531) due to missing `USDC_BASE_GOERLI` in `usdGasTokensByChain`. This just goes through the new chain checklist and adds full support for base goerli
