### PR TITLE
chore: use single default view-only quoter deploy address

### DIFF
--- a/src/util/addresses.ts
+++ b/src/util/addresses.ts
@@ -61,11 +61,8 @@ export const QUOTER_V2_ADDRESSES: AddressMap = {
 };
 
 export const NEW_QUOTER_V2_ADDRESSES: AddressMap = {
-  ...constructSameAddressMap('0x61fFE014bA17989E743c5F6cB21bF9697530B21e'),
+  ...constructSameAddressMap('0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3'),
   [ChainId.POLYGON_MUMBAI]: '0x60e06b92bC94a665036C26feC5FF2A92E2d04c5f',
-  [ChainId.SEPOLIA]: '0x6650ab818c0a7efa72fc1404a878fef1fec8e058',
-  [ChainId.MAINNET]: '0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3',
-  [ChainId.POLYGON]: '0x5e55c9e631fae526cd4b0526c4818d6e0a9ef0e3',
 };
 
 export const MIXED_ROUTE_QUOTER_V1_ADDRESSES: AddressMap = {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
chore

- **What is the current behavior?** (You can also link to an open issue here)
Since we are using the same deployer wallet to deploy, most likely the first deployed address will be the same across chains. We are enumerating the view-only quoter address for now.

- **What is the new behavior (if this is a feature change)?**
We don't enumerate the view-only quoter address per chain, unless that particular chain has a different deploy address. This will speed up our new chain deploy, where we can just ship changes in routing-api for each newly deployed quoter on a new chain.

- **Other information**:
