### PR TITLE
fix: return tenderly not supported on zksync

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -135,6 +135,8 @@ const TENDERLY_NODE_API = (chainId: ChainId, tenderlyNodeApiKey: string) => {
   }
 };
 
+export const TENDERLY_NOT_SUPPORTED_CHAINS = [ChainId.CELO, ChainId.CELO_ALFAJORES, ChainId.ZKSYNC]
+
 // We multiply tenderly gas limit by this to overestimate gas limit
 const DEFAULT_ESTIMATE_MULTIPLIER = 1.3;
 
@@ -271,8 +273,9 @@ export class TenderlySimulator extends Simulator {
     const currencyIn = swapRoute.trade.inputAmount.currency;
     const tokenIn = currencyIn.wrapped;
     const chainId = this.chainId;
-    if ([ChainId.CELO, ChainId.CELO_ALFAJORES, ChainId.ZKSYNC].includes(chainId)) {
-      const msg = 'Celo not supported by Tenderly!';
+
+    if (TENDERLY_NOT_SUPPORTED_CHAINS.includes(chainId)) {
+      const msg = `${TENDERLY_NOT_SUPPORTED_CHAINS.toString()} not supported by Tenderly!`;
       log.info(msg);
       return { ...swapRoute, simulationStatus: SimulationStatus.NotSupported };
     }

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -271,7 +271,7 @@ export class TenderlySimulator extends Simulator {
     const currencyIn = swapRoute.trade.inputAmount.currency;
     const tokenIn = currencyIn.wrapped;
     const chainId = this.chainId;
-    if ([ChainId.CELO, ChainId.CELO_ALFAJORES].includes(chainId)) {
+    if ([ChainId.CELO, ChainId.CELO_ALFAJORES, ChainId.ZKSYNC].includes(chainId)) {
       const msg = 'Celo not supported by Tenderly!';
       log.info(msg);
       return { ...swapRoute, simulationStatus: SimulationStatus.NotSupported };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We return simulation error on zksync, meanwhile tenderly doesn't support zksync simulation yet. So we should return tenderly not supported.

- **What is the new behavior (if this is a feature change)?**
return tenderly not supported on zksync.

- **Other information**:
