### PR TITLE
fix: improve quote provider logging & update sepolia quoter address

### DIFF
--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -8,7 +8,7 @@ import {
 import { ChainId } from '@uniswap/sdk-core';
 import { encodeRouteToPath } from '@uniswap/v3-sdk';
 import retry, { Options as RetryOptions } from 'async-retry';
-import _, from 'lodash';
+import _ from 'lodash';
 import stats from 'stats-lite';
 
 import { MixedRoute, V2Route, V3Route } from '../routers/router';

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -303,13 +303,19 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
     // In alpha-router default case, we will also define the constants with same values as below.
     protected successRateFailureOverrides: FailureOverrides = DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
     protected blockNumberConfig: BlockNumberConfig = DEFAULT_BLOCK_NUMBER_CONFIGS,
-    protected quoterAddressOverride?: string,
-    protected metricsPrefix: string = '' // default metric prefix to be empty string
+    protected quoterAddressOverride?: (useMixedRouteQuoter: boolean) => string,
+    protected metricsPrefix: (
+      chainId: ChainId,
+      useMixedRouteQuoter: boolean
+    ) => string = (chainId, useMixedRouteQuoter) =>
+      useMixedRouteQuoter
+        ? `ChainId_${chainId}_MixedQuoter`
+        : 'ChainId_${chainId}_V3Quoter'
   ) {}
 
   private getQuoterAddress(useMixedRouteQuoter: boolean): string {
     if (this.quoterAddressOverride) {
-      return this.quoterAddressOverride;
+      return this.quoterAddressOverride(useMixedRouteQuoter);
     }
     const quoterAddress = useMixedRouteQuoter
       ? MIXED_ROUTE_QUOTER_V1_ADDRESSES[this.chainId]
@@ -424,12 +430,15 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
     );
 
     metric.putMetric(
-      `${this.metricsPrefix}QuoteBatchSize`,
+      `${this.metricsPrefix(this.chainId, useMixedRouteQuoter)}QuoteBatchSize`,
       inputs.length,
       MetricLoggerUnit.Count
     );
     metric.putMetric(
-      `${this.metricsPrefix}QuoteBatchSize_${ID_TO_NETWORK_NAME(this.chainId)}`,
+      `${this.metricsPrefix(
+        this.chainId,
+        useMixedRouteQuoter
+      )}QuoteBatchSize_${ID_TO_NETWORK_NAME(this.chainId)}`,
       inputs.length,
       MetricLoggerUnit.Count
     );
