### PR TITLE
feat: gas param also by protocol version

### DIFF
--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -289,9 +289,10 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
       minTimeout: 25,
       maxTimeout: 250,
     },
-    protected batchParams: (optimisticCachedRoutes: boolean) => BatchParams = (
-      _
-    ) => {
+    protected batchParams: (
+      optimisticCachedRoutes: boolean,
+      useMixedRouteQuoter: boolean
+    ) => BatchParams = (_optimisticCachedRoutes, _useMixedRouteQuoter) => {
       return {
         multicallChunk: 150,
         gasLimitPerCall: 1_000_000,
@@ -389,10 +390,12 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
     this.validateRoutes(routes, functionName, useMixedRouteQuoter);
 
     let multicallChunk = this.batchParams(
-      optimisticCachedRoutes
+      optimisticCachedRoutes,
+      useMixedRouteQuoter
     ).multicallChunk;
     let gasLimitOverride = this.batchParams(
-      optimisticCachedRoutes
+      optimisticCachedRoutes,
+      useMixedRouteQuoter
     ).gasLimitPerCall;
     const { baseBlockOffset, rollback } = this.blockNumberConfig;
 
@@ -1092,7 +1095,10 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
 
     const successRate = (1.0 * numSuccessResults) / numResults;
 
-    const { quoteMinSuccessRate } = this.batchParams(optimisticCachedRoutes);
+    const { quoteMinSuccessRate } = this.batchParams(
+      optimisticCachedRoutes,
+      useMixedRouteQuoter
+    );
     if (successRate < quoteMinSuccessRate) {
       if (haveRetriedForSuccessRate) {
         log.info(


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
Current gas param doesn't differ by protocol version

- **What is the new behavior (if this is a feature change)?**
Now gas param will differ by protocol version. This is important, because mixed-quoter-v1 is gas-inefficient in terms of reverting to get quote for V3 pools of the mixed path.

- **Other information**:
