### PR TITLE
Allow SubgraphProviders to receive a URL override

### DIFF
--- a/src/providers/v2/subgraph-provider.ts
+++ b/src/providers/v2/subgraph-provider.ts
@@ -67,9 +67,10 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
     private retries = 2,
     private timeout = 360000,
     private rollback = true,
-    private pageSize = PAGE_SIZE
+    private pageSize = PAGE_SIZE,
+    private subgraphUrlOverride?: string
   ) {
-    const subgraphUrl = SUBGRAPH_URL_BY_CHAIN[this.chainId];
+    const subgraphUrl = this.subgraphUrlOverride ?? SUBGRAPH_URL_BY_CHAIN[this.chainId];
     if (!subgraphUrl) {
       throw new Error(`No subgraph url for chain id: ${this.chainId}`);
     }

--- a/src/providers/v3/subgraph-provider.ts
+++ b/src/providers/v3/subgraph-provider.ts
@@ -93,9 +93,10 @@ export class V3SubgraphProvider implements IV3SubgraphProvider {
     private chainId: ChainId,
     private retries = 2,
     private timeout = 30000,
-    private rollback = true
+    private rollback = true,
+    private subgraphUrlOverride?: string
   ) {
-    const subgraphUrl = SUBGRAPH_URL_BY_CHAIN[this.chainId];
+    const subgraphUrl = this.subgraphUrlOverride ?? SUBGRAPH_URL_BY_CHAIN[this.chainId];
     if (!subgraphUrl) {
       throw new Error(`No subgraph url for chain id: ${this.chainId}`);
     }


### PR DESCRIPTION
Create a way for the SubgraphProviders to receive an override URL.

This will be used in RoutingAPI to pull the url from a secret for our custom subgraphs