@@ -602,7 +611,10 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
             if (error instanceof BlockConflictError) {
               if (!haveRetriedForBlockConflictError) {
                 metric.putMetric(
-                  `${this.metricsPrefix}QuoteBlockConflictErrorRetry`,
+                  `${this.metricsPrefix(
+                    this.chainId,
+                    useMixedRouteQuoter
+                  )}QuoteBlockConflictErrorRetry`,
                   1,
                   MetricLoggerUnit.Count
                 );
@@ -613,7 +625,10 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
             } else if (error instanceof ProviderBlockHeaderError) {
               if (!haveRetriedForBlockHeader) {
                 metric.putMetric(
-                  `${this.metricsPrefix}QuoteBlockHeaderNotFoundRetry`,
+                  `${this.metricsPrefix(
+                    this.chainId,
+                    useMixedRouteQuoter
+                  )}QuoteBlockHeaderNotFoundRetry`,
                   1,
                   MetricLoggerUnit.Count
                 );
@@ -653,7 +668,10 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
             } else if (error instanceof ProviderTimeoutError) {
               if (!haveRetriedForTimeout) {
                 metric.putMetric(
-                  `${this.metricsPrefix}QuoteTimeoutRetry`,
+                  `${this.metricsPrefix(
+                    this.chainId,
+                    useMixedRouteQuoter
+                  )}QuoteTimeoutRetry`,
                   1,
                   MetricLoggerUnit.Count
                 );
@@ -662,7 +680,10 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
             } else if (error instanceof ProviderGasError) {
               if (!haveRetriedForOutOfGas) {
                 metric.putMetric(
-                  `${this.metricsPrefix}QuoteOutOfGasExceptionRetry`,
+                  `${this.metricsPrefix(
+                    this.chainId,
+                    useMixedRouteQuoter
+                  )}QuoteOutOfGasExceptionRetry`,
                   1,
                   MetricLoggerUnit.Count
                 );
@@ -674,7 +695,10 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
             } else if (error instanceof SuccessRateError) {
               if (!haveRetriedForSuccessRate) {
                 metric.putMetric(
-                  `${this.metricsPrefix}QuoteSuccessRateRetry`,
+                  `${this.metricsPrefix(
+                    this.chainId,
+                    useMixedRouteQuoter
+                  )}QuoteSuccessRateRetry`,
                   1,
                   MetricLoggerUnit.Count
                 );
@@ -690,7 +714,10 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
             } else {
               if (!haveRetriedForUnknownReason) {
                 metric.putMetric(
-                  `${this.metricsPrefix}QuoteUnknownReasonRetry`,
+                  `${this.metricsPrefix(
+                    this.chainId,
+                    useMixedRouteQuoter
+                  )}QuoteUnknownReasonRetry`,
                   1,
                   MetricLoggerUnit.Count
                 );
@@ -781,37 +808,52 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
 
     const endTime = Date.now();
     metric.putMetric(
-      `${this.metricsPrefix}QuoteLatency`,
+      `${this.metricsPrefix(this.chainId, useMixedRouteQuoter)}QuoteLatency`,
       endTime - startTime,
       MetricLoggerUnit.Milliseconds
     );
 
     metric.putMetric(
-      `${this.metricsPrefix}QuoteApproxGasUsedPerSuccessfulCall`,
+      `${this.metricsPrefix(
+        this.chainId,
+        useMixedRouteQuoter
+      )}QuoteApproxGasUsedPerSuccessfulCall`,
       approxGasUsedPerSuccessCall,
       MetricLoggerUnit.Count
     );
 
     metric.putMetric(
-      `${this.metricsPrefix}QuoteNumRetryLoops`,
+      `${this.metricsPrefix(
+        this.chainId,
+        useMixedRouteQuoter
+      )}QuoteNumRetryLoops`,
       finalAttemptNumber - 1,
       MetricLoggerUnit.Count
     );
 
     metric.putMetric(
-      `${this.metricsPrefix}QuoteTotalCallsToProvider`,
+      `${this.metricsPrefix(
+        this.chainId,
+        useMixedRouteQuoter
+      )}QuoteTotalCallsToProvider`,
       totalCallsMade,
       MetricLoggerUnit.Count
     );
 
     metric.putMetric(
-      `${this.metricsPrefix}QuoteExpectedCallsToProvider`,
+      `${this.metricsPrefix(
+        this.chainId,
+        useMixedRouteQuoter
+      )}QuoteExpectedCallsToProvider`,
       expectedCallsMade,
       MetricLoggerUnit.Count
     );
 
     metric.putMetric(
-      `${this.metricsPrefix}QuoteNumRetriedCalls`,
+      `${this.metricsPrefix(
+        this.chainId,
+        useMixedRouteQuoter
+      )}QuoteNumRetriedCalls`,
       totalCallsMade - expectedCallsMade,
       MetricLoggerUnit.Count
     );

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -8,7 +8,7 @@ import {
 import { ChainId } from '@uniswap/sdk-core';
 import { encodeRouteToPath } from '@uniswap/v3-sdk';
 import retry, { Options as RetryOptions } from 'async-retry';
-import _, { chain } from 'lodash';
+import _, from 'lodash';
 import stats from 'stats-lite';
 
 import { MixedRoute, V2Route, V3Route } from '../routers/router';

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -8,7 +8,7 @@ import {
 import { ChainId } from '@uniswap/sdk-core';
 import { encodeRouteToPath } from '@uniswap/v3-sdk';
 import retry, { Options as RetryOptions } from 'async-retry';
-import _ from 'lodash';
+import _, { chain } from 'lodash';
 import stats from 'stats-lite';
 
 import { MixedRoute, V2Route, V3Route } from '../routers/router';
@@ -310,7 +310,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
     ) => string = (chainId, useMixedRouteQuoter) =>
       useMixedRouteQuoter
         ? `ChainId_${chainId}_MixedQuoter`
-        : 'ChainId_${chainId}_V3Quoter'
+        : `ChainId_${chainId}_V3Quoter`
   ) {}
 
   private getQuoterAddress(useMixedRouteQuoter: boolean): string {

--- a/src/util/addresses.ts
+++ b/src/util/addresses.ts
@@ -1,4 +1,9 @@
-import { CHAIN_TO_ADDRESSES_MAP, ChainId, SWAP_ROUTER_02_ADDRESSES as SWAP_ROUTER_02_ADDRESSES_HELPER, Token } from '@uniswap/sdk-core';
+import {
+  ChainId,
+  CHAIN_TO_ADDRESSES_MAP,
+  SWAP_ROUTER_02_ADDRESSES as SWAP_ROUTER_02_ADDRESSES_HELPER,
+  Token,
+} from '@uniswap/sdk-core';
 import { FACTORY_ADDRESS } from '@uniswap/v3-sdk';
 
 import { NETWORKS_WITH_SAME_UNISWAP_ADDRESSES } from './chains';
@@ -62,6 +67,7 @@ export const QUOTER_V2_ADDRESSES: AddressMap = {
 
 export const NEW_QUOTER_V2_ADDRESSES: AddressMap = {
   ...constructSameAddressMap('0x5e55C9e631FAE526cd4B0526C4818D6e0a9eF0e3'),
+  [ChainId.SEPOLIA]: '0xf0c802dcb0cf1c4f7b953756b49d940eed190221',
   [ChainId.POLYGON_MUMBAI]: '0x60e06b92bC94a665036C26feC5FF2A92E2d04c5f',
   [ChainId.BASE]: '0x222cA98F00eD15B1faE10B61c277703a194cf5d2',
   [ChainId.BLAST]: '0x9D0F15f2cf58655fDDcD1EE6129C547fDaeD01b1',


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Our quote provider logging doesn't differentiate between mixed quoter and v3 quoter. We should differentiate them for better perf analysis.
Also the sepolia quoter address has to be updated because it was using the wrong v3 factory address.

- **What is the new behavior (if this is a feature change)?**
Enrich the quote provider logging with the mixed quoter vs v3 quoter.

- **Other information**:
