### PR TITLE
add sepolia to v2 supported array

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -2089,7 +2089,7 @@ export class AlphaRouter
           token: quoteToken,
           l2GasDataProvider: this.l2GasDataProvider,
           providerConfig: providerConfig,
-        })
+        }).catch(_ => undefined) // If v2 model throws uncaught exception, we return undefined v2 gas model, so there's a chance v3 route can go through
       : Promise.resolve(undefined);
 
     const v3GasModelPromise = this.v3GasModelFactory.buildGasModel({

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -29,6 +29,7 @@ export const SUPPORTED_CHAINS: ChainId[] = [
 
 export const V2_SUPPORTED = [
   ChainId.MAINNET,
+  ChainId.SEPOLIA,
   ChainId.ARBITRUM_ONE,
   ChainId.OPTIMISM,
   ChainId.POLYGON,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
V2 swap is not supported on Sepolia

- **What is the new behavior (if this is a feature change)?**
We already deployed V2 universal router and factory to Sepolia, we can support Sepolia on L2.

- **Other information**:
