### PR TITLE
feat: implement v4-quoter with computeV4Routes and stub getQuotes (invoke onchain quoter provider class)

### DIFF
--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -88,6 +88,10 @@ export type CandidatePoolsBySelectionCriteria = {
   protocol: Protocol;
   selections: CandidatePoolsSelections;
 };
+export type SupportedCandidatePools =
+  | V2CandidatePools
+  | V3CandidatePools
+  | V4CandidatePools;
 
 /// Utility type for allowing us to use `keyof CandidatePoolsSelections` to map
 export type CandidatePoolsSelections = {

--- a/src/routers/alpha-router/quoters/base-quoter.ts
+++ b/src/routers/alpha-router/quoters/base-quoter.ts
@@ -2,7 +2,8 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { Protocol } from '@uniswap/router-sdk';
 import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
 import { Pair } from '@uniswap/v2-sdk';
-import { Pool } from '@uniswap/v3-sdk';
+import { Pool as V3Pool } from '@uniswap/v3-sdk';
+import { Pool as V4Pool } from '@uniswap/v4-sdk';
 import _ from 'lodash';
 
 import {
@@ -18,12 +19,13 @@ import {
   MetricLoggerUnit,
   poolToString,
 } from '../../../util';
-import { MixedRoute, V2Route, V3Route } from '../../router';
+import { SupportedRoutes } from '../../router';
 import { AlphaRouterConfig } from '../alpha-router';
 import { RouteWithValidQuote } from '../entities/route-with-valid-quote';
 import {
   CandidatePoolsBySelectionCriteria,
   CrossLiquidityCandidatePools,
+  SupportedCandidatePools,
   V2CandidatePools,
   V3CandidatePools,
 } from '../functions/get-candidate-pools';
@@ -41,10 +43,10 @@ import { GetQuotesResult, GetRoutesResult } from './model/results';
  */
 export abstract class BaseQuoter<
   CandidatePools extends
-    | V2CandidatePools
-    | V3CandidatePools
+    | SupportedCandidatePools
     | [V3CandidatePools, V2CandidatePools, CrossLiquidityCandidatePools],
-  Route extends V2Route | V3Route | MixedRoute
+  Route extends SupportedRoutes,
+  TCurrency extends Currency
 > {
   protected tokenProvider: ITokenProvider;
   protected chainId: ChainId;
@@ -79,8 +81,8 @@ export abstract class BaseQuoter<
    * @returns Promise<GetRoutesResult<Route>>
    */
   protected abstract getRoutes(
-    tokenIn: Token,
-    tokenOut: Token,
+    tokenIn: TCurrency,
+    tokenOut: TCurrency,
     candidatePools: CandidatePools,
     tradeType: TradeType,
     routingConfig: AlphaRouterConfig
@@ -127,8 +129,8 @@ export abstract class BaseQuoter<
    * @param gasPriceWei instead of passing gasModel, gasPriceWei is used to generate a gasModel
    */
   public getRoutesThenQuotes(
-    tokenIn: Token,
-    tokenOut: Token,
+    tokenIn: TCurrency,
+    tokenOut: TCurrency,
     amount: CurrencyAmount,
     amounts: CurrencyAmount[],
     percents: number[],
@@ -184,7 +186,7 @@ export abstract class BaseQuoter<
     });
   }
 
-  protected async applyTokenValidatorToPools<T extends Pool | Pair>(
+  protected async applyTokenValidatorToPools<T extends V4Pool | V3Pool | Pair>(
     pools: T[],
     isInvalidFn: (
       token: Currency,
@@ -200,14 +202,16 @@ export abstract class BaseQuoter<
     const tokens = _.flatMap(pools, (pool) => [pool.token0, pool.token1]);
 
     const tokenValidationResults =
-      await this.tokenValidatorProvider.validateTokens(tokens);
+      await this.tokenValidatorProvider.validateTokens(
+        tokens.map((token) => token.wrapped)
+      );
 
     const poolsFiltered = _.filter(pools, (pool: T) => {
       const token0Validation = tokenValidationResults.getValidationByToken(
-        pool.token0
+        pool.token0.wrapped
       );
       const token1Validation = tokenValidationResults.getValidationByToken(
-        pool.token1
+        pool.token1.wrapped
       );
 
       const token0Invalid = isInvalidFn(pool.token0, token0Validation);

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -38,7 +38,8 @@ import { GetQuotesResult, GetRoutesResult } from './model';
 
 export class MixedQuoter extends BaseQuoter<
   [V3CandidatePools, V2CandidatePools, CrossLiquidityCandidatePools],
-  MixedRoute
+  MixedRoute,
+  Token
 > {
   protected v3SubgraphProvider: IV3SubgraphProvider;
   protected v3PoolProvider: IV3PoolProvider;

--- a/src/routers/alpha-router/quoters/model/results/get-routes-result.ts
+++ b/src/routers/alpha-router/quoters/model/results/get-routes-result.ts
@@ -1,7 +1,7 @@
-import { MixedRoute, V2Route, V3Route } from '../../../../router';
+import { SupportedRoutes } from '../../../../router';
 import { CandidatePoolsBySelectionCriteria } from '../../../functions/get-candidate-pools';
 
-export interface GetRoutesResult<Route extends V2Route | V3Route | MixedRoute> {
+export interface GetRoutesResult<Route extends SupportedRoutes> {
   routes: Route[];
   candidatePools: CandidatePoolsBySelectionCriteria;
 }

--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -38,7 +38,7 @@ import { BaseQuoter } from './base-quoter';
 import { GetQuotesResult } from './model/results/get-quotes-result';
 import { GetRoutesResult } from './model/results/get-routes-result';
 
-export class V2Quoter extends BaseQuoter<V2CandidatePools, V2Route> {
+export class V2Quoter extends BaseQuoter<V2CandidatePools, V2Route, Token> {
   protected v2SubgraphProvider: IV2SubgraphProvider;
   protected v2PoolProvider: IV2PoolProvider;
   protected v2QuoteProvider: IV2QuoteProvider;

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -32,7 +32,7 @@ import { BaseQuoter } from './base-quoter';
 import { GetQuotesResult } from './model/results/get-quotes-result';
 import { GetRoutesResult } from './model/results/get-routes-result';
 
-export class V3Quoter extends BaseQuoter<V3CandidatePools, V3Route> {
+export class V3Quoter extends BaseQuoter<V3CandidatePools, V3Route, Token> {
   protected v3SubgraphProvider: IV3SubgraphProvider;
   protected v3PoolProvider: IV3PoolProvider;
   protected onChainQuoteProvider: IOnChainQuoteProvider;

--- a/src/routers/alpha-router/quoters/v4-quoter.ts
+++ b/src/routers/alpha-router/quoters/v4-quoter.ts
@@ -1,0 +1,131 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { Protocol } from '@uniswap/router-sdk';
+import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
+import {
+  IOnChainQuoteProvider,
+  ITokenListProvider,
+  ITokenProvider,
+  ITokenValidatorProvider,
+  IV4PoolProvider,
+  IV4SubgraphProvider,
+  TokenValidationResult,
+} from '../../../providers';
+import { CurrencyAmount, metric, MetricLoggerUnit } from '../../../util';
+import { V4Route } from '../../router';
+import { AlphaRouterConfig } from '../alpha-router';
+import { RouteWithValidQuote } from '../entities';
+import { computeAllV4Routes } from '../functions/compute-all-routes';
+import {
+  CandidatePoolsBySelectionCriteria,
+  V4CandidatePools,
+} from '../functions/get-candidate-pools';
+import { IGasModel } from '../gas-models';
+import { BaseQuoter } from './base-quoter';
+import { GetQuotesResult, GetRoutesResult } from './model';
+
+export class V4Quoter extends BaseQuoter<V4CandidatePools, V4Route, Currency> {
+  protected v4SubgraphProvider: IV4SubgraphProvider;
+  protected v4PoolProvider: IV4PoolProvider;
+  protected onChainQuoteProvider: IOnChainQuoteProvider;
+
+  constructor(
+    v4SubgraphProvider: IV4SubgraphProvider,
+    v4PoolProvider: IV4PoolProvider,
+    onChainQuoteProvider: IOnChainQuoteProvider,
+    tokenProvider: ITokenProvider,
+    chainId: ChainId,
+    blockedTokenListProvider?: ITokenListProvider,
+    tokenValidatorProvider?: ITokenValidatorProvider
+  ) {
+    super(
+      tokenProvider,
+      chainId,
+      Protocol.V4,
+      blockedTokenListProvider,
+      tokenValidatorProvider
+    );
+    this.v4SubgraphProvider = v4SubgraphProvider;
+    this.v4PoolProvider = v4PoolProvider;
+    this.onChainQuoteProvider = onChainQuoteProvider;
+  }
+
+  protected async getRoutes(
+    tokenIn: Currency,
+    tokenOut: Currency,
+    v4CandidatePools: V4CandidatePools,
+    _tradeType: TradeType,
+    routingConfig: AlphaRouterConfig
+  ): Promise<GetRoutesResult<V4Route>> {
+    const beforeGetRoutes = Date.now();
+    // Fetch all the pools that we will consider routing via. There are thousands
+    // of pools, so we filter them to a set of candidate pools that we expect will
+    // result in good prices.
+    const { poolAccessor, candidatePools } = v4CandidatePools;
+    const poolsRaw = poolAccessor.getAllPools();
+
+    // Drop any pools that contain fee on transfer tokens (not supported by v3) or have issues with being transferred.
+    const pools = await this.applyTokenValidatorToPools(
+      poolsRaw,
+      (
+        token: Currency,
+        tokenValidation: TokenValidationResult | undefined
+      ): boolean => {
+        // If there is no available validation result we assume the token is fine.
+        if (!tokenValidation) {
+          return false;
+        }
+
+        // Only filters out *intermediate* pools that involve tokens that we detect
+        // cant be transferred. This prevents us trying to route through tokens that may
+        // not be transferrable, but allows users to still swap those tokens if they
+        // specify.
+        //
+        if (
+          tokenValidation == TokenValidationResult.STF &&
+          (token.equals(tokenIn) || token.equals(tokenOut))
+        ) {
+          return false;
+        }
+
+        return (
+          tokenValidation == TokenValidationResult.FOT ||
+          tokenValidation == TokenValidationResult.STF
+        );
+      }
+    );
+
+    // Given all our candidate pools, compute all the possible ways to route from tokenIn to tokenOut.
+    const { maxSwapsPerPath } = routingConfig;
+    const routes = computeAllV4Routes(
+      tokenIn,
+      tokenOut,
+      pools,
+      maxSwapsPerPath
+    );
+
+    metric.putMetric(
+      'V4GetRoutesLoad',
+      Date.now() - beforeGetRoutes,
+      MetricLoggerUnit.Milliseconds
+    );
+
+    return {
+      routes,
+      candidatePools,
+    };
+  }
+
+  getQuotes(
+    _routes: V4Route[],
+    _amounts: CurrencyAmount[],
+    _percents: number[],
+    _quoteToken: Token,
+    _tradeType: TradeType,
+    _routingConfig: AlphaRouterConfig,
+    _candidatePools: CandidatePoolsBySelectionCriteria | undefined,
+    _gasModel: IGasModel<RouteWithValidQuote> | undefined,
+    _gasPriceWei: BigNumber | undefined
+  ): Promise<GetQuotesResult> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/routers/router.ts
+++ b/src/routers/router.ts
@@ -39,7 +39,7 @@ export class V2Route extends V2RouteRaw<Token, Token> {
 export class MixedRoute extends MixedRouteSDK<Token, Token> {
   protocol: Protocol.MIXED = Protocol.MIXED;
 }
-export type SupportedRoutes = V4Route | V3Route | V2Route | MixedRoute
+export type SupportedRoutes = V4Route | V3Route | V2Route | MixedRoute;
 
 export type SwapRoute = {
   /**

--- a/test/unit/routers/alpha-router/functions/compute-all-routes.test.ts
+++ b/test/unit/routers/alpha-router/functions/compute-all-routes.test.ts
@@ -1,5 +1,6 @@
 import { Pair } from '@uniswap/v2-sdk';
-import { encodeSqrtRatioX96, FeeAmount, Pool } from '@uniswap/v3-sdk';
+import { encodeSqrtRatioX96, FeeAmount, Pool as V3Pool } from '@uniswap/v3-sdk';
+import { Pool as V4Pool } from '@uniswap/v4-sdk';
 import {
   CurrencyAmount,
   DAI_MAINNET as DAI,
@@ -11,21 +12,82 @@ import {
 import {
   computeAllMixedRoutes,
   computeAllV2Routes,
-  computeAllV3Routes
+  computeAllV3Routes, computeAllV4Routes
 } from '../../../../../src/routers/alpha-router/functions/compute-all-routes';
 import {
   DAI_USDT,
-  DAI_USDT_LOW,
+  DAI_USDT_LOW, DAI_USDT_V4_LOW,
   USDC_DAI,
   USDC_DAI_LOW,
-  USDC_DAI_MEDIUM,
+  USDC_DAI_MEDIUM, USDC_DAI_V4_LOW, USDC_DAI_V4_MEDIUM,
   USDC_USDT,
   USDC_WETH,
-  USDC_WETH_LOW,
+  USDC_WETH_LOW, USDC_WETH_V4_LOW,
   WBTC_WETH,
-  WETH9_USDT_LOW,
-  WETH_USDT,
+  WETH9_USDT_LOW, WETH9_USDT_V4_LOW,
+  WETH_USDT
 } from '../../../../test-util/mock-data';
+import { ADDRESS_ZERO } from '@uniswap/router-sdk';
+
+describe('compute all v4 routes', () => {
+  test('succeeds to compute all routes', async () => {
+    const pools = [
+      USDC_DAI_V4_LOW,
+      USDC_DAI_V4_MEDIUM,
+      USDC_WETH_V4_LOW,
+      WETH9_USDT_V4_LOW,
+      DAI_USDT_V4_LOW
+    ];
+    const routes = computeAllV4Routes(USDC, DAI, pools, 3);
+
+    expect(routes).toHaveLength(3);
+  })
+
+  test('succeeds to compute all routes with 1 hop', async () => {
+    const pools = [
+      USDC_DAI_V4_LOW,
+      USDC_DAI_V4_MEDIUM,
+      USDC_WETH_V4_LOW,
+      WETH9_USDT_V4_LOW,
+      DAI_USDT_V4_LOW,
+    ];
+    const routes = computeAllV4Routes(USDC, DAI, pools, 1);
+
+    expect(routes).toHaveLength(2);
+  });
+
+  test('succeeds to compute all routes with 4 hops, ignoring arbitrage opportunities', async () => {
+    const pools = [
+      USDC_DAI_V4_LOW,
+      USDC_DAI_V4_MEDIUM,
+      USDC_WETH_V4_LOW,
+      WETH9_USDT_V4_LOW,
+      DAI_USDT_V4_LOW,
+    ];
+    const routes = computeAllV4Routes(USDC, WRAPPED_NATIVE_CURRENCY[1]!, pools, 4);
+
+    routes.forEach((route) => {
+      expect(route.pools).not.toEqual([USDC_DAI_V4_MEDIUM, USDC_DAI_V4_LOW, USDC_WETH_V4_LOW]);
+    });
+    expect(routes).toHaveLength(3);
+  });
+
+  test('succeeds when no routes', async () => {
+    const pools = [
+      USDC_DAI_V4_LOW,
+      USDC_DAI_V4_MEDIUM,
+      USDC_WETH_V4_LOW,
+      WETH9_USDT_V4_LOW,
+      DAI_USDT_V4_LOW,
+      new V4Pool(USDT, WBTC, FeeAmount.LOW, 10, ADDRESS_ZERO, encodeSqrtRatioX96(1, 1), 500, 0),
+    ];
+
+    // No way to get from USDC to WBTC in 2 hops
+    const routes = computeAllV4Routes(USDC, WBTC, pools, 2);
+
+    expect(routes).toHaveLength(0);
+  });
+})
 
 describe('compute all v3 routes', () => {
   test('succeeds to compute all routes', async () => {
@@ -77,7 +139,7 @@ describe('compute all v3 routes', () => {
       USDC_WETH_LOW,
       WETH9_USDT_LOW,
       DAI_USDT_LOW,
-      new Pool(USDT, WBTC, FeeAmount.LOW, encodeSqrtRatioX96(1, 1), 500, 0),
+      new V3Pool(USDT, WBTC, FeeAmount.LOW, encodeSqrtRatioX96(1, 1), 500, 0),
     ];
 
     // No way to get from USDC to WBTC in 2 hops


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
After getting the top v4 candidate pools by TVL, we need to compute the v4-only routes.

- **What is the new behavior (if this is a feature change)?**
We are implementing computeV4Routes as part of v4-quoter, that will get invoked by alpha router.

- **Other information**:
It's protected under explicitly protocol version specification.