### PR TITLE
chore: bump to v3.26.0 and remove goerli from supported chains

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -452,40 +452,6 @@ jobs:
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
 
-  integration-tests-quote-for-other-networks-goerli:
-    name: Integration Tests - Quote For Other Networks Goerli
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 18.x
-          registry-url: https://registry.npmjs.org
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install dependencies
-        run: npm install
-
-      # This is required separately from yarn test because it generates the typechain definitions
-      - name: Compile
-        run: npm run build
-
-      - name: Run Integration tests
-        run: npm run integ-test  -- -t 'quote for other networks * goerli'
-        env:
-          JSON_RPC_PROVIDER_GORLI: ${{ secrets.JSON_RPC_PROVIDER_GORLI }}
-          TENDERLY_BASE_URL: ${{ secrets.TENDERLY_BASE_URL }}
-          TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
-          TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
-          TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
-
   integration-tests-quote-for-other-networks-sepolia:
     name: Integration Tests - Quote For Other Networks Sepolia
     runs-on: ubuntu-latest
@@ -718,7 +684,7 @@ jobs:
 
       # This is to capture any new networks added into the integ-test suite
       - name: Run Integration tests
-        run: npm run integ-test  -- -t 'quote for other networks * (?!(mainnet|optimism|arbitrum|polygon|goerli|sepolia|celo|bnb|avalanche|base|blast))'
+        run: npm run integ-test  -- -t 'quote for other networks * (?!(mainnet|optimism|arbitrum|polygon|sepolia|celo|bnb|avalanche|base|blast))'
         env:
           # We don't know which new networks will be added, so we have no way to provider RPC URL ahead of time
           # This will make remaining networks integ-test suite to fail, and dev is expected to manually add RPC URL for the new network

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.25.1",
+  "version": "3.26.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "3.25.1",
+      "version": "3.26.0",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.25.1",
+  "version": "3.26.0",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -17,7 +17,6 @@ export const SUPPORTED_CHAINS: ChainId[] = [
   ChainId.ARBITRUM_SEPOLIA,
   ChainId.POLYGON,
   ChainId.POLYGON_MUMBAI,
-  ChainId.GOERLI,
   ChainId.SEPOLIA,
   ChainId.CELO_ALFAJORES,
   ChainId.CELO,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Release https://github.com/Uniswap/smart-order-router/pull/515

Also removes goerli from supported chains.
