### PR TITLE
fix: add tenderly simulation request bodies in the mismatch error logging

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -3,6 +3,7 @@ import https from 'https';
 
 import { MaxUint256 } from '@ethersproject/constants';
 import { JsonRpcProvider } from '@ethersproject/providers';
+import { permit2Address } from '@uniswap/permit2-sdk';
 import { ChainId } from '@uniswap/sdk-core';
 import {
   UNIVERSAL_ROUTER_ADDRESS,
@@ -41,7 +42,7 @@ import {
 } from './simulation-provider';
 import { IV2PoolProvider } from './v2/pool-provider';
 import { IV3PoolProvider } from './v3/pool-provider';
-import { permit2Address } from '@uniswap/permit2-sdk';
+
 
 export type TenderlyResponseUniversalRouter = {
   config: {
@@ -398,6 +399,7 @@ export class TenderlySimulator extends Simulator {
         approvePermit2,
         approveUniversalRouter,
         swap,
+        body,
         resp
       );
 
@@ -677,6 +679,7 @@ export class TenderlySimulator extends Simulator {
     approvePermit2: TenderlySimulationRequest,
     approveUniversalRouter: TenderlySimulationRequest,
     swap: TenderlySimulationRequest,
+    gatewayReq: TenderlySimulationBody,
     gatewayResp: TenderlyResponseUniversalRouter
   ): Promise<void> {
     if (
@@ -782,7 +785,9 @@ export class TenderlySimulator extends Simulator {
 
           if (gatewayGas !== nodeGas) {
             log.error(
-              `Gateway gas and node gas estimates do not match for index ${i}`,
+              `Gateway gas and node gas estimates do not match for index ${i}
+              gateway request body ${JSON.stringify(gatewayReq.simulations[i], null, 2)}
+              node request body ${JSON.stringify(body.params[i], null, 2)}`,
               { gatewayGas, nodeGas }
             );
             metric.putMetric(
@@ -795,7 +800,9 @@ export class TenderlySimulator extends Simulator {
 
           if (gatewayGasUsed !== nodeGasUsed) {
             log.error(
-              `Gateway gas and node gas used estimates do not match for index ${i}`,
+              `Gateway gas and node gas used estimates do not match for index ${i}
+              gateway request body ${JSON.stringify(gatewayReq.simulations[i], null, 2)}
+              node request body ${JSON.stringify(body.params[i], null, 2)}`,
               { gatewayGasUsed, nodeGasUsed }
             );
             metric.putMetric(

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -43,7 +43,6 @@ import {
 import { IV2PoolProvider } from './v2/pool-provider';
 import { IV3PoolProvider } from './v3/pool-provider';
 
-
 export type TenderlyResponseUniversalRouter = {
   config: {
     url: string;
@@ -786,7 +785,11 @@ export class TenderlySimulator extends Simulator {
           if (gatewayGas !== nodeGas) {
             log.error(
               `Gateway gas and node gas estimates do not match for index ${i}
-              gateway request body ${JSON.stringify(gatewayReq.simulations[i], null, 2)}
+              gateway request body ${JSON.stringify(
+                gatewayReq.simulations[i],
+                null,
+                2
+              )}
               node request body ${JSON.stringify(body.params[i], null, 2)}`,
               { gatewayGas, nodeGas }
             );
@@ -801,7 +804,11 @@ export class TenderlySimulator extends Simulator {
           if (gatewayGasUsed !== nodeGasUsed) {
             log.error(
               `Gateway gas and node gas used estimates do not match for index ${i}
-              gateway request body ${JSON.stringify(gatewayReq.simulations[i], null, 2)}
+              gateway request body ${JSON.stringify(
+                gatewayReq.simulations[i],
+                null,
+                2
+              )}
               node request body ${JSON.stringify(body.params[i], null, 2)}`,
               { gatewayGasUsed, nodeGasUsed }
             );


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Because in routing-api, we set logging at info level at 10% percent chance upon lambda instantiation (https://github.com/Uniswap/routing-api/blob/main/lib/handlers/quote/injector.ts#L40), 90% of the chance log.info won't log anything. In order to troubleshoot tenderly gas mismatch, e.g. for this request id [19ec5e03-5abb-420d-979d-e765e7923eac](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20like*20*2719ec5e03-5abb-420d-979d-e765e7923eac*27*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*201000~queryId~'773ed3a6c6e1ffa1-12dcbe51-442f542-eba5f19d-3b419cd385eb41fde3ca0~source~(~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-Ro-RoutingLambdaF7AD8A1A-erFTueZgLnZ1~'*2faws*2flambda*2fprod-us-east-2-RoutingAPI-R-RoutingLambda2C4DF0900-Bbcx5MI4vlM6))), I have to know both tenderly api simulation request [body](https://github.com/Uniswap/smart-order-router/blob/ef444090d4a7e375f529e6563ab97bd69ea83348/src/providers/tenderly-simulation-provider.ts#L406) as well as the tenderly node request [body](https://github.com/Uniswap/smart-order-router/blob/ef444090d4a7e375f529e6563ab97bd69ea83348/src/providers/tenderly-simulation-provider.ts#L748) and send it to the tenderly team. Both are logging at info level.

- **What is the new behavior (if this is a feature change)?**
We don't want to change the above logging level from info to error, because that'd be excessive logging. Instead, we want to log both bodies, when we find the gas mismatch.

- **Other information**:
