### PR TITLE
chore(subgraph): Add metrics to measure untracked pools thresholds

### DIFF
--- a/src/providers/v2/subgraph-provider.ts
+++ b/src/providers/v2/subgraph-provider.ts
@@ -229,7 +229,13 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
     // TODO: Remove. Temporary fix to ensure tokens without trackedReserveETH are in the list.
     const FEI = '0x956f47f50a910163d8bf957cf5846d573e7f87ca';
 
-    const untrackedPools = pools.filter(pool => parseFloat(pool.reserveUSD) > this.untrackedUsdThreshold);
+    const untrackedPools = pools.filter(pool =>
+      pool.token0.id == FEI ||
+      pool.token1.id == FEI ||
+      parseFloat(pool.trackedReserveETH) > this.trackedEthThreshold ||
+      parseFloat(pool.reserveUSD) > this.untrackedUsdThreshold
+    );
+
     metric.putMetric(`V2SubgraphProvider.chain_${this.chainId}.getPools.untracked.length`, untrackedPools.length);
     metric.putMetric(
       `V2SubgraphProvider.chain_${this.chainId}.getPools.untracked.percent`,

--- a/src/providers/v3/subgraph-provider.ts
+++ b/src/providers/v3/subgraph-provider.ts
@@ -234,7 +234,11 @@ export class V3SubgraphProvider implements IV3SubgraphProvider {
 
     metric.putMetric(`V3SubgraphProvider.chain_${this.chainId}.getPools.retries`, retries);
 
-    const untrackedPools = pools.filter(pool => parseFloat(pool.totalValueLockedUSDUntracked) > this.untrackedUsdThreshold);
+    const untrackedPools = pools.filter(pool =>
+      parseInt(pool.liquidity) > 0 ||
+      parseFloat(pool.totalValueLockedETH) > this.trackedEthThreshold ||
+      parseFloat(pool.totalValueLockedUSDUntracked) > this.untrackedUsdThreshold
+    );
     metric.putMetric(`V3SubgraphProvider.chain_${this.chainId}.getPools.untracked.length`, untrackedPools.length);
     metric.putMetric(
       `V3SubgraphProvider.chain_${this.chainId}.getPools.untracked.percent`,


### PR DESCRIPTION
# Untracked Pools Metrics

Add metrics to measure untracked pools thresholds, this change is a no-op for the live feature but it will allow us to measure the impact of allowing untracked pools in the cache.
