### PR TITLE
chore: onchain quoter batch param differed by optimistic cached routes

### DIFF
--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -3,7 +3,7 @@ import { BaseProvider } from '@ethersproject/providers';
 import {
   encodeMixedRouteToPath,
   MixedRouteSDK,
-  Protocol,
+  Protocol
 } from '@uniswap/router-sdk';
 import { ChainId } from '@uniswap/sdk-core';
 import { encodeRouteToPath } from '@uniswap/v3-sdk';
@@ -12,18 +12,20 @@ import _ from 'lodash';
 import stats from 'stats-lite';
 
 import { MixedRoute, V2Route, V3Route } from '../routers/router';
-import { IMixedRouteQuoterV1__factory } from '../types/other/factories/IMixedRouteQuoterV1__factory';
+import {
+  IMixedRouteQuoterV1__factory
+} from '../types/other/factories/IMixedRouteQuoterV1__factory';
 import { IQuoterV2__factory } from '../types/v3/factories/IQuoterV2__factory';
 import { ID_TO_NETWORK_NAME, metric, MetricLoggerUnit } from '../util';
 import {
   MIXED_ROUTE_QUOTER_V1_ADDRESSES,
-  NEW_QUOTER_V2_ADDRESSES,
+  NEW_QUOTER_V2_ADDRESSES
 } from '../util/addresses';
 import { CurrencyAmount } from '../util/amounts';
 import { log } from '../util/log';
 import {
   DEFAULT_BLOCK_NUMBER_CONFIGS,
-  DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
+  DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES
 } from '../util/onchainQuoteProviderConfigs';
 import { routeToString } from '../util/routes';
 
@@ -289,11 +291,14 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
       minTimeout: 25,
       maxTimeout: 250,
     },
-    protected batchParams: BatchParams = {
-      multicallChunk: 150,
-      gasLimitPerCall: 1_000_000,
-      quoteMinSuccessRate: 0.2,
-    },
+    protected batchParams: (optimisticCachedRoutes: boolean) => BatchParams =
+      (_) => {
+        return {
+            multicallChunk: 150,
+            gasLimitPerCall: 1_000_000,
+            quoteMinSuccessRate: 0.2,
+          };
+        },
     protected gasErrorFailureOverride: FailureOverrides = {
       gasLimitOverride: 1_500_000,
       multicallChunk: 100,
@@ -384,8 +389,8 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
     /// Validate that there are no incorrect routes / function combinations
     this.validateRoutes(routes, functionName, useMixedRouteQuoter);
 
-    let multicallChunk = this.batchParams.multicallChunk;
-    let gasLimitOverride = this.batchParams.gasLimitPerCall;
+    let multicallChunk = this.batchParams(optimisticCachedRoutes).multicallChunk;
+    let gasLimitOverride = this.batchParams(optimisticCachedRoutes).gasLimitPerCall;
     const { baseBlockOffset, rollback } = this.blockNumberConfig;
 
     // Apply the base block offset if provided
@@ -1084,7 +1089,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
 
     const successRate = (1.0 * numSuccessResults) / numResults;
 
-    const { quoteMinSuccessRate } = this.batchParams;
+    const { quoteMinSuccessRate } = this.batchParams(optimisticCachedRoutes);
     if (successRate < quoteMinSuccessRate) {
       if (haveRetriedForSuccessRate) {
         log.info(

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -3,7 +3,7 @@ import { BaseProvider } from '@ethersproject/providers';
 import {
   encodeMixedRouteToPath,
   MixedRouteSDK,
-  Protocol
+  Protocol,
 } from '@uniswap/router-sdk';
 import { ChainId } from '@uniswap/sdk-core';
 import { encodeRouteToPath } from '@uniswap/v3-sdk';
@@ -12,20 +12,18 @@ import _ from 'lodash';
 import stats from 'stats-lite';
 
 import { MixedRoute, V2Route, V3Route } from '../routers/router';
-import {
-  IMixedRouteQuoterV1__factory
-} from '../types/other/factories/IMixedRouteQuoterV1__factory';
+import { IMixedRouteQuoterV1__factory } from '../types/other/factories/IMixedRouteQuoterV1__factory';
 import { IQuoterV2__factory } from '../types/v3/factories/IQuoterV2__factory';
 import { ID_TO_NETWORK_NAME, metric, MetricLoggerUnit } from '../util';
 import {
   MIXED_ROUTE_QUOTER_V1_ADDRESSES,
-  NEW_QUOTER_V2_ADDRESSES
+  NEW_QUOTER_V2_ADDRESSES,
 } from '../util/addresses';
 import { CurrencyAmount } from '../util/amounts';
 import { log } from '../util/log';
 import {
   DEFAULT_BLOCK_NUMBER_CONFIGS,
-  DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES
+  DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
 } from '../util/onchainQuoteProviderConfigs';
 import { routeToString } from '../util/routes';
 
@@ -291,14 +289,15 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
       minTimeout: 25,
       maxTimeout: 250,
     },
-    protected batchParams: (optimisticCachedRoutes: boolean) => BatchParams =
-      (_) => {
-        return {
-            multicallChunk: 150,
-            gasLimitPerCall: 1_000_000,
-            quoteMinSuccessRate: 0.2,
-          };
-        },
+    protected batchParams: (optimisticCachedRoutes: boolean) => BatchParams = (
+      _
+    ) => {
+      return {
+        multicallChunk: 150,
+        gasLimitPerCall: 1_000_000,
+        quoteMinSuccessRate: 0.2,
+      };
+    },
     protected gasErrorFailureOverride: FailureOverrides = {
       gasLimitOverride: 1_500_000,
       multicallChunk: 100,
@@ -389,8 +388,12 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
     /// Validate that there are no incorrect routes / function combinations
     this.validateRoutes(routes, functionName, useMixedRouteQuoter);
 
-    let multicallChunk = this.batchParams(optimisticCachedRoutes).multicallChunk;
-    let gasLimitOverride = this.batchParams(optimisticCachedRoutes).gasLimitPerCall;
+    let multicallChunk = this.batchParams(
+      optimisticCachedRoutes
+    ).multicallChunk;
+    let gasLimitOverride = this.batchParams(
+      optimisticCachedRoutes
+    ).gasLimitPerCall;
     const { baseBlockOffset, rollback } = this.blockNumberConfig;
 
     // Apply the base block offset if provided

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -526,10 +526,12 @@ export class AlphaRouter
               minTimeout: 100,
               maxTimeout: 1000,
             },
-            {
-              multicallChunk: 110,
-              gasLimitPerCall: 1_200_000,
-              quoteMinSuccessRate: 0.1,
+            (_) => {
+              return {
+                multicallChunk: 110,
+                gasLimitPerCall: 1_200_000,
+                quoteMinSuccessRate: 0.1,
+              }
             },
             {
               gasLimitOverride: 3_000_000,
@@ -561,10 +563,12 @@ export class AlphaRouter
               minTimeout: 100,
               maxTimeout: 1000,
             },
-            {
-              multicallChunk: 80,
-              gasLimitPerCall: 1_200_000,
-              quoteMinSuccessRate: 0.1,
+            (_) => {
+              return {
+                multicallChunk: 80,
+                gasLimitPerCall: 1_200_000,
+                quoteMinSuccessRate: 0.1,
+              }
             },
             {
               gasLimitOverride: 3_000_000,
@@ -596,10 +600,12 @@ export class AlphaRouter
               minTimeout: 100,
               maxTimeout: 1000,
             },
-            {
-              multicallChunk: 10,
-              gasLimitPerCall: 12_000_000,
-              quoteMinSuccessRate: 0.1,
+            (_) => {
+              return {
+                multicallChunk: 10,
+                gasLimitPerCall: 12_000_000,
+                quoteMinSuccessRate: 0.1,
+              }
             },
             {
               gasLimitOverride: 30_000_000,
@@ -622,10 +628,12 @@ export class AlphaRouter
               minTimeout: 100,
               maxTimeout: 1000,
             },
-            {
-              multicallChunk: 10,
-              gasLimitPerCall: 5_000_000,
-              quoteMinSuccessRate: 0.1,
+            (_) => {
+              return {
+                multicallChunk: 10,
+                gasLimitPerCall: 5_000_000,
+                quoteMinSuccessRate: 0.1,
+              }
             },
             {
               gasLimitOverride: 5_000_000,
@@ -646,7 +654,7 @@ export class AlphaRouter
             provider,
             this.multicall2Provider,
             RETRY_OPTIONS[chainId],
-            BATCH_PARAMS[chainId],
+            (_) => BATCH_PARAMS[chainId]!,
             GAS_ERROR_FAILURE_OVERRIDES[chainId],
             SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
             BLOCK_NUMBER_CONFIGS[chainId]
@@ -658,7 +666,7 @@ export class AlphaRouter
             provider,
             this.multicall2Provider,
             DEFAULT_RETRY_OPTIONS,
-            DEFAULT_BATCH_PARAMS,
+            (_) => DEFAULT_BATCH_PARAMS,
             DEFAULT_GAS_ERROR_FAILURE_OVERRIDES,
             DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
             DEFAULT_BLOCK_NUMBER_CONFIGS,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
chore

- **What is the current behavior?** (You can also link to an open issue here)
We don't differ gas batch param by intent-quote vs caching-quote.

- **What is the new behavior (if this is a feature change)?**
We will differentiate

- **Other information**:
