### PR TITLE
chore(subgraph): Remove not necessary fields

### DIFF
--- a/src/providers/v2/subgraph-provider.ts
+++ b/src/providers/v2/subgraph-provider.ts
@@ -239,7 +239,6 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
       })
       .map((pool) => {
         return {
-          ...pool,
           id: pool.id.toLowerCase(),
           token0: {
             id: pool.token0.id.toLowerCase(),

--- a/src/providers/v3/subgraph-provider.ts
+++ b/src/providers/v3/subgraph-provider.ts
@@ -238,17 +238,18 @@ export class V3SubgraphProvider implements IV3SubgraphProvider {
           parseFloat(pool.totalValueLockedETH) > 0.01
       )
       .map((pool) => {
-        const { totalValueLockedETH, totalValueLockedUSD, ...rest } = pool;
+        const { totalValueLockedETH, totalValueLockedUSD } = pool;
 
         return {
-          ...rest,
           id: pool.id.toLowerCase(),
+          feeTier: pool.feeTier,
           token0: {
             id: pool.token0.id.toLowerCase(),
           },
           token1: {
             id: pool.token1.id.toLowerCase(),
           },
+          liquidity: pool.liquidity,
           tvlETH: parseFloat(totalValueLockedETH),
           tvlUSD: parseFloat(totalValueLockedUSD),
         };


### PR DESCRIPTION
The V2 and V3 Subgraph Providers are currently returning pools that contain more fields than are necessary.

When we store these fields in our S3 bucket in routing-api we end up with additional data that increase our blob size, and we don't need them.

This PR removes the additional fields
