### PR TITLE
chore(infra): adds write permissions to the gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on:
       group: npm-deploy
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Load Secrets


### PR DESCRIPTION
Fixes the deploy script to have write ability inside github to make a github release 