### PR TITLE
fix: remove arb from v2 support

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -259,6 +259,11 @@ export type AlphaRouterParams = {
    * A provider for computing the portion-related data for routes and quotes.
    */
   portionProvider?: IPortionProvider;
+
+  /**
+   * All the supported v2 chains configuration
+   */
+  v2Supported?: ChainId[];
 };
 
 export class MapWithLowerCaseKey<V> extends Map<string, V> {
@@ -458,6 +463,7 @@ export class AlphaRouter
   protected routeCachingProvider?: IRouteCachingProvider;
   protected tokenPropertiesProvider: ITokenPropertiesProvider;
   protected portionProvider: IPortionProvider;
+  protected v2Supported?: ChainId[];
 
   constructor({
     chainId,
@@ -483,6 +489,7 @@ export class AlphaRouter
     routeCachingProvider,
     tokenPropertiesProvider,
     portionProvider,
+    v2Supported,
   }: AlphaRouterParams) {
     this.chainId = chainId;
     this.provider = provider;
@@ -820,6 +827,8 @@ export class AlphaRouter
       this.blockedTokenListProvider,
       this.tokenValidatorProvider
     );
+
+    this.v2Supported = v2Supported ?? V2_SUPPORTED;
   }
 
   public async routeToRatio(
@@ -1716,7 +1725,7 @@ export class AlphaRouter
     const noProtocolsSpecified = protocols.length === 0;
     const v3ProtocolSpecified = protocols.includes(Protocol.V3);
     const v2ProtocolSpecified = protocols.includes(Protocol.V2);
-    const v2SupportedInChain = V2_SUPPORTED.includes(this.chainId);
+    const v2SupportedInChain = this.v2Supported?.includes(this.chainId);
     const shouldQueryMixedProtocol =
       protocols.includes(Protocol.MIXED) ||
       (noProtocolsSpecified && v2SupportedInChain);

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -30,7 +30,6 @@ export const V2_SUPPORTED = [
   ChainId.GOERLI,
   ChainId.SEPOLIA,
   ChainId.OPTIMISM,
-  ChainId.ARBITRUM_ONE,
   ChainId.POLYGON,
   ChainId.BNB,
   ChainId.AVALANCHE,

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -205,7 +205,7 @@ if (process.env.INTEG_TEST_DEBUG) {
   );
 }
 
-jest.retryTimes(0);
+jest.retryTimes(5);
 
 describe('alpha router integration', () => {
   let alice: JsonRpcSigner;

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -205,7 +205,7 @@ if (process.env.INTEG_TEST_DEBUG) {
   );
 }
 
-jest.retryTimes(5);
+jest.retryTimes(0);
 
 describe('alpha router integration', () => {
   let alice: JsonRpcSigner;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Arbitrum subgraph is having problem for couple days.. Before we enable [V2_SUPPORTED](https://github.com/Uniswap/smart-order-router/pull/465/files#diff-f3f77a5e3d0a3c99c85eca60409b77f685b1ca0fe3e1a9e63cb45523905682afR28) in SOR, v3 subgraph issue would result in 404 no route. Now with v2 support, it will get all the pools metadata as part of [getHighestLiquidityUSDPool](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model.ts#L220), so SOR/routing-api will now throw at [L254](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/gas-models/v2/v2-heuristic-gas-model.ts#L254), resulting in 500.

- **What is the new behavior (if this is a feature change)?**
We can explicitly remove arbitrum from [V2_SUPPORTED](https://github.com/Uniswap/smart-order-router/pull/465/files#diff-f3f77a5e3d0a3c99c85eca60409b77f685b1ca0fe3e1a9e63cb45523905682afR28), so that it is equivalent to prior the deploy, and observe 5xx to go down on Arbitrum.

- **Other information**:
