### PR TITLE
fix: eip-1559 gas model for arbitrum and op stack chains

### DIFF
--- a/src/providers/on-chain-gas-price-provider.ts
+++ b/src/providers/on-chain-gas-price-provider.ts
@@ -3,11 +3,14 @@ import { ChainId } from '@uniswap/sdk-core';
 import { EIP1559GasPriceProvider } from './eip-1559-gas-price-provider';
 import { GasPrice, IGasPriceProvider } from './gas-price-provider';
 import { LegacyGasPriceProvider } from './legacy-gas-price-provider';
+import { opStackChains } from '../util/l2FeeChains';
 
 const DEFAULT_EIP_1559_SUPPORTED_CHAINS = [
   ChainId.MAINNET,
   ChainId.GOERLI,
   ChainId.POLYGON_MUMBAI,
+  ChainId.ARBITRUM_ONE,
+  ...opStackChains
 ];
 
 /**

--- a/src/util/l2FeeChains.ts
+++ b/src/util/l2FeeChains.ts
@@ -7,4 +7,5 @@ export const opStackChains = [
   ChainId.BASE,
   ChainId.BASE_GOERLI,
   ChainId.BLAST,
+  ChainId.ZORA
 ];


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
SOR return legacy gas price for OP stack chains and arbitrum

- **What is the new behavior (if this is a feature change)?**
SOR return EIP-1559 gas price for OP stack chains and arbitrum

- **Other information**:
