### PR TITLE
fix: blast weth address

### DIFF
--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -501,7 +501,7 @@ export const WRAPPED_NATIVE_CURRENCY: { [chainId in ChainId]: Token } = {
   ),
   [ChainId.BLAST]: new Token(
     ChainId.BLAST,
-    '0x4200000000000000000000000000000000000006',
+    '0x4300000000000000000000000000000000000004',
     18,
     'WETH',
     'Wrapped Ether'


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
I saw routing-api pipeline failed with blast tests. Digging into it, it's because blast weth address is wrong to compute v3 gas model.

- **What is the new behavior (if this is a feature change)?**
Fix blast weth address.

- **Other information**:
This only impacts the route going through v3. For v2 route, since we don't compute the WETH/USDC gas model, the quote can still work.