### PR TITLE
Bump uniswap sdk core to 4.09 and add correct base swap router address

### DIFF
--- a/src/providers/simulation-provider.ts
+++ b/src/providers/simulation-provider.ts
@@ -1,5 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
-import { ChainId, TradeType } from '@uniswap/sdk-core';
+import { ChainId, SWAP_ROUTER_02_ADDRESSES, TradeType } from '@uniswap/sdk-core';
 import { PERMIT2_ADDRESS } from '@uniswap/universal-router-sdk';
 import { BigNumber } from 'ethers/lib/ethers';
 
@@ -11,7 +11,7 @@ import {
 } from '../routers';
 import { Erc20__factory } from '../types/other/factories/Erc20__factory';
 import { Permit2__factory } from '../types/other/factories/Permit2__factory';
-import { CurrencyAmount, log, SWAP_ROUTER_02_ADDRESSES } from '../util';
+import { CurrencyAmount, log } from '../util';
 
 import { IPortionProvider } from './portion-provider';
 import { ArbitrumGasData, OptimismGasData } from './v3/gas-data-provider';

--- a/src/providers/swap-router-provider.ts
+++ b/src/providers/swap-router-provider.ts
@@ -1,8 +1,8 @@
 import { ApprovalTypes } from '@uniswap/router-sdk';
-import { ChainId, Currency, CurrencyAmount } from '@uniswap/sdk-core';
+import { ChainId, Currency, CurrencyAmount, SWAP_ROUTER_02_ADDRESSES } from '@uniswap/sdk-core';
 
 import { SwapRouter02__factory } from '../types/other/factories/SwapRouter02__factory';
-import { log, SWAP_ROUTER_02_ADDRESSES } from '../util';
+import { log } from '../util';
 
 import { IMulticallProvider } from './multicall-provider';
 

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -3,7 +3,7 @@ import https from 'https';
 
 import { MaxUint256 } from '@ethersproject/constants';
 import { JsonRpcProvider } from '@ethersproject/providers';
-import { ChainId } from '@uniswap/sdk-core';
+import { ChainId, SWAP_ROUTER_02_ADDRESSES } from '@uniswap/sdk-core';
 import {
   PERMIT2_ADDRESS,
   UNIVERSAL_ROUTER_ADDRESS,
@@ -25,7 +25,6 @@ import {
   BEACON_CHAIN_DEPOSIT_ADDRESS,
   log,
   MAX_UINT160,
-  SWAP_ROUTER_02_ADDRESSES,
 } from '../util';
 import { APPROVE_TOKEN_FOR_TRANSFER } from '../util/callData';
 import {

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -6,6 +6,7 @@ import {
   ChainId,
   Currency,
   Fraction,
+  SWAP_ROUTER_02_ADDRESSES,
   Token,
   TradeType,
 } from '@uniswap/sdk-core';
@@ -83,7 +84,7 @@ import {
 } from '../../providers/v3/pool-provider';
 import { IV3SubgraphProvider } from '../../providers/v3/subgraph-provider';
 import { Erc20__factory } from '../../types/other/factories/Erc20__factory';
-import { SWAP_ROUTER_02_ADDRESSES, WRAPPED_NATIVE_CURRENCY } from '../../util';
+import { WRAPPED_NATIVE_CURRENCY } from '../../util';
 import { CurrencyAmount } from '../../util/amounts';
 import {
   ID_TO_CHAIN_ID,

--- a/src/routers/legacy-router/legacy-router.ts
+++ b/src/routers/legacy-router/legacy-router.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Logger } from '@ethersproject/logger';
 import { SwapRouter, Trade } from '@uniswap/router-sdk';
-import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
+import { ChainId, Currency, SWAP_ROUTER_02_ADDRESSES, Token, TradeType } from '@uniswap/sdk-core';
 import { FeeAmount, MethodParameters, Pool, Route } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
@@ -13,7 +13,6 @@ import {
   USDC_MAINNET,
 } from '../../providers/token-provider';
 import { IV3PoolProvider } from '../../providers/v3/pool-provider';
-import { SWAP_ROUTER_02_ADDRESSES } from '../../util';
 import { CurrencyAmount } from '../../util/amounts';
 import { log } from '../../util/log';
 import { routeToString } from '../../util/routes';

--- a/src/util/addresses.ts
+++ b/src/util/addresses.ts
@@ -88,13 +88,6 @@ export const UNISWAP_MULTICALL_ADDRESSES: AddressMap = {
   // TODO: Gnosis + Moonbeam contracts to be deployed
 };
 
-export const SWAP_ROUTER_02_ADDRESSES = (chainId: number): string => {
-  if (chainId == ChainId.BNB) {
-    return BNB_SWAP_ROUTER_02_ADDRESS;
-  }
-  return '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45';
-};
-
 export const OVM_GASPRICE_ADDRESS =
   '0x420000000000000000000000000000000000000F';
 export const ARB_GASINFO_ADDRESS = '0x000000000000000000000000000000000000006C';

--- a/src/util/methodParameters.ts
+++ b/src/util/methodParameters.ts
@@ -4,7 +4,7 @@ import {
   SwapRouter as SwapRouter02,
   Trade,
 } from '@uniswap/router-sdk';
-import { ChainId, Currency, TradeType } from '@uniswap/sdk-core';
+import { ChainId, Currency, SWAP_ROUTER_02_ADDRESSES, TradeType } from '@uniswap/sdk-core';
 import {
   SwapRouter as UniversalRouter,
   UNIVERSAL_ROUTER_ADDRESS,
@@ -20,7 +20,6 @@ import {
   RouteWithValidQuote,
   SwapOptions,
   SwapType,
-  SWAP_ROUTER_02_ADDRESSES,
   V2RouteWithValidQuote,
   V3RouteWithValidQuote,
 } from '..';

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -13,6 +13,7 @@ import {
   Fraction,
   Percent,
   Rounding,
+  SWAP_ROUTER_02_ADDRESSES,
   Token,
   TradeType
 } from '@uniswap/sdk-core';
@@ -56,7 +57,6 @@ import {
   SimulationStatus,
   StaticGasPriceProvider,
   SUPPORTED_CHAINS,
-  SWAP_ROUTER_02_ADDRESSES,
   SwapOptions,
   SwapType,
   TenderlySimulator,


### PR DESCRIPTION
The swap router address for base is different for other chains so the function needs to account for that. Also, @uniswap/sdk-core needs to be bumped to 4.0.9 where the WETH9 contract for Base was added otherwise any pools with WETH on base will not work in this SDK with the swap router.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This will fix bugs with using base with the smart order router. Currently does not work with the current version of the sdk and is fixed with these changes

- **What is the current behavior?** (You can also link to an open issue here)
The current behavior will throw an error when requesting a swap router quote on base

- **What is the new behavior (if this is a feature change)?**
The swap router will work correctly and quotes are able to be fetched using the SDK

- **Other information**:
