### PR TITLE
fix(sor): catch div zero + log but don't throw

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1557,10 +1557,15 @@ export class AlphaRouter
               },
               'Error calculating misquote percent'
             );
+
+            metric.putMetric(
+              `TapcompareCachedRoute_quoteGasAdjustedDiffPercent_divzero`,
+              1,
+              MetricLoggerUnit.Count
+            );
           }
 
-          // We don't want to change the behavior here. If it throws an error, we want to log it and re-throw
-          throw error;
+          // Log but don't throw here - this is only for logging.
         }
       }
     }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Fixes exception throwing in from logging code

- **What is the current behavior?** (You can also link to an open issue here)
throws exception when logging fails with div by zero

- **What is the new behavior (if this is a feature change)?**
logs metric but doesn't throw

- **Other information**:
