### PR TITLE
chore: log quote sucecss rate metric

### DIFF
--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -515,7 +515,8 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
 
                 const successRateError = this.validateSuccessRate(
                   results.results,
-                  haveRetriedForSuccessRate
+                  haveRetriedForSuccessRate,
+                  useMixedRouteQuoter
                 );
 
                 if (successRateError) {
@@ -1046,7 +1047,8 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
 
   protected validateSuccessRate(
     allResults: Result<[BigNumber, BigNumber[], number[], BigNumber]>[],
-    haveRetriedForSuccessRate: boolean
+    haveRetriedForSuccessRate: boolean,
+    useMixedRouteQuoter: boolean
   ): void | SuccessRateError {
     const numResults = allResults.length;
     const numSuccessResults = allResults.filter(
@@ -1061,9 +1063,12 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
         log.info(
           `Quote success rate still below threshold despite retry. Continuing. ${quoteMinSuccessRate}: ${successRate}`
         );
+        metric.putMetric(`${this.metricsPrefix(this.chainId, useMixedRouteQuoter)}QuoteRetriedSuccessRateLow`, successRate, MetricLoggerUnit.Percent);
+
         return;
       }
 
+      metric.putMetric(`${this.metricsPrefix(this.chainId, useMixedRouteQuoter)}QuoteSuccessRateLow`, successRate, MetricLoggerUnit.Percent);
       return new SuccessRateError(
         `Quote success rate below threshold of ${quoteMinSuccessRate}: ${successRate}`
       );


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
chore

- **What is the current behavior?** (You can also link to an open issue here)
We don't log quote success rate metrics. In case of low success rate, quote has to retry and impacts the latencies.

- **What is the new behavior (if this is a feature change)?**
We are tracking the per-chain v3/mixed quoter success rate, this includes the initial success rate as well as the retried success rate.

- **Other information**:
