### PR TITLE
fix: tenderly API simulation missing block number on permit2 and UR approvals

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -345,6 +345,7 @@ export class TenderlySimulator extends Simulator {
         to: tokenIn.address,
         value: '0',
         from: fromAddress,
+        block_number: blockNumber,
         simulation_type: TenderlySimulationType.QUICK,
         save_if_fails: providerConfig?.saveTenderlySimulationIfFailed,
       };
@@ -356,6 +357,7 @@ export class TenderlySimulator extends Simulator {
         to: permit2Address(this.chainId),
         value: '0',
         from: fromAddress,
+        block_number: blockNumber,
         simulation_type: TenderlySimulationType.QUICK,
         save_if_fails: providerConfig?.saveTenderlySimulationIfFailed,
       };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
tenderly API simulation does not include block number on permit2 and UR approvals

- **What is the new behavior (if this is a feature change)?**
tenderly API simulation to include block number on permit2 and UR approvals

- **Other information**:
