### PR TITLE
Bug Fix: Remove Sepolia from v2 support

### DIFF
--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -29,7 +29,6 @@ export const SUPPORTED_CHAINS: ChainId[] = [
 
 export const V2_SUPPORTED = [
   ChainId.MAINNET,
-  ChainId.SEPOLIA,
   ChainId.ARBITRUM_ONE,
   ChainId.OPTIMISM,
   ChainId.POLYGON,


### PR DESCRIPTION
Fix to remove Sepolia from v2 support until the new v2 liquidity swapRouter02 launched on Sepolia

