### PR TITLE
feat: implement best swap route with v4 routes

### DIFF
--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -977,3 +977,19 @@ export const USDC_ON = (chainId: ChainId): Token => {
 export const WNATIVE_ON = (chainId: ChainId): Token => {
   return WRAPPED_NATIVE_CURRENCY[chainId];
 };
+
+export const V4_SEPOLIA_TEST_OP = new Token(
+  ChainId.SEPOLIA,
+  '0xc268035619873d85461525f5fdb792dd95982161',
+  18,
+  'OP',
+  'Optimism'
+);
+
+export const V4_SEPOLIA_TEST_USDC = new Token(
+  ChainId.SEPOLIA,
+  '0xbe2a7f5acecdc293bf34445a0021f229dd2edd49',
+  6,
+  'USDC',
+  'USD'
+);

--- a/src/providers/v3/subgraph-provider.ts
+++ b/src/providers/v3/subgraph-provider.ts
@@ -100,4 +100,49 @@ export class V3SubgraphProvider
       subgraphUrlOverride ?? SUBGRAPH_URL_BY_CHAIN[chainId]
     );
   }
+
+  protected override subgraphQuery(blockNumber?: number): string {
+    return `
+    query getPools($pageSize: Int!, $id: String) {
+      pools(
+        first: $pageSize
+        ${blockNumber ? `block: { number: ${blockNumber} }` : ``}
+          where: { id_gt: $id }
+        ) {
+          id
+          token0 {
+            symbol
+            id
+          }
+          token1 {
+            symbol
+            id
+          }
+          feeTier
+          liquidity
+          totalValueLockedUSD
+          totalValueLockedETH
+          totalValueLockedUSDUntracked
+        }
+      }
+   `;
+  }
+
+  protected override mapSubgraphPool(
+    rawPool: V3RawSubgraphPool
+  ): V3SubgraphPool {
+    return {
+      id: rawPool.id,
+      feeTier: rawPool.feeTier,
+      liquidity: rawPool.liquidity,
+      token0: {
+        id: rawPool.token0.id,
+      },
+      token1: {
+        id: rawPool.token1.id,
+      },
+      tvlETH: parseFloat(rawPool.totalValueLockedETH),
+      tvlUSD: parseFloat(rawPool.totalValueLockedUSD),
+    };
+  }
 }

--- a/src/providers/v4/subgraph-provider.ts
+++ b/src/providers/v4/subgraph-provider.ts
@@ -81,4 +81,53 @@ export class V4SubgraphProvider
       subgraphUrlOverride ?? SUBGRAPH_URL_BY_CHAIN[chainId]
     );
   }
+
+  protected override subgraphQuery(blockNumber?: number): string {
+    return `
+    query getPools($pageSize: Int!, $id: String) {
+      pools(
+        first: $pageSize
+        ${blockNumber ? `block: { number: ${blockNumber} }` : ``}
+          where: { id_gt: $id }
+        ) {
+          id
+          token0 {
+            symbol
+            id
+          }
+          token1 {
+            symbol
+            id
+          }
+          feeTier
+          tickSpacing
+          hooks
+          liquidity
+          totalValueLockedUSD
+          totalValueLockedETH
+          totalValueLockedUSDUntracked
+        }
+      }
+   `;
+  }
+
+  protected override mapSubgraphPool(
+    rawPool: V4RawSubgraphPool
+  ): V4SubgraphPool {
+    return {
+      id: rawPool.id,
+      feeTier: rawPool.feeTier,
+      tickSpacing: rawPool.tickSpacing,
+      hooks: rawPool.hooks,
+      liquidity: rawPool.liquidity,
+      token0: {
+        id: rawPool.token0.id,
+      },
+      token1: {
+        id: rawPool.token1.id,
+      },
+      tvlETH: parseFloat(rawPool.totalValueLockedETH),
+      tvlUSD: parseFloat(rawPool.totalValueLockedUSD),
+    };
+  }
 }

--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -7,7 +7,7 @@ import FixedReverseHeap from 'mnemonist/fixed-reverse-heap';
 import Queue from 'mnemonist/queue';
 
 import { IPortionProvider } from '../../../providers/portion-provider';
-import { HAS_L1_FEE, V2_SUPPORTED } from '../../../util';
+import { HAS_L1_FEE, V2_SUPPORTED, V4_SUPPORTED } from '../../../util';
 import { CurrencyAmount } from '../../../util/amounts';
 import { log } from '../../../util/log';
 import { metric, MetricLoggerUnit } from '../../../util/metric';
@@ -21,6 +21,7 @@ import {
   RouteWithValidQuote,
   V2RouteWithValidQuote,
   V3RouteWithValidQuote,
+  V4RouteWithValidQuote,
 } from './../entities/route-with-valid-quote';
 
 export type BestSwapRoute = {
@@ -43,6 +44,7 @@ export async function getBestSwapRoute(
   portionProvider: IPortionProvider,
   v2GasModel?: IGasModel<V2RouteWithValidQuote>,
   v3GasModel?: IGasModel<V3RouteWithValidQuote>,
+  v4GasModel?: IGasModel<V4RouteWithValidQuote>,
   swapConfig?: SwapOptions,
   providerConfig?: ProviderConfig
 ): Promise<BestSwapRoute | null> {
@@ -93,6 +95,7 @@ export async function getBestSwapRoute(
     portionProvider,
     v2GasModel,
     v3GasModel,
+    v4GasModel,
     swapConfig,
     providerConfig
   );
@@ -159,6 +162,7 @@ export async function getBestSwapRouteBy(
   portionProvider: IPortionProvider,
   v2GasModel?: IGasModel<V2RouteWithValidQuote>,
   v3GasModel?: IGasModel<V3RouteWithValidQuote>,
+  v4GasModel?: IGasModel<V4RouteWithValidQuote>,
   swapConfig?: SwapOptions,
   providerConfig?: ProviderConfig
 ): Promise<BestSwapRoute | undefined> {
@@ -362,9 +366,14 @@ export async function getBestSwapRouteBy(
           );
 
           if (HAS_L1_FEE.includes(chainId)) {
-            if (v2GasModel == undefined && v3GasModel == undefined) {
+            if (
+              v2GasModel == undefined &&
+              v3GasModel == undefined &&
+              v4GasModel == undefined
+            ) {
               throw new Error("Can't compute L1 gas fees.");
             } else {
+              // ROUTE-249: consoliate L1 + L2 gas fee adjustment within best-swap-route
               const v2Routes = curRoutesNew.filter(
                 (routes) => routes.protocol === Protocol.V2
               );
@@ -388,6 +397,19 @@ export async function getBestSwapRouteBy(
                   );
                   gasCostL1QuoteToken = gasCostL1QuoteToken.add(
                     v3GasCostL1.gasCostL1QuoteToken
+                  );
+                }
+              }
+              const v4Routes = curRoutesNew.filter(
+                (routes) => routes.protocol === Protocol.V4
+              );
+              if (v4Routes.length > 0 && V4_SUPPORTED.includes(chainId)) {
+                if (v4GasModel) {
+                  const v4GasCostL1 = await v4GasModel.calculateL1GasFees!(
+                    v4Routes as V4RouteWithValidQuote[]
+                  );
+                  gasCostL1QuoteToken = gasCostL1QuoteToken.add(
+                    v4GasCostL1.gasCostL1QuoteToken
                   );
                 }
               }
@@ -477,7 +499,8 @@ export async function getBestSwapRouteBy(
   };
   // If swapping on an L2 that includes a L1 security fee, calculate the fee and include it in the gas adjusted quotes
   if (HAS_L1_FEE.includes(chainId)) {
-    if (v2GasModel == undefined && v3GasModel == undefined) {
+    // ROUTE-249: consoliate L1 + L2 gas fee adjustment within best-swap-route
+    if (v2GasModel == undefined && v3GasModel == undefined && v4GasModel == undefined) {
       throw new Error("Can't compute L1 gas fees.");
     } else {
       // Before v2 deploy everywhere, a quote on L2 can only go through v3 protocol,
@@ -574,6 +597,52 @@ export async function getBestSwapRouteBy(
           gasCostsL1ToL2.gasCostL1QuoteToken =
             gasCostsL1ToL2.gasCostL1QuoteToken.add(
               v3GasCostL1.gasCostL1QuoteToken
+            );
+        }
+      }
+      const v4Routes = bestSwap.filter(
+        (routes) => routes.protocol === Protocol.V4
+      );
+      if (v4Routes.length > 0 && V4_SUPPORTED.includes(chainId)) {
+        if (v4GasModel) {
+          const v4GasCostL1 = await v4GasModel.calculateL1GasFees!(
+            v4Routes as V4RouteWithValidQuote[]
+          );
+          gasCostsL1ToL2.gasUsedL1 = gasCostsL1ToL2.gasUsedL1.add(
+            v4GasCostL1.gasUsedL1
+          );
+          gasCostsL1ToL2.gasUsedL1OnL2 = gasCostsL1ToL2.gasUsedL1OnL2.add(
+            v4GasCostL1.gasUsedL1OnL2
+          );
+          if (
+            gasCostsL1ToL2.gasCostL1USD.currency.equals(
+              v4GasCostL1.gasCostL1USD.currency
+            )
+          ) {
+            gasCostsL1ToL2.gasCostL1USD = gasCostsL1ToL2.gasCostL1USD.add(
+              v4GasCostL1.gasCostL1USD
+            );
+          } else {
+            // This is to handle the case where gasCostsL1ToL2.gasCostL1USD and v4GasCostL1.gasCostL1USD have different currencies.
+            //
+            // gasCostsL1ToL2.gasCostL1USD was initially hardcoded to CurrencyAmount.fromRawAmount(usdGasTokensByChain[chainId]![0]!, 0)
+            // (https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/functions/best-swap-route.ts#L438)
+            // , where usdGasTokensByChain is coded in the descending order of decimals per chain,
+            // e.g. Arbitrum_one DAI (18 decimals), USDC bridged (6 decimals), USDC native (6 decimals)
+            // so gasCostsL1ToL2.gasCostL1USD will have DAI as currency.
+            //
+            // For v4GasCostL1.gasCostL1USD, it's calculated within getHighestLiquidityV3USDPool among usdGasTokensByChain[chainId]!,
+            // (https://github.com/Uniswap/smart-order-router/blob/1c93e133c46af545f8a3d8af7fca3f1f2dcf597d/src/util/gas-factory-helpers.ts#L110)
+            // , so the code will actually see which USD pool has the highest liquidity, if any.
+            // e.g. Arbitrum_one on v3 has highest liquidity on USDC native
+            // so v4GasCostL1.gasCostL1USD will have USDC native as currency.
+            //
+            // We will re-assign gasCostsL1ToL2.gasCostL1USD to v3GasCostL1.gasCostL1USD in this case.
+            gasCostsL1ToL2.gasCostL1USD = v4GasCostL1.gasCostL1USD;
+          }
+          gasCostsL1ToL2.gasCostL1QuoteToken =
+            gasCostsL1ToL2.gasCostL1QuoteToken.add(
+              v4GasCostL1.gasCostL1QuoteToken
             );
         }
       }

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -756,13 +756,13 @@ export async function getV4CandidatePools({
 
   const tokenPairsRaw = _.map<
     V4SubgraphPool,
-    [Token, Token, FeeAmount, number, string] | undefined
+    [Token, Token, number, number, string] | undefined
   >(subgraphPools, (subgraphPool) => {
     const tokenA = tokenAccessor.getTokenByAddress(subgraphPool.token0.id);
     const tokenB = tokenAccessor.getTokenByAddress(subgraphPool.token1.id);
     let fee: FeeAmount;
     try {
-      fee = parseFeeAmount(subgraphPool.feeTier);
+      fee = Number(subgraphPool.feeTier);
     } catch (err) {
       log.info(
         { subgraphPool },

--- a/src/routers/alpha-router/gas-models/gas-costs.ts
+++ b/src/routers/alpha-router/gas-models/gas-costs.ts
@@ -1,9 +1,9 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { ChainId, Currency } from '@uniswap/sdk-core';
 
+import { Protocol } from '@uniswap/router-sdk';
 import { AAVE_MAINNET, LIDO_MAINNET } from '../../../providers';
 import { V3Route, V4Route } from '../../router';
-import { Protocol } from '@uniswap/router-sdk';
 
 // Cost for crossing an uninitialized tick.
 export const COST_PER_UNINIT_TICK = BigNumber.from(0);

--- a/src/routers/alpha-router/gas-models/gas-model.ts
+++ b/src/routers/alpha-router/gas-models/gas-model.ts
@@ -23,6 +23,7 @@ import {
   DAI_SEPOLIA,
   DAI_ZKSYNC,
   USDB_BLAST,
+  USDCE_ZKSYNC,
   USDC_ARBITRUM,
   USDC_ARBITRUM_GOERLI,
   USDC_ARBITRUM_SEPOLIA,
@@ -49,7 +50,6 @@ import {
   USDC_WORMHOLE_CELO,
   USDC_ZKSYNC,
   USDC_ZORA,
-  USDCE_ZKSYNC,
   USDT_ARBITRUM,
   USDT_BNB,
   USDT_GOERLI,
@@ -71,7 +71,7 @@ import {
   RouteWithValidQuote,
   V2RouteWithValidQuote,
   V3RouteWithValidQuote,
-  V4RouteWithValidQuote
+  V4RouteWithValidQuote,
 } from '../entities/route-with-valid-quote';
 
 // When adding new usd gas tokens, ensure the tokens are ordered

--- a/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
@@ -12,6 +12,12 @@ import { CurrencyAmount } from '../../../../util/amounts';
 import { getV2NativePool } from '../../../../util/gas-factory-helpers';
 import { MixedRouteWithValidQuote } from '../../entities/route-with-valid-quote';
 import {
+  BASE_SWAP_COST,
+  COST_PER_HOP,
+  COST_PER_INIT_TICK,
+  COST_PER_UNINIT_TICK,
+} from '../gas-costs';
+import {
   BuildOnChainGasModelFactoryType,
   GasModelProviderConfig,
   getQuoteThroughNativePool,
@@ -22,12 +28,6 @@ import {
   BASE_SWAP_COST as BASE_SWAP_COST_V2,
   COST_PER_EXTRA_HOP as COST_PER_EXTRA_HOP_V2,
 } from '../v2/v2-heuristic-gas-model';
-import {
-  BASE_SWAP_COST,
-  COST_PER_HOP,
-  COST_PER_INIT_TICK,
-  COST_PER_UNINIT_TICK,
-} from '../gas-costs';
 
 /**
  * Computes a gas estimate for a mixed route swap using heuristics.

--- a/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
@@ -6,13 +6,6 @@ import { CurrencyAmount, log, WRAPPED_NATIVE_CURRENCY } from '../../../util';
 import { calculateL1GasFeesHelper } from '../../../util/gas-factory-helpers';
 import { V3RouteWithValidQuote, V4RouteWithValidQuote } from '../entities';
 import {
-  BuildOnChainGasModelFactoryType,
-  GasModelProviderConfig,
-  getQuoteThroughNativePool,
-  IGasModel,
-  IOnChainGasModelFactory,
-} from './gas-model';
-import {
   BASE_SWAP_COST,
   COST_PER_HOP,
   COST_PER_INIT_TICK,
@@ -20,6 +13,13 @@ import {
   SINGLE_HOP_OVERHEAD,
   TOKEN_OVERHEAD,
 } from './gas-costs';
+import {
+  BuildOnChainGasModelFactoryType,
+  GasModelProviderConfig,
+  getQuoteThroughNativePool,
+  IGasModel,
+  IOnChainGasModelFactory,
+} from './gas-model';
 
 export abstract class TickBasedHeuristicGasModelFactory<
   TRouteWithValidQuote extends V3RouteWithValidQuote | V4RouteWithValidQuote

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -40,6 +40,8 @@ export const V2_SUPPORTED = [
   ChainId.AVALANCHE,
 ];
 
+export const V4_SUPPORTED = [ChainId.SEPOLIA];
+
 export const HAS_L1_FEE = [
   ChainId.OPTIMISM,
   ChainId.OPTIMISM_GOERLI,

--- a/test/unit/providers/on-chain-quote-provider.test.ts
+++ b/test/unit/providers/on-chain-quote-provider.test.ts
@@ -3,7 +3,7 @@ import {
   CurrencyAmount,
   ID_TO_PROVIDER,
   OnChainQuoteProvider, parseAmount,
-  UniswapMulticallProvider, V4Route
+  UniswapMulticallProvider, V4_SEPOLIA_TEST_OP, V4_SEPOLIA_TEST_USDC, V4Route
 } from '../../../src';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { Pool } from '@uniswap/v4-sdk';
@@ -28,20 +28,8 @@ describe('on chain quote provider', () => {
       provider,
       multicall2Provider,
     );
-    const op = new Token(
-        chain,
-        '0xc268035619873d85461525f5fdb792dd95982161',
-        18,
-        'OP',
-        'Optimism'
-      )
-    const usdc = new Token(
-      chain,
-      '0xbe2a7f5acecdc293bf34445a0021f229dd2edd49',
-      6,
-      'USDC',
-      'USD'
-    )
+    const op = V4_SEPOLIA_TEST_OP
+    const usdc = V4_SEPOLIA_TEST_USDC
     const amountIns = [
       parseAmount("0.01", op)
     ]


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
best swap route does not account for v4 routes

- **What is the new behavior (if this is a feature change)?**
best swap route is now implemented to account for v4 routes.

- **Other information**:
I added v4 routing integ-test against alpha router, in [alpha-router.integration.test.ts](https://github.com/Uniswap/smart-order-router/pull/680/files#diff-b1a09e5a7156f19225eba6ca4e2e78d0942580ff1118bab472bf0ea3b1294904). I can see the alpha router can quote 1 OP -> 997404.407521 USDC against pool id 0xa40318dea5fabf21971f683f641b54d6d7d86f5b083cd6f0af9332c5c7a9ec06. Tenderly simulation does not work yet, because universal router doesn't support v4 swap commands yet.