### PR TITLE
docs: correct comment about quote computation

### DIFF
--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -169,7 +169,7 @@ export class V2Quoter extends BaseQuoter<V2CandidatePools, V2Route> {
       return { routesWithValidQuotes: [], candidatePools };
     }
 
-    // For all our routes, and all the fractional amounts, fetch quotes on-chain.
+    // For all our routes and fractional amounts, compute quotes off-chain using pool balances.
     const quoteFn =
       tradeType == TradeType.EXACT_INPUT
         ? this.v2QuoteProvider.getQuotesManyExactIn.bind(this.v2QuoteProvider)

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -147,7 +147,7 @@ export class V3Quoter extends BaseQuoter<V3CandidatePools, V3Route> {
       return { routesWithValidQuotes: [], candidatePools };
     }
 
-    // For all our routes, and all the fractional amounts, fetch quotes on-chain.
+    // For all our routes and fractional amounts, fetch quotes on-chain.
     const quoteFn =
       tradeType == TradeType.EXACT_INPUT
         ? this.onChainQuoteProvider.getQuotesManyExactIn.bind(


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs update

- **What is the current behavior?** (You can also link to an open issue here)
Misplaced comment in the V2Quoter class. The comment says that the quote is computed on-chain yet the V2QuoteProvider that is used for quoting is doing off-chain computation using the uniswap v2 sdk.

- **What is the new behavior (if this is a feature change)?**
Updated comment

- **Other information**: