### PR TITLE
fix: update view-only quoter address in base

### DIFF
--- a/src/util/addresses.ts
+++ b/src/util/addresses.ts
@@ -63,7 +63,7 @@ export const QUOTER_V2_ADDRESSES: AddressMap = {
 export const NEW_QUOTER_V2_ADDRESSES: AddressMap = {
   ...constructSameAddressMap('0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3'),
   [ChainId.POLYGON_MUMBAI]: '0x60e06b92bC94a665036C26feC5FF2A92E2d04c5f',
-  [ChainId.BASE]: '0xf0c802dcb0cf1c4f7b953756b49d940eed190221',
+  [ChainId.BASE]: '0x222cA98F00eD15B1faE10B61c277703a194cf5d2',
 };
 
 export const MIXED_ROUTE_QUOTER_V1_ADDRESSES: AddressMap = {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Big fix

- **What is the current behavior?** (You can also link to an open issue here)
Since shadow quoting in Base today (https://github.com/Uniswap/routing-api/pull/598), the accuracy has been low:
![Screenshot 2024-04-18 at 9 52 46 PM](https://github.com/Uniswap/smart-order-router/assets/91580504/d2c18e04-1ae2-4ec7-adf3-0ebab0f0988b)

I used tenderly [simulation](https://www.tdly.co/shared/simulation/cf37f5ed-5eaf-49f6-b966-fc33c10e0748) to debug, then I noticed the computed pool address from the view-only quoter is non-existent on Base. I was using the wrong v3 core factory when deploying to Base. I already fixed that and re-deployed https://github.com/Uniswap/view-quoter-v3/pull/12, but we also need to update the quoter deploy address in SOR, so that routing-api quote accuracy can go up on Base.

- **What is the new behavior (if this is a feature change)?**
Update [quoter](https://basescan.org/address/0x222cA98F00eD15B1faE10B61c277703a194cf5d2#code) address 

- **Other information**:
