### PR TITLE
Revert "fix: tenderly node simulation block with (block number - 1) (#629)"

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -310,7 +310,6 @@ export class TenderlySimulator extends Simulator {
       'Simulating transaction on Tenderly'
     );
 
-    // tenderly API simulates at the beginning of the block
     const blockNumber = await providerConfig?.blockNumber;
     let estimatedGasUsed: BigNumber;
     const estimateMultiplier =
@@ -709,8 +708,7 @@ export class TenderlySimulator extends Simulator {
         this.tenderlyNodeApiKey
       );
       const blockNumber = swap.block_number
-        // tenderly node simulates at the end of the block, so we need to simulate at the end of the previous block
-        ? BigNumber.from(swap.block_number - 1).toHexString().replace('0x0', '0x')
+        ? BigNumber.from(swap.block_number).toHexString().replace('0x0', '0x')
         : 'latest';
       const body: TenderlyNodeEstimateGasBundleBody = {
         id: 1,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Turned out we should not subtract block number from 1 for node request

- **What is the new behavior (if this is a feature change)?**
Revert previous change.

- **Other information**:
