### PR TITLE
chore: bump ur-sdk to v1.8.2, support blast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@uniswap/swap-router-contracts": "^1.3.1",
         "@uniswap/token-lists": "^1.0.0-beta.31",
         "@uniswap/universal-router": "^1.6.0",
-        "@uniswap/universal-router-sdk": "^1.8.1",
+        "@uniswap/universal-router-sdk": "^1.8.2",
         "@uniswap/v2-sdk": "^4.3.0",
         "@uniswap/v3-sdk": "^3.11.0",
         "async-retry": "^1.3.1",
@@ -3373,9 +3373,9 @@
       }
     },
     "node_modules/@uniswap/universal-router-sdk": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-1.8.1.tgz",
-      "integrity": "sha512-oA4JFLD1JmfJn5AnPcvgOmLIqZnsUpDYSShYCt8CaA3AzBzKmPTz9xpGdQwVHIH8rJnYu6mPTqRg5GwLobeMGA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-1.8.2.tgz",
+      "integrity": "sha512-u7ZnKxf4NH2J3DoTOOueh2rNruQku1JpLTRGl+/Kvol1NKTXdMAkaTTNRcwBzSpolpfbldK4pAIuwDza7gWzDw==",
       "dependencies": {
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",
@@ -14687,9 +14687,9 @@
       }
     },
     "@uniswap/universal-router-sdk": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-1.8.1.tgz",
-      "integrity": "sha512-oA4JFLD1JmfJn5AnPcvgOmLIqZnsUpDYSShYCt8CaA3AzBzKmPTz9xpGdQwVHIH8rJnYu6mPTqRg5GwLobeMGA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-1.8.2.tgz",
+      "integrity": "sha512-u7ZnKxf4NH2J3DoTOOueh2rNruQku1JpLTRGl+/Kvol1NKTXdMAkaTTNRcwBzSpolpfbldK4pAIuwDza7gWzDw==",
       "requires": {
         "@uniswap/permit2-sdk": "^1.2.0",
         "@uniswap/router-sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@uniswap/swap-router-contracts": "^1.3.1",
     "@uniswap/token-lists": "^1.0.0-beta.31",
     "@uniswap/universal-router": "^1.6.0",
-    "@uniswap/universal-router-sdk": "^1.8.1",
+    "@uniswap/universal-router-sdk": "^1.8.2",
     "@uniswap/v2-sdk": "^4.3.0",
     "@uniswap/v3-sdk": "^3.11.0",
     "async-retry": "^1.3.1",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Release https://github.com/Uniswap/universal-router-sdk/pull/169
