### PR TITLE
fix: check decimal diffs <= 0 and avoid throwing unchecked exceptions in gas diff token at all

### DIFF
--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -585,7 +585,7 @@ export async function getBestSwapRouteBy(
       const decimalsDiff =
         usdTokenDecimals - routeWithValidQuote.gasCostInUSD.currency.decimals;
 
-      if (decimalsDiff == 0) {
+      if (decimalsDiff <= 0) {
         return CurrencyAmount.fromRawAmount(
           usdToken,
           routeWithValidQuote.gasCostInUSD.quotient
@@ -594,7 +594,7 @@ export async function getBestSwapRouteBy(
 
       if (decimalsDiff < 0 && chainId === 324) {
           log.error(`Decimals diff is negative for ZkSync. This should not happen.
-          usdTokenDecimals ${usdTokenDecimals} routeWithValidQuote.gasCostInUSD.currency.decimals
+          usdToken ${JSON.stringify(usdToken)} usdTokenDecimals ${usdTokenDecimals} routeWithValidQuote.gasCostInUSD.currency.decimals
           ${routeWithValidQuote.gasCostInUSD.currency.decimals} ${JSON.stringify(routeWithValidQuote)}`);
       }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Even using DAI we can see runtime error.

- **What is the new behavior (if this is a feature change)?**
We don't know why, and it shouldn't happen, because DAI and zksync ETH are both 18 decimals. But we will hotfix by checking decimaldiff <=0 so it cannot throw.

- **Other information**:
