### PR TITLE
fix: use DAI as first gas token

### DIFF
--- a/src/routers/alpha-router/gas-models/gas-model.ts
+++ b/src/routers/alpha-router/gas-models/gas-model.ts
@@ -117,7 +117,7 @@ export const usdGasTokensByChain: { [chainId in ChainId]?: Token[] } = {
   [ChainId.BASE]: [USDC_BASE, USDC_NATIVE_BASE],
   [ChainId.BLAST]: [USDB_BLAST],
   [ChainId.ZORA]: [USDC_ZORA],
-  [ChainId.ZKSYNC]: [USDCE_ZKSYNC, USDC_ZKSYNC, DAI_ZKSYNC],
+  [ChainId.ZKSYNC]: [DAI_ZKSYNC, USDCE_ZKSYNC, USDC_ZKSYNC],
 };
 
 export type L1ToL2GasCosts = {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
USDC has 6 decimals, DAI has 18 decimals.

```
  // For each gas estimate, normalize decimals to that of the chosen usd token.
  const estimatedGasUsedUSDs = _(bestSwap)
    .map((routeWithValidQuote) => {
      // TODO: will error if gasToken has decimals greater than usdToken
      const decimalsDiff =
        usdTokenDecimals - routeWithValidQuote.gasCostInUSD.currency.decimals;

      if (decimalsDiff == 0) {
        return CurrencyAmount.fromRawAmount(
          usdToken,
          routeWithValidQuote.gasCostInUSD.quotient
        );
      }

      return CurrencyAmount.fromRawAmount(
        usdToken,
        JSBI.multiply(
          routeWithValidQuote.gasCostInUSD.quotient,
          JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(decimalsDiff))
        )
      );
    })
    .value();
```


- **What is the new behavior (if this is a feature change)?**
we need to use DAI as primary gas token

- **Other information**:
