### PR TITLE
fix: use permit2-sdk PERTMIT2_ADDRESS

### DIFF
--- a/src/providers/simulation-provider.ts
+++ b/src/providers/simulation-provider.ts
@@ -1,6 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { ChainId, TradeType } from '@uniswap/sdk-core';
-import { PERMIT2_ADDRESS } from '@uniswap/universal-router-sdk';
 import { BigNumber } from 'ethers/lib/ethers';
 
 import {
@@ -14,6 +13,7 @@ import { Permit2__factory } from '../types/other/factories/Permit2__factory';
 import { CurrencyAmount, log, SWAP_ROUTER_02_ADDRESSES } from '../util';
 
 import { IPortionProvider } from './portion-provider';
+import { permit2Address } from '@uniswap/permit2-sdk';
 
 export type SimulationResult = {
   transaction: {
@@ -157,7 +157,7 @@ export abstract class Simulator {
     if (swapOptions.type == SwapType.UNIVERSAL_ROUTER) {
       const permit2Allowance = await tokenContract.allowance(
         fromAddress,
-        PERMIT2_ADDRESS
+        permit2Address(this.chainId)
       );
 
       // If a permit has been provided we don't need to check if UR has already been allowed.
@@ -176,7 +176,7 @@ export abstract class Simulator {
 
       // Check UR has been approved from Permit2.
       const permit2Contract = Permit2__factory.connect(
-        PERMIT2_ADDRESS,
+        permit2Address(this.chainId),
         provider
       );
 

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -5,7 +5,6 @@ import { MaxUint256 } from '@ethersproject/constants';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { ChainId } from '@uniswap/sdk-core';
 import {
-  PERMIT2_ADDRESS,
   UNIVERSAL_ROUTER_ADDRESS,
 } from '@uniswap/universal-router-sdk';
 import axios, { AxiosRequestConfig } from 'axios';
@@ -42,6 +41,7 @@ import {
 } from './simulation-provider';
 import { IV2PoolProvider } from './v2/pool-provider';
 import { IV3PoolProvider } from './v3/pool-provider';
+import { permit2Address } from '@uniswap/permit2-sdk';
 
 export type TenderlyResponseUniversalRouter = {
   config: {
@@ -310,7 +310,7 @@ export class TenderlySimulator extends Simulator {
       const erc20Interface = Erc20__factory.createInterface();
       const approvePermit2Calldata = erc20Interface.encodeFunctionData(
         'approve',
-        [PERMIT2_ADDRESS, MaxUint256]
+        [permit2Address(this.chainId), MaxUint256]
       );
 
       // We are unsure if the users calldata contains a permit or not. We just
@@ -339,7 +339,7 @@ export class TenderlySimulator extends Simulator {
         network_id: chainId,
         estimate_gas: true,
         input: approveUniversalRouterCallData,
-        to: PERMIT2_ADDRESS,
+        to: permit2Address(this.chainId),
         value: '0',
         from: fromAddress,
         simulation_type: TenderlySimulationType.QUICK,

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
-import { AllowanceTransfer, PermitSingle } from '@uniswap/permit2-sdk';
+import {
+  AllowanceTransfer,
+  permit2Address,
+  PermitSingle
+} from '@uniswap/permit2-sdk';
 import { Protocol } from '@uniswap/router-sdk';
 import {
   ChainId,
@@ -17,7 +21,6 @@ import {
   TradeType
 } from '@uniswap/sdk-core';
 import {
-  PERMIT2_ADDRESS,
   UNIVERSAL_ROUTER_ADDRESS as UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN
 } from '@uniswap/universal-router-sdk';
 import {
@@ -298,14 +301,14 @@ describe('alpha router integration', () => {
       // because there is custom logic built in for handling USDT and other checks
       tokenInBefore = await getBalanceAndApprove(
         alice,
-        PERMIT2_ADDRESS,
+        permit2Address(ChainId.MAINNET),
         tokenIn
       );
       const MAX_UINT160 = '0xffffffffffffffffffffffffffffffffffffffff';
 
       // If not using permit do a regular approval allowing narwhal max balance.
       if (!permit) {
-        const aliceP2 = Permit2__factory.connect(PERMIT2_ADDRESS, alice);
+        const aliceP2 = Permit2__factory.connect(permit2Address(ChainId.MAINNET), alice);
         const approveNarwhal = await aliceP2.approve(
           tokenIn.wrapped.address,
           UNIVERSAL_ROUTER_ADDRESS,
@@ -914,7 +917,7 @@ describe('alpha router integration', () => {
 
           const { domain, types, values } = AllowanceTransfer.getPermitData(
             permit,
-            PERMIT2_ADDRESS,
+            permit2Address(ChainId.MAINNET),
             1
           );
 
@@ -990,7 +993,7 @@ describe('alpha router integration', () => {
 
           const { domain, types, values } = AllowanceTransfer.getPermitData(
             permit,
-            PERMIT2_ADDRESS,
+            permit2Address(ChainId.MAINNET),
             1
           );
 
@@ -1200,7 +1203,7 @@ describe('alpha router integration', () => {
 
           const { domain, types, values } = AllowanceTransfer.getPermitData(
             permit,
-            PERMIT2_ADDRESS,
+            permit2Address(ChainId.MAINNET),
             1
           );
 
@@ -1862,7 +1865,7 @@ describe('alpha router integration', () => {
 
               const { domain, types, values } = AllowanceTransfer.getPermitData(
                 permit,
-                PERMIT2_ADDRESS,
+                permit2Address(ChainId.MAINNET),
                 1
               );
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We are using wrong permit2 address on ZkSync.

- **What is the new behavior (if this is a feature change)?**
We will use correct permit2 address by importing from permit2-sdk

- **Other information**:
No