### PR TITLE
fix & chore: fix v2 supported bug & bump to v3.24.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.24.2",
+  "version": "3.24.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "3.24.2",
+      "version": "3.24.4",
       "license": "GPL",
       "dependencies": {
         "@types/brotli": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.24.2",
+  "version": "3.24.4",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -2081,7 +2081,7 @@ export class AlphaRouter
       nativeAndSpecifiedGasTokenV3Pool: nativeAndSpecifiedGasTokenV3Pool,
     };
 
-    const v2GasModelPromise = V2_SUPPORTED.includes(this.chainId)
+    const v2GasModelPromise = this.v2Supported?.includes(this.chainId)
       ? this.v2GasModelFactory.buildGasModel({
           chainId: this.chainId,
           gasPriceWei,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix and chore

- **What is the current behavior?** (You can also link to an open issue here)
V2_Supported array is being used in the gas model calculation, so that routing-api override doesn't work.

- **What is the new behavior (if this is a feature change)?**
makes it a alpha router config.

- **Other information**:
release to v3.24.4 as well