### PR TITLE
fix: for token pair only quote against v2 quoter

### DIFF
--- a/test/test-util/mock-data.ts
+++ b/test/test-util/mock-data.ts
@@ -305,6 +305,21 @@ export const WBTC_WETH = new Pair(
   CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[1]!, 10000000000)
 );
 
+export const BULLET = new Token(
+  ChainId.MAINNET,
+  '0x8ef32a03784c8Fd63bBf027251b9620865bD54B6',
+  8,
+  'BULLET',
+  'Bullet Game Betting Token',
+  false,
+  BigNumber.from(500),
+  BigNumber.from(500)
+);
+export const BULLET_USDC = new Pair(
+  CurrencyAmount.fromRawAmount(BULLET, 10000000000),
+  CurrencyAmount.fromRawAmount(USDC, 10000000000)
+);
+
 export const poolToV4SubgraphPool = (
   pool: V4Pool,
   idx: number | string
@@ -514,16 +529,6 @@ export const BULLET_WITHOUT_TAX = new Token(
   'BULLET',
   'Bullet Game Betting Token',
   false
-);
-export const BULLET = new Token(
-  ChainId.MAINNET,
-  '0x8ef32a03784c8Fd63bBf027251b9620865bD54B6',
-  8,
-  'BULLET',
-  'Bullet Game Betting Token',
-  false,
-  BigNumber.from(500),
-  BigNumber.from(500)
 );
 export const STETH_WITHOUT_TAX = new Token(
   ChainId.MAINNET,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We will attempt to quote a FOT pair against v3 quoter or mixed quoter.

- **What is the new behavior (if this is a feature change)?**
FOT doesn't work in v3 pool. This means quoting against v3 quoter or mixed quoter (which goes through at least one v3 pool of the mixed route) doesn't work. If we see the tokenIn is sell FOT tax or tokenOut is buy FOT tax, then we only go through v2 quoter.

- **Other information**:
Testing wise, I'm relying on the existing e2e tests in both SOR and routing-api. On SOR level, it never goes through cached routes, so it will test against `swapRouteFromChain`. On routing-api level, we constantly run the code pipeline, so that the same FOT e2e test will likely go through the cached routes, i.e. `swapRouteFromCache`.