### PR TITLE
fix: op gas oracles

### DIFF
--- a/src/providers/v3/gas-data-provider.ts
+++ b/src/providers/v3/gas-data-provider.ts
@@ -81,9 +81,9 @@ export class OptimismGasDataProvider
 
     // TODO: replace the hardcoded scalar and overhead with op gas estimate sdk
     const { result: l1BaseFee } = tx.results![0];
-    const { result: scalar } = [1];
+    const scalar = [1];
     const { result: decimals } = tx.results![1];
-    const { result: overhead } = [0];
+    const overhead = [0];
 
     return {
       l1BaseFee: l1BaseFee[0],

--- a/src/providers/v3/gas-data-provider.ts
+++ b/src/providers/v3/gas-data-provider.ts
@@ -81,9 +81,9 @@ export class OptimismGasDataProvider
 
     // TODO: replace the hardcoded scalar and overhead with op gas estimate sdk
     const { result: l1BaseFee } = tx.results![0];
-    const scalar = 1;
+    const scalar = BigNumber.from(1)
     const { result: decimals } = tx.results![1];
-    const overhead = 0;
+    const overhead = BigNumber.from(0);
 
     return {
       l1BaseFee: l1BaseFee[0],

--- a/src/providers/v3/gas-data-provider.ts
+++ b/src/providers/v3/gas-data-provider.ts
@@ -81,15 +81,15 @@ export class OptimismGasDataProvider
 
     // TODO: replace the hardcoded scalar and overhead with op gas estimate sdk
     const { result: l1BaseFee } = tx.results![0];
-    const scalar = [1];
+    const scalar = 1;
     const { result: decimals } = tx.results![1];
-    const overhead = [0];
+    const overhead = 0;
 
     return {
       l1BaseFee: l1BaseFee[0],
-      scalar: scalar[0],
+      scalar: scalar,
       decimals: decimals[0],
-      overhead: overhead[0],
+      overhead: overhead,
     };
   }
 }

--- a/src/providers/v3/gas-data-provider.ts
+++ b/src/providers/v3/gas-data-provider.ts
@@ -54,7 +54,7 @@ export class OptimismGasDataProvider
     providerConfig?: ProviderConfig
   ): Promise<OptimismGasData> {
     // TODO: Also get the gasPrice from GasPriceOracle.sol
-    const funcNames = ['l1BaseFee', 'scalar', 'decimals', 'overhead'];
+    const funcNames = ['l1BaseFee', 'decimals'];
     const tx =
       await this.multicall2Provider.callMultipleFunctionsOnSameContract<
         undefined,
@@ -68,9 +68,7 @@ export class OptimismGasDataProvider
 
     if (
       !tx.results[0]?.success ||
-      !tx.results[1]?.success ||
-      !tx.results[2]?.success ||
-      !tx.results[3]?.success
+      !tx.results[1]?.success
     ) {
       log.info(
         { results: tx.results },
@@ -81,10 +79,11 @@ export class OptimismGasDataProvider
       );
     }
 
+    // TODO: replace the hardcoded scalar and overhead with op gas estimate sdk
     const { result: l1BaseFee } = tx.results![0];
-    const { result: scalar } = tx.results![1];
-    const { result: decimals } = tx.results![2];
-    const { result: overhead } = tx.results![3];
+    const { result: scalar } = [1];
+    const { result: decimals } = tx.results![1];
+    const { result: overhead } = [0];
 
     return {
       l1BaseFee: l1BaseFee[0],


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
OP gas oracles disabled [overhead](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/GasPriceOracle.sol#L70) and [scalar](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/GasPriceOracle.sol#L78) after Dencun/Ecotone

- **What is the new behavior (if this is a feature change)?**
Hardcode overhead and scalar to make swap work on OP and OP-stack networks

- **Other information**:
Proper fix requires adopting OP gas estimate SDK