### PR TITLE
fix: add node response logging for undefined error

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -788,6 +788,23 @@ export class TenderlySimulator extends Simulator {
           return;
         }
 
+        if (!gatewayResp.simulation_results || !resp.result) {
+          log.error(
+            `Gateway and node response bodies do not contain simulation results for gas estimation bundle ${JSON.stringify(
+              body,
+              null,
+              2
+            )}.`,
+            { gatewayResp, resp }
+          );
+          metric.putMetric(
+            'TenderlyNodeGasEstimateBundleMismatch',
+            1,
+            MetricLoggerUnit.Count
+          );
+          return;
+        }
+
         if (gatewayResp.simulation_results.length !== resp.result.length) {
           metric.putMetric(
             'TenderlyNodeGasEstimateBundleLengthMismatch',


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
There are some unexpected error from shadow calling tenderly node endpoint:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at vCe.sampleNodeEndpoint (/node_modules/@uniswap/smart-order-router/src/providers/tenderly-simulation-provider.ts:791:67)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
hostname	
169.254.94.253
level	
50
msg	
Failed to invoke Tenderly Node Endpoint for gas estimation bundle {
  "id": 1,
  "jsonrpc": "2.0",
  "method": "tenderly_estimateGasBundle",
  "params": [
    [
      {
        "from": "0xc1092Fff8e8d0208167040143C10b8eDCAB17e63",
        "to": "0xad162d5523cDE449d91e3be69ca38bC157B18E53",
        "data": "0x095ea7b3000000000000000000000000000000000022d473030f116ddee9f6b43ac78ba3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
      },
      {
        "from": "0xc1092Fff8e8d0208167040143C10b8eDCAB17e63",
        "to": "0x000000000022D473030F116dDEE9F6B43aC78BA3",
        "data": "0x87517c45000000000000000000000000ad162d5523cde449d91e3be69ca38bc157b18e530000000000000000000000003fc91a3afd70395cd496c647d5a6cc9d4b2b7fad000000000000000000000000ffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000067418f5f"
      },
      {
        "from": "0xc1092Fff8e8d0208167040143C10b8eDCAB17e63",
        "to": "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
        "data": "0x3593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000066a8fb37000000000000000000000000000000000000000000000000000000000000000308060c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000015fb06875db601f671c00000000000000000000000000000000000000000000000034259486f23d36b500000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000ad162d5523cde449d91e3be69ca38bc157b18e53000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000060000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000000000fee13a103a10d593b9ae06b3e05f2e7e1c00000000000000000000000000000000000000000000000000000000000000190000000000000000000000000000000000000000000000000000000000000040000000000000000000000000c1092fff8e8d0208167040143c10b8edcab17e63000000000000000000000000000000000000000000000000340434cbba97f0cf"
      }
    ],
    "0x1379585"
  ]
}. Error: TypeError: Cannot read properties of undefined (reading 'length')
```

We don't know what the response looked like to cause this error

- **What is the new behavior (if this is a feature change)?**
We will add new logging to ensure uncaught exception won't get throw, and instead we will log the response entirely in case `resp.result` is undefined.

- **Other information**:
