### PR TITLE
fix: add quote latency metrics within onchain quote provider

### DIFF
--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -300,7 +300,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
     protected successRateFailureOverrides: FailureOverrides = DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
     protected blockNumberConfig: BlockNumberConfig = DEFAULT_BLOCK_NUMBER_CONFIGS,
     protected quoterAddressOverride?: string,
-    protected metricsPrefix?: string
+    protected metricsPrefix: string = '' // default metric prefix to be empty string
   ) {}
 
   private getQuoterAddress(useMixedRouteQuoter: boolean): string {
@@ -429,6 +429,8 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
       inputs.length,
       MetricLoggerUnit.Count
     );
+
+    const startTime = Date.now();
 
     let haveRetriedForSuccessRate = false;
     let haveRetriedForBlockHeader = false;
@@ -771,6 +773,13 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
       routes,
       amounts
     );
+
+    const endTime = Date.now();
+    metric.putMetric(
+      `${this.metricsPrefix}QuoteLatency`,
+      endTime - startTime,
+      MetricLoggerUnit.Milliseconds
+    )
 
     metric.putMetric(
       `${this.metricsPrefix}QuoteApproxGasUsedPerSuccessfulCall`,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
I noticed that the quote latencies between current quoter and view-only quoter do not look expected. Somehow exact out current quoter always has lower latencies than view-only quoter:
![Screenshot 2024-04-15 at 2 50 16 PM](https://github.com/Uniswap/smart-order-router/assets/91580504/20af54b0-6696-4695-bfb7-c8005f37cdba)

This is not expected, given that the view-only quoter consumes a lot less guess, and it does not simulate the swap:
![Screenshot 2024-04-15 at 2 51 01 PM](https://github.com/Uniswap/smart-order-router/assets/91580504/25385423-b25a-4902-9868-66d28f783eea)

I think the bug is in the routing-api latencies [logging](https://github.com/Uniswap/routing-api/blob/main/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts#L67-L87) - meanwhile we use `Promise.all` to parallelize two quoters call, and use `then` to log the latencies, but since JS runtime adds Promises into the event loop and wait until all Promises are settled. So a more accurate way is to log latency right outside the quote on-chain calls within SOR.

- **What is the new behavior (if this is a feature change)?**
Log the accurate quote latencies within SOR. I tested in routing-api locally, and can see the latencies are looking expected now:
![Screenshot 2024-04-15 at 2 58 05 PM](https://github.com/Uniswap/smart-order-router/assets/91580504/9cb09566-a424-4702-98fc-b57f76c1dd1b)


- **Other information**:
