### PR TITLE
fix: log error response in case of tenderly node non 200 http status

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -772,6 +772,18 @@ export class TenderlySimulator extends Simulator {
           )}, having latencies ${latencies} in milliseconds.`
         );
 
+        if (httpStatus !== 200) {
+          log.error(
+            `Failed to invoke Tenderly Node Endpoint for gas estimation bundle ${JSON.stringify(
+              body,
+              null,
+              2
+            )}. HTTP Status: ${httpStatus}`,
+            { resp }
+          );
+          return;
+        }
+
         if (gatewayResp.simulation_results.length !== resp.result.length) {
           metric.putMetric(
             'TenderlyNodeGasEstimateBundleLengthMismatch',


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Besides small amount of tenderly API vs tenderly node response mismatch, I noticed small amount of [TenderlyNodeGasEstimateBundleFailure](https://github.com/Uniswap/smart-order-router/blob/5b86d2f707d875ed4ebe9639f73c5c9f2a752c6b/src/providers/tenderly-simulation-provider.ts#L868).

This is due to:

![Screenshot 2024-06-27 at 3.17.16 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/67f3480a-9267-42d2-a821-60ad8074b8bb.png)

If I hit against the same tenderly node endpoint with the same payload, I got a result array:

```
{"id":1,"jsonrpc":"2.0","result":[{"error":{"code":3,"message":"execution reverted","data":"0x"}},{"gas":"0x77e6","gasUsed":"0x77e6"},{"gas":"0x29cee","gasUsed":"0x23bac"}]}%         
```

This tells me that `Cannot read properties of undefined (reading 'length')` from reading `resp.result.length` is a sporadic runtime error, most likely because tenderly returned a non-200 status code.

- **What is the new behavior (if this is a feature change)?**
If tenderly node returns non-200, we want to log that response as error.

- **Other information**:
