### PR TITLE
feat: tenderly support live switch with integ-test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-alpha-router-integration-mainnet-alpha-exact_input-hardhat:
     name: Integration Tests - Alpha Router Integration Mainnet Alpha EXACT_INPUT Execute On Hardhat Fork
@@ -109,6 +110,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-alpha-router-integration-mainnet-alpha-exact_input-tenderly-hardhat:
     name: Integration Tests - Alpha Router Integration Mainnet Alpha EXACT_INPUT Simulate On Tenderly Execute On Hardhat Fork
@@ -143,6 +145,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-alpha-router-integration-mainnet-alpha-exact_output-erc20-to-erc20:
     name: Integration Tests - Alpha Router Integration Mainnet Alpha EXACT_OUTPUT ERC20 -> ERC20
@@ -177,6 +180,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-alpha-router-integration-mainnet-alpha-exact_output-hardhat:
     name: Integration Tests - Alpha Router Integration Mainnet Alpha EXACT_OUTPUT Execute On Hardhat Fork
@@ -211,6 +215,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-alpha-router-integration-mainnet-alpha-exact_output-tenderly-hardhat:
     name: Integration Tests - Alpha Router Integration Mainnet Alpha EXACT_OUTPUT Simulate On Tenderly Execute On Hardhat Fork
@@ -245,6 +250,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-alpha-router-integration-mixed-routes:
     name: Integration Tests - Alpha Router Integration Mixed Routes
@@ -279,6 +285,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-external-class-tests:
     name: Integration Tests - External Class Tests
@@ -313,6 +320,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-mainnet:
     name: Integration Tests - Quote For Other Networks Mainnet
@@ -347,6 +355,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-optimism:
     name: Integration Tests - Quote For Other Networks Optimism
@@ -382,6 +391,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-arbitrum:
     name: Integration Tests - Quote For Other Networks Arbitrum
@@ -417,6 +427,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-polygon:
     name: Integration Tests - Quote For Other Networks Polygon
@@ -452,6 +463,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-sepolia:
     name: Integration Tests - Quote For Other Networks Sepolia
@@ -486,6 +498,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-celo:
     name: Integration Tests - Quote For Other Networks Celo
@@ -521,6 +534,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-bnb:
     name: Integration Tests - Quote For Other Networks BNB
@@ -555,6 +569,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-avalanche:
     name: Integration Tests - Quote For Other Networks Avalanche
@@ -589,6 +604,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-base:
     name: Integration Tests - Quote For Other Networks Base
@@ -623,6 +639,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-blast:
     name: Integration Tests - Quote For Other Networks Blast
@@ -657,6 +674,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-zora:
     name: Integration Tests - Quote For Other Networks Zora
@@ -691,6 +709,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-zksync:
     name: Integration Tests - Quote For Other Networks ZkSync
@@ -724,6 +743,7 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}
 
   integration-tests-quote-for-other-networks-remaining-networks:
     name: Integration Tests - Quote For Other Networks Remaining Networks
@@ -760,3 +780,4 @@ jobs:
           TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
           TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
           TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_NODE_API_KEY: ${{ secrets.TENDERLY_NODE_API_KEY }}

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -408,6 +408,11 @@ export class TenderlySimulator extends Simulator {
           approveUniversalRouter,
           swap
         );
+        // We will maintain the original metrics TenderlySimulationUniversalRouterLatencies and TenderlySimulationUniversalRouterResponseStatus
+        // so that they don't provide the existing tenderly dashboard as well as simulation alerts
+        // In the meanwhile, we also add tenderly node metrics to distinguish from the tenderly api metrics
+        // Once we migrate to node endpoint 100%, original metrics TenderlySimulationUniversalRouterLatencies and TenderlySimulationUniversalRouterResponseStatus
+        // will work as is
         metric.putMetric(
           'TenderlySimulationUniversalRouterLatencies',
           Date.now() - before,

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -414,7 +414,17 @@ export class TenderlySimulator extends Simulator {
           MetricLoggerUnit.Milliseconds
         );
         metric.putMetric(
+          'TenderlyNodeSimulationUniversalRouterLatencies',
+          Date.now() - before,
+          MetricLoggerUnit.Milliseconds
+        );
+        metric.putMetric(
           `TenderlySimulationUniversalRouterResponseStatus${httpStatus}`,
+          1,
+          MetricLoggerUnit.Count
+        );
+        metric.putMetric(
+          `TenderlyNodeSimulationUniversalRouterResponseStatus${httpStatus}`,
           1,
           MetricLoggerUnit.Count
         );
@@ -457,7 +467,7 @@ export class TenderlySimulator extends Simulator {
             swapGas: (resp.result[2] as GasBody).gas,
             swapWithMultiplier: estimatedGasUsed.toString(),
           },
-          'Successfully Simulated Approvals + Swap via Tenderly for Universal Router. Gas used.'
+          'Successfully Simulated Approvals + Swap via Tenderly node endpoint for Universal Router. Gas used.'
         );
       } else {
         const { data: resp, status: httpStatus } =
@@ -476,7 +486,17 @@ export class TenderlySimulator extends Simulator {
           MetricLoggerUnit.Milliseconds
         );
         metric.putMetric(
+          'TenderlyApiSimulationUniversalRouterLatencies',
+          Date.now() - before,
+          MetricLoggerUnit.Milliseconds
+        );
+        metric.putMetric(
           `TenderlySimulationUniversalRouterResponseStatus${httpStatus}`,
+          1,
+          MetricLoggerUnit.Count
+        );
+        metric.putMetric(
+          `TenderlyApiSimulationUniversalRouterResponseStatus${httpStatus}`,
           1,
           MetricLoggerUnit.Count
         );
@@ -512,7 +532,7 @@ export class TenderlySimulator extends Simulator {
             swapGas: resp.simulation_results[2].transaction.gas,
             swapWithMultiplier: estimatedGasUsed.toString(),
           },
-          'Successfully Simulated Approvals + Swap via Tenderly for Universal Router. Gas used.'
+          'Successfully Simulated Approvals + Swap via Tenderly Api endpoint for Universal Router. Gas used.'
         );
 
         log.info(
@@ -521,7 +541,7 @@ export class TenderlySimulator extends Simulator {
             swapSimulation: resp.simulation_results[2].simulation,
             swapTransaction: resp.simulation_results[2].transaction,
           },
-          'Successful Tenderly Swap Simulation for Universal Router'
+          'Successful Tenderly Api endpoint Swap Simulation for Universal Router'
         );
       }
     } else if (swapOptions.type == SwapType.SWAP_ROUTER_02) {

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -704,6 +704,10 @@ describe('alpha router integration', () => {
         // so we can use the gas limits returned from Tenderly for more accurate L2 gas estimate assertions.
         [ChainId.ARBITRUM_ONE]: 1
       },
+      // we will start using the new tenderly node endpoint in SOR integ-test suite at 100%
+      3000,
+      100,
+      [ChainId.MAINNET]
     );
 
     const simulator = new FallbackTenderlySimulator(


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
We are only shadow sampling tenderly node endpoint. Now that tenderly fixed the final gas estimate bug, we consistently see 100% gas estimate matches:

![Screenshot 2024-07-30 at 7.44.23 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/b64a0beb-f83c-47c3-b696-352373b2d7d3.png)

- **What is the new behavior (if this is a feature change)?**
We are implementing the tenderly node live switch feature.

- **Other information**:
In integ-test, we set the migration percent to 100%, so that all the simulation tests always use tenderly node endpoint for testing coverages.
