### PR TITLE
Fix cache batchGet keys + update unit test

### DIFF
--- a/src/providers/token-properties-provider.ts
+++ b/src/providers/token-properties-provider.ts
@@ -64,14 +64,15 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
 
     const addressesToFetchFeesOnchain: string[] = [];
     const addressesRaw = this.buildAddressesRaw(tokens);
+    const addressesCacheKeys = this.buildAddressesCacheKeys(tokens);
 
     const tokenProperties = await this.tokenPropertiesCache.batchGet(
-      addressesRaw
+      addressesCacheKeys
     );
 
     // Check if we have cached token validation results for any tokens.
     for (const address of addressesRaw) {
-      const cachedValue = tokenProperties[address];
+      const cachedValue = tokenProperties[this.CACHE_KEY(this.chainId, address.toLowerCase())];
       if (cachedValue) {
         metric.putMetric(
           'TokenPropertiesProviderBatchGetCacheHit',
@@ -195,5 +196,18 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
     }
 
     return addressesRaw;
+  }
+
+  private buildAddressesCacheKeys(tokens: Token[]): Set<string> {
+    const addressesCacheKeys = new Set<string>();
+
+    for (const token of tokens) {
+      const addressCacheKey = this.CACHE_KEY(this.chainId, token.address.toLowerCase());
+      if (!addressesCacheKeys.has(addressCacheKey)) {
+        addressesCacheKeys.add(addressCacheKey);
+      }
+    }
+
+    return addressesCacheKeys;
   }
 }

--- a/test/unit/providers/token-properties-provider.test.ts
+++ b/test/unit/providers/token-properties-provider.test.ts
@@ -88,7 +88,10 @@ describe('TokenPropertiesProvider', () => {
 
       const cachedTokenProperties = await tokenPropertiesResultCache.get(CACHE_KEY(ChainId.MAINNET, token.address.toLowerCase()))
       expect(cachedTokenProperties).toBeDefined();
-      assertExpectedTokenProperties(cachedTokenProperties, BigNumber.from(213), BigNumber.from(800), TokenValidationResult.FOT);
+
+      // Second call to get token properties should not call token fee fetcher
+      const tokenPropertiesMapFromSecondCall = await tokenPropertiesProvider.getTokensProperties([token], { enableFeeOnTransferFeeFetching: true });
+      assertExpectedTokenProperties(tokenPropertiesMapFromSecondCall[token.address.toLowerCase()], BigNumber.from(213), BigNumber.from(800), TokenValidationResult.FOT);
       sinon.assert.calledOnce(mockTokenFeeFetcher.fetchFees)
 
       underlyingCache.getTtl(CACHE_KEY(ChainId.MAINNET, token.address.toLowerCase()))


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We don't get fee fetch [cache hits](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'Uniswap~'TokenFeeFetcherFetchFeesFailure~'Service~'RoutingAPI)~(~'.~'TokenFeeFetcherFetchFeesSuccess~'.~'.)~(~'.~'TokenPropertiesProviderBatchGetCacheMiss~'.~'.))~sparkline~true~view~'timeSeries~stacked~false~region~'us-east-2~start~'-PT24H~end~'P0D~stat~'SampleCount~period~60)&query=~'*7bUniswap*2cService*7d*20TokenPropertiesProviderBatchGetCacheHit) due to misconfigured batchGet keys.
With this fix we should start seeing cache hits and a big qps reduction. Also updated/fixed related unit test.

- **What is the new behavior (if this is a feature change)?**


- **Other information**:
