### PR TITLE
chore(subgraph): Add error logs for subgraph pool fetching

### DIFF
--- a/src/providers/v2/subgraph-provider.ts
+++ b/src/providers/v2/subgraph-provider.ts
@@ -162,8 +162,8 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
                   pools = [];
                   retries += 1;
                   log.info(
-                    { err },
-                    `Failed request for page of pools from subgraph. Retry attempt: ${retry}`
+                    { err, lastId },
+                    `Failed request for page of pools from subgraph. Retry attempt: ${retry}. LastId: ${lastId}`
                   );
                 },
               }
@@ -188,6 +188,7 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
           pools = await Promise.race([getPoolsPromise, timerPromise]);
           return;
         } catch (err) {
+          log.error({ err }, 'Error fetching V2 Subgraph Pools.');
           throw err;
         } finally {
           timeout.clear();

--- a/src/providers/v2/subgraph-provider.ts
+++ b/src/providers/v2/subgraph-provider.ts
@@ -177,7 +177,6 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
           return pairs;
         };
 
-        /* eslint-disable no-useless-catch */
         try {
           const getPoolsPromise = getPools();
           const timerPromise = timeout.set(this.timeout).then(() => {
@@ -193,7 +192,6 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
         } finally {
           timeout.clear();
         }
-        /* eslint-enable no-useless-catch */
       },
       {
         retries: this.retries,

--- a/src/providers/v2/subgraph-provider.ts
+++ b/src/providers/v2/subgraph-provider.ts
@@ -161,7 +161,7 @@ export class V2SubgraphProvider implements IV2SubgraphProvider {
                 onRetry: (err, retry) => {
                   pools = [];
                   retries += 1;
-                  log.info(
+                  log.error(
                     { err, lastId },
                     `Failed request for page of pools from subgraph. Retry attempt: ${retry}. LastId: ${lastId}`
                   );

--- a/src/providers/v3/subgraph-provider.ts
+++ b/src/providers/v3/subgraph-provider.ts
@@ -201,6 +201,7 @@ export class V3SubgraphProvider implements IV3SubgraphProvider {
           pools = await Promise.race([getPoolsPromise, timerPromise]);
           return;
         } catch (err) {
+          log.error({ err }, 'Error fetching V3 Subgraph Pools.');
           throw err;
         } finally {
           timeout.clear();

--- a/src/providers/v3/subgraph-provider.ts
+++ b/src/providers/v3/subgraph-provider.ts
@@ -190,7 +190,6 @@ export class V3SubgraphProvider implements IV3SubgraphProvider {
           return pools;
         };
 
-        /* eslint-disable no-useless-catch */
         try {
           const getPoolsPromise = getPools();
           const timerPromise = timeout.set(this.timeout).then(() => {
@@ -206,7 +205,6 @@ export class V3SubgraphProvider implements IV3SubgraphProvider {
         } finally {
           timeout.clear();
         }
-        /* eslint-enable no-useless-catch */
       },
       {
         retries: this.retries,


### PR DESCRIPTION
# Error logs in subgraph pool fetching

In order to triage the issue of high latency when loading the subgraph, we need to know the page in which it fails.

This change will hopefully provide this information.
