### PR TITLE
Remove unncessary mainnet check when trying ethEstimateGas

### DIFF
--- a/src/providers/simulation-provider.ts
+++ b/src/providers/simulation-provider.ts
@@ -64,13 +64,17 @@ export abstract class Simulator {
     quote: CurrencyAmount,
     providerConfig?: GasModelProviderConfig
   ): Promise<SwapRoute> {
+    const neededBalance =
+      swapRoute.trade.tradeType == TradeType.EXACT_INPUT ? amount : quote;
     if (
-      await this.userHasSufficientBalance(
+      // we assume we always have enough eth mainnet balance because we use beacon address later
+      (neededBalance.currency.isNative && this.chainId == ChainId.MAINNET) ||
+      (await this.userHasSufficientBalance(
         fromAddress,
         swapRoute.trade.tradeType,
         amount,
         quote
-      )
+      ))
     ) {
       log.info(
         'User has sufficient balance to simulate. Simulating transaction.'

--- a/src/providers/simulation-provider.ts
+++ b/src/providers/simulation-provider.ts
@@ -64,16 +64,13 @@ export abstract class Simulator {
     quote: CurrencyAmount,
     providerConfig?: GasModelProviderConfig
   ): Promise<SwapRoute> {
-    const neededBalance =
-      swapRoute.trade.tradeType == TradeType.EXACT_INPUT ? amount : quote;
     if (
-      (neededBalance.currency.isNative && this.chainId == ChainId.MAINNET) ||
-      (await this.userHasSufficientBalance(
+      await this.userHasSufficientBalance(
         fromAddress,
         swapRoute.trade.tradeType,
         amount,
         quote
-      ))
+      )
     ) {
       log.info(
         'User has sufficient balance to simulate. Simulating transaction.'

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -177,7 +177,7 @@ export class FallbackTenderlySimulator extends Simulator {
     const inputAmount = swapRoute.trade.inputAmount;
 
     if (
-      (inputAmount.currency.isNative && this.chainId == ChainId.MAINNET) ||
+      (inputAmount.currency.isNative) ||
       (await this.checkTokenApproved(
         fromAddress,
         inputAmount,

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -200,7 +200,8 @@ export class FallbackTenderlySimulator extends Simulator {
         return swapRouteWithGasEstimate;
       } catch (err) {
         log.info({ err: err }, 'Error simulating using eth_estimateGas');
-        return { ...swapRoute, simulationStatus: SimulationStatus.Failed };
+        // If it fails, we should still try to simualte using Tenderly
+        // return { ...swapRoute, simulationStatus: SimulationStatus.Failed };
       }
     }
 

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -200,7 +200,7 @@ export class FallbackTenderlySimulator extends Simulator {
         return swapRouteWithGasEstimate;
       } catch (err) {
         log.info({ err: err }, 'Error simulating using eth_estimateGas');
-        // If it fails, we should still try to simualte using Tenderly
+        // If it fails, we should still try to simulate using Tenderly
         // return { ...swapRoute, simulationStatus: SimulationStatus.Failed };
       }
     }

--- a/test/unit/providers/simulation-provider.test.ts
+++ b/test/unit/providers/simulation-provider.test.ts
@@ -277,6 +277,7 @@ describe('Fallback Tenderly simulator', () => {
       quote
     );
     expect(ethEstimateGasSimulator.ethEstimateGas.called).toBeTruthy();
+    expect(tenderlySimulator.ethEstimateGas.called).toBeTruthy();
     expect(swapRouteWithGasEstimate.simulationStatus).toEqual(
       SimulationStatus.Succeeded
     );

--- a/test/unit/providers/simulation-provider.test.ts
+++ b/test/unit/providers/simulation-provider.test.ts
@@ -277,7 +277,7 @@ describe('Fallback Tenderly simulator', () => {
       quote
     );
     expect(ethEstimateGasSimulator.ethEstimateGas.called).toBeTruthy();
-    expect(tenderlySimulator.ethEstimateGas.called).toBeTruthy();
+    expect(tenderlySimulator.simulateTransaction.called).toBeTruthy();
     expect(swapRouteWithGasEstimate.simulationStatus).toEqual(
       SimulationStatus.Succeeded
     );

--- a/test/unit/providers/simulation-provider.test.ts
+++ b/test/unit/providers/simulation-provider.test.ts
@@ -259,7 +259,7 @@ describe('Fallback Tenderly simulator', () => {
       SimulationStatus.Failed
     );
   });
-  test('when eth estimate gas simulator throws', async () => {
+  test('when eth estimate gas simulator throws, try tenderly anyway', async () => {
     tokenContract = {
       balanceOf: async () => {
         return BigNumber.from(325);
@@ -278,7 +278,7 @@ describe('Fallback Tenderly simulator', () => {
     );
     expect(ethEstimateGasSimulator.ethEstimateGas.called).toBeTruthy();
     expect(swapRouteWithGasEstimate.simulationStatus).toEqual(
-      SimulationStatus.Failed
+      SimulationStatus.Succeeded
     );
   });
 });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove unncessary mainnet check when trying ethEstimateGas
- **What is the current behavior?** (You can also link to an open issue here)
- Currently we go straight to tenderly for all natives except for mainnet, when we shouldnt. 

- **What is the new behavior (if this is a feature change)?**
We will try ethEstimategas for all native tokens of all chains, and fallback to tenderly if it fails.
- **Other information**:
