### PR TITLE
fix: multicall return gas used in case of failure

### DIFF
--- a/src/providers/multicall-provider.ts
+++ b/src/providers/multicall-provider.ts
@@ -47,6 +47,7 @@ export type SuccessResult<TReturn> = {
 export type FailResult = {
   success: false;
   returnData: string;
+  gasUsed?: BigNumber;
 };
 
 export type Result<TReturn> = SuccessResult<TReturn> | FailResult;

--- a/src/providers/multicall-uniswap-provider.ts
+++ b/src/providers/multicall-uniswap-provider.ts
@@ -196,6 +196,7 @@ export class UniswapMulticallProvider extends IMulticallProvider<UniswapMultical
         results.push({
           success: false,
           returnData,
+          gasUsed,
         });
         continue;
       }

--- a/src/providers/multicall-uniswap-provider.ts
+++ b/src/providers/multicall-uniswap-provider.ts
@@ -191,7 +191,7 @@ export class UniswapMulticallProvider extends IMulticallProvider<UniswapMultical
       if (!success || returnData.length <= 2) {
         log.debug(
           { result: aggregateResults[i] },
-          `Invalid result calling ${functionName} with params ${functionParams[i]}`
+          `Invalid result calling ${functionName} address ${address} with params ${functionParams[i]}`
         );
         results.push({
           success: false,

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -905,7 +905,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
               amount,
               quote: null,
               sqrtPriceX96AfterList: null,
-              gasEstimate: quoteResult.gasUsed,
+              gasEstimate: quoteResult.gasUsed ?? null,
               initializedTicksCrossedList: null,
             };
           }

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -54,6 +54,10 @@ export type AmountQuote = {
    * depending on if the slot has already been loaded in the call.
    */
   gasEstimate: BigNumber | null;
+  /**
+   * Final attempted gas limit set by the on-chain quote provider
+   */
+  gasLimit: BigNumber | null;
 };
 
 export class BlockConflictError extends Error {
@@ -771,7 +775,8 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
     const routesQuotes = this.processQuoteResults(
       quoteResults,
       routes,
-      amounts
+      amounts,
+      BigNumber.from(gasLimitOverride)
     );
 
     const endTime = Date.now();
@@ -866,7 +871,8 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
   private processQuoteResults<TRoute extends V3Route | V2Route | MixedRoute>(
     quoteResults: Result<[BigNumber, BigNumber[], number[], BigNumber]>[],
     routes: TRoute[],
-    amounts: CurrencyAmount[]
+    amounts: CurrencyAmount[],
+    gasLimit: BigNumber
   ): RouteWithQuotes<TRoute>[] {
     const routesQuotes: RouteWithQuotes<TRoute>[] = [];
 
@@ -906,6 +912,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
               quote: null,
               sqrtPriceX96AfterList: null,
               gasEstimate: quoteResult.gasUsed ?? null,
+              gasLimit: gasLimit,
               initializedTicksCrossedList: null,
             };
           }
@@ -916,6 +923,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
             sqrtPriceX96AfterList: quoteResult.result[1],
             initializedTicksCrossedList: quoteResult.result[2],
             gasEstimate: quoteResult.result[3],
+            gasLimit: gasLimit,
           };
         }
       );

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -779,7 +779,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
       `${this.metricsPrefix}QuoteLatency`,
       endTime - startTime,
       MetricLoggerUnit.Milliseconds
-    )
+    );
 
     metric.putMetric(
       `${this.metricsPrefix}QuoteApproxGasUsedPerSuccessfulCall`,
@@ -905,7 +905,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
               amount,
               quote: null,
               sqrtPriceX96AfterList: null,
-              gasEstimate: null,
+              gasEstimate: quoteResult.gasUsed,
               initializedTicksCrossedList: null,
             };
           }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
Meanwhile we are comparing the current quoter quotes vs new view-only quoter quotes in prod in shadow sampling for mainnet at 1%, we encounter a case, where we have some quotes that are failing due to the out-of-gas from multicall (e.g. this [simulation](https://www.tdly.co/shared/simulation/39de04bb-d794-43b0-aed2-8ea31957ca77)), but from routing-api side, we don't have a good way to programmatically determine this is the case, within [compareQuotes](https://github.com/Uniswap/routing-api/blob/d05f590db3facdc76850fb3ade374b17f485d315/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts#L213). 

This is the case where some quotes from multicalls fail, but overall success rate is still above the [threshold](https://github.com/Uniswap/smart-order-router/blob/19afca6760c5d346ef1d0c20206c3e6758fee0e5/src/providers/on-chain-quote-provider.ts#L496). This is different from the entire multicall failures due to out of gas. In that case, on-chain quote provider will throw [ProviderOutOfGasError](https://github.com/Uniswap/smart-order-router/blob/19afca6760c5d346ef1d0c20206c3e6758fee0e5/src/providers/on-chain-quote-provider.ts#L544), and routing-api can generalize to where [currentQuoterSucceeded](https://github.com/Uniswap/routing-api/blob/d05f590db3facdc76850fb3ade374b17f485d315/lib/handlers/quote/provider-migration/v3/traffic-switch-on-chain-quote-provider.ts#L81) = false

- **What is the new behavior (if this is a feature change)?**
Within SOR, we will return both gasUsed and gasLimit per call from the multicalls, so that routing-api can calculate that the difference between gasUsed and gasLimit may be small enough to be due to out of gas.

- **Other information**:
This works in tendom with routing-api changes.