### PR TITLE
chore(caching): Increase token fee data cache ttl to 20m

### DIFF
--- a/src/providers/token-properties-provider.ts
+++ b/src/providers/token-properties-provider.ts
@@ -19,8 +19,8 @@ import {
 export const DEFAULT_TOKEN_PROPERTIES_RESULT: TokenPropertiesResult = {
   tokenFeeResult: DEFAULT_TOKEN_FEE_RESULT,
 };
-export const POSITIVE_CACHE_ENTRY_TTL = 600; // 10 minutes in seconds
-export const NEGATIVE_CACHE_ENTRY_TTL = 600; // 10 minutes in seconds
+export const POSITIVE_CACHE_ENTRY_TTL = 1200; // 20 minutes in seconds
+export const NEGATIVE_CACHE_ENTRY_TTL = 1200; // 20 minutes in seconds
 
 type Address = string;
 export type TokenPropertiesResult = {


### PR DESCRIPTION
Increase token fee data cache ttl to 20m.
FOT fees don't change often so we are ok increasing this caching time, should be enough to reduce onchain requests due to lambda recycling

- **What is the current behavior?** (You can also link to an open issue here)
10m caching

- **What is the new behavior (if this is a feature change)?**
20m caching

- **Other information**:
