### PR TITLE
fix: tenderly node request param array indexing

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -5,9 +5,7 @@ import { MaxUint256 } from '@ethersproject/constants';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { permit2Address } from '@uniswap/permit2-sdk';
 import { ChainId } from '@uniswap/sdk-core';
-import {
-  UNIVERSAL_ROUTER_ADDRESS,
-} from '@uniswap/universal-router-sdk';
+import { UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk';
 import axios, { AxiosRequestConfig } from 'axios';
 import { BigNumber } from 'ethers/lib/ethers';
 
@@ -135,7 +133,11 @@ const TENDERLY_NODE_API = (chainId: ChainId, tenderlyNodeApiKey: string) => {
   }
 };
 
-export const TENDERLY_NOT_SUPPORTED_CHAINS = [ChainId.CELO, ChainId.CELO_ALFAJORES, ChainId.ZKSYNC]
+export const TENDERLY_NOT_SUPPORTED_CHAINS = [
+  ChainId.CELO,
+  ChainId.CELO_ALFAJORES,
+  ChainId.ZKSYNC,
+];
 
 // We multiply tenderly gas limit by this to overestimate gas limit
 const DEFAULT_ESTIMATE_MULTIPLIER = 1.3;
@@ -682,7 +684,7 @@ export class TenderlySimulator extends Simulator {
     approveUniversalRouter: TenderlySimulationRequest,
     swap: TenderlySimulationRequest,
     gatewayReq: TenderlySimulationBody,
-    gatewayResp: TenderlyResponseUniversalRouter,
+    gatewayResp: TenderlyResponseUniversalRouter
   ): Promise<void> {
     if (
       Math.random() * 100 < (this.tenderlyNodeApiSamplingPercent ?? 0) &&
@@ -695,10 +697,8 @@ export class TenderlySimulator extends Simulator {
         this.tenderlyNodeApiKey
       );
       const blockNumber = swap.block_number
-        ? BigNumber.from(swap.block_number)
-          .toHexString()
-          .replace('0x0', '0x')
-        : 'latest'
+        ? BigNumber.from(swap.block_number).toHexString().replace('0x0', '0x')
+        : 'latest';
       const body: TenderlyNodeEstimateGasBundleBody = {
         id: 1,
         jsonrpc: '2.0',
@@ -788,13 +788,7 @@ export class TenderlySimulator extends Simulator {
 
           if (gatewayGas !== nodeGas) {
             log.error(
-              `Gateway gas and node gas estimates do not match for index ${i}
-              gateway request body ${JSON.stringify(
-                gatewayReq.simulations[i],
-                null,
-                2
-              )}
-              node request body ${JSON.stringify((body.params[0]! as Array<EthJsonRpcRequestBody>)[i], null, 2)}`,
+              `Gateway gas and node gas estimates do not match for index ${i}`,
               { gatewayGas, nodeGas, blockNumber }
             );
             metric.putMetric(
@@ -807,14 +801,8 @@ export class TenderlySimulator extends Simulator {
 
           if (gatewayGasUsed !== nodeGasUsed) {
             log.error(
-              `Gateway gas and node gas used estimates do not match for index ${i}
-              gateway request body ${JSON.stringify(
-                gatewayReq.simulations[i],
-                null,
-                2
-              )}
-              node request body ${JSON.stringify((body.params[0]! as Array<EthJsonRpcRequestBody>)[i], null, 2)}`,
-              { gatewayGasUsed, nodeGasUsed, blockNumber }
+              `Gateway gas and node gas used estimates do not match for index ${i}`,
+              { gatewayGas, nodeGas, blockNumber }
             );
             metric.putMetric(
               `TenderlyNodeGasEstimateBundleGasUsedMismatch${i}`,
@@ -830,6 +818,12 @@ export class TenderlySimulator extends Simulator {
             'TenderlyNodeGasEstimateBundleMatch',
             1,
             MetricLoggerUnit.Count
+          );
+        } else {
+          log.error(
+            `Gateway gas and node gas estimates do not match
+              gateway request body ${JSON.stringify(gatewayReq, null, 2)}
+              node request body ${JSON.stringify(body, null, 2)}`
           );
         }
       } catch (err) {

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -793,7 +793,7 @@ export class TenderlySimulator extends Simulator {
                 null,
                 2
               )}
-              node request body ${JSON.stringify((body.params[0]! as Array<EthJsonRpcRequestBody>)[0], null, 2)}`,
+              node request body ${JSON.stringify((body.params[0]! as Array<EthJsonRpcRequestBody>)[i], null, 2)}`,
               { gatewayGas, nodeGas }
             );
             metric.putMetric(
@@ -812,7 +812,7 @@ export class TenderlySimulator extends Simulator {
                 null,
                 2
               )}
-              node request body ${JSON.stringify((body.params[0]! as Array<EthJsonRpcRequestBody>)[0], null, 2)}`,
+              node request body ${JSON.stringify((body.params[0]! as Array<EthJsonRpcRequestBody>)[i], null, 2)}`,
               { gatewayGasUsed, nodeGasUsed }
             );
             metric.putMetric(

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -694,6 +694,11 @@ export class TenderlySimulator extends Simulator {
         this.chainId,
         this.tenderlyNodeApiKey
       );
+      const blockNumber = swap.block_number
+        ? BigNumber.from(swap.block_number)
+          .toHexString()
+          .replace('0x0', '0x')
+        : 'latest'
       const body: TenderlyNodeEstimateGasBundleBody = {
         id: 1,
         jsonrpc: '2.0',
@@ -712,11 +717,7 @@ export class TenderlySimulator extends Simulator {
             },
             { from: swap.from, to: swap.to, data: swap.input },
           ],
-          swap.block_number
-            ? BigNumber.from(swap.block_number)
-              .toHexString()
-              .replace('0x0', '0x')
-            : 'latest',
+          blockNumber,
         ],
       };
 
@@ -794,7 +795,7 @@ export class TenderlySimulator extends Simulator {
                 2
               )}
               node request body ${JSON.stringify((body.params[0]! as Array<EthJsonRpcRequestBody>)[i], null, 2)}`,
-              { gatewayGas, nodeGas }
+              { gatewayGas, nodeGas, blockNumber }
             );
             metric.putMetric(
               `TenderlyNodeGasEstimateBundleGasMismatch${i}`,
@@ -813,7 +814,7 @@ export class TenderlySimulator extends Simulator {
                 2
               )}
               node request body ${JSON.stringify((body.params[0]! as Array<EthJsonRpcRequestBody>)[i], null, 2)}`,
-              { gatewayGasUsed, nodeGasUsed }
+              { gatewayGasUsed, nodeGasUsed, blockNumber }
             );
             metric.putMetric(
               `TenderlyNodeGasEstimateBundleGasUsedMismatch${i}`,

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -402,8 +402,7 @@ export class TenderlySimulator extends Simulator {
         approveUniversalRouter,
         swap,
         body,
-        resp,
-        blockNumber
+        resp
       );
 
       const latencies = Date.now() - before;
@@ -684,7 +683,6 @@ export class TenderlySimulator extends Simulator {
     swap: TenderlySimulationRequest,
     gatewayReq: TenderlySimulationBody,
     gatewayResp: TenderlyResponseUniversalRouter,
-    blockNumber?: number
   ): Promise<void> {
     if (
       Math.random() * 100 < (this.tenderlyNodeApiSamplingPercent ?? 0) &&
@@ -714,7 +712,11 @@ export class TenderlySimulator extends Simulator {
             },
             { from: swap.from, to: swap.to, data: swap.input },
           ],
-          blockNumber ?? 'latest',
+          swap.block_number
+            ? BigNumber.from(swap.block_number)
+              .toHexString()
+              .replace('0x0', '0x')
+            : 'latest',
         ],
       };
 

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -402,7 +402,8 @@ export class TenderlySimulator extends Simulator {
         approveUniversalRouter,
         swap,
         body,
-        resp
+        resp,
+        blockNumber
       );
 
       const latencies = Date.now() - before;
@@ -682,7 +683,8 @@ export class TenderlySimulator extends Simulator {
     approveUniversalRouter: TenderlySimulationRequest,
     swap: TenderlySimulationRequest,
     gatewayReq: TenderlySimulationBody,
-    gatewayResp: TenderlyResponseUniversalRouter
+    gatewayResp: TenderlyResponseUniversalRouter,
+    blockNumber?: number
   ): Promise<void> {
     if (
       Math.random() * 100 < (this.tenderlyNodeApiSamplingPercent ?? 0) &&
@@ -712,11 +714,7 @@ export class TenderlySimulator extends Simulator {
             },
             { from: swap.from, to: swap.to, data: swap.input },
           ],
-          swap.block_number
-            ? BigNumber.from(swap.block_number)
-              .toHexString()
-              .replace('0x0', '0x')
-            : 'latest',
+          blockNumber ?? 'latest',
         ],
       };
 
@@ -793,7 +791,7 @@ export class TenderlySimulator extends Simulator {
                 null,
                 2
               )}
-              node request body ${JSON.stringify(body.params[i], null, 2)}`,
+              node request body ${JSON.stringify((body.params[0]! as Array<EthJsonRpcRequestBody>)[0], null, 2)}`,
               { gatewayGas, nodeGas }
             );
             metric.putMetric(
@@ -812,7 +810,7 @@ export class TenderlySimulator extends Simulator {
                 null,
                 2
               )}
-              node request body ${JSON.stringify(body.params[i], null, 2)}`,
+              node request body ${JSON.stringify((body.params[0]! as Array<EthJsonRpcRequestBody>)[0], null, 2)}`,
               { gatewayGasUsed, nodeGasUsed }
             );
             metric.putMetric(


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
I think it's possible that the node gas estimate didn't return the gas/gasUsed for some requests:

![Screenshot 2024-06-20 at 9.06.39 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/27066b97-de29-4699-bb2f-6f7943871236.png)

Both request and nodeGas are undefined/NaN. This is possible in case the node gas estimate returns a failed response.

We should log the entire request body and response payload to account for this situation.

- **What is the new behavior (if this is a feature change)?**
We log them correctly so that we can debug
We will log the entire request and response.

- **Other information**:
