### PR TITLE
fix: Best swap route, decimal condition check

### DIFF
--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -585,7 +585,7 @@ export async function getBestSwapRouteBy(
       const decimalsDiff =
         usdTokenDecimals - routeWithValidQuote.gasCostInUSD.currency.decimals;
 
-      if (decimalsDiff == 0) {
+      if (decimalsDiff <= 0) {
         return CurrencyAmount.fromRawAmount(
           usdToken,
           routeWithValidQuote.gasCostInUSD.quotient


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

As described on line 584 `estimatedGasUsedUSDs` throws an error if token gas decimals are greater than usd tokens.

There's a check to handle that issue, but the existing condition is incorrect.

- **What is the current behavior?**

When decimal difference is negative, the condition fails and the next logic throws `Exponent must be positive`.

```ts
JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(decimalsDiff)) // <-- Code will throw an error here.
```

- **What is the new behavior?**

The new behavior handles the decimal difference issue when the difference is equal or less than 0.