### PR TITLE
fix: alpha router integ tests

### DIFF
--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -118,7 +118,7 @@ import {
 import { WHALES } from '../../../test-util/whales';
 import { V4SubgraphProvider } from '../../../../build/main';
 
-const FORK_BLOCK = 20413900;
+const FORK_BLOCK = 20444945;
 const UNIVERSAL_ROUTER_ADDRESS = UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN(1);
 const SLIPPAGE = new Percent(15, 100); // 5% or 10_000?
 const LARGE_SLIPPAGE = new Percent(45, 100); // 5% or 10_000?
@@ -126,7 +126,7 @@ const LARGE_SLIPPAGE = new Percent(45, 100); // 5% or 10_000?
 // Those are the worst deviation (we intend to keep them low and strict) tested manually with FORK_BLOCK = 18222746
 // We may need to tune them if we change the FORK_BLOCK
 const GAS_ESTIMATE_DEVIATION_PERCENT: { [chainId in ChainId]: number } = {
-  [ChainId.MAINNET]: 40,
+  [ChainId.MAINNET]: 50,
   [ChainId.GOERLI]: 62,
   [ChainId.SEPOLIA]: 50,
   [ChainId.OPTIMISM]: 61,
@@ -135,17 +135,17 @@ const GAS_ESTIMATE_DEVIATION_PERCENT: { [chainId in ChainId]: number } = {
   [ChainId.ARBITRUM_ONE]: 53,
   [ChainId.ARBITRUM_GOERLI]: 50,
   [ChainId.ARBITRUM_SEPOLIA]: 50,
-  [ChainId.POLYGON]: 38,
+  [ChainId.POLYGON]: 53,
   [ChainId.POLYGON_MUMBAI]: 30,
   [ChainId.CELO]: 30,
   [ChainId.CELO_ALFAJORES]: 30,
   [ChainId.GNOSIS]: 30,
   [ChainId.MOONBEAM]: 30,
-  [ChainId.BNB]: 63,
-  [ChainId.AVALANCHE]: 36,
-  [ChainId.BASE]: 39,
+  [ChainId.BNB]: 82,
+  [ChainId.AVALANCHE]: 45,
+  [ChainId.BASE]: 50,
   [ChainId.BASE_GOERLI]: 30,
-  [ChainId.ZORA]: 40,
+  [ChainId.ZORA]: 50,
   [ChainId.ZORA_SEPOLIA]: 30,
   [ChainId.ROOTSTOCK]: 30,
   [ChainId.BLAST]: 34,
@@ -4068,9 +4068,9 @@ describe('quote for other networks', () => {
               const tokenIn = erc1;
               const tokenOut = erc2;
               const amount =
-                tradeType == TradeType.EXACT_INPUT
+                tradeType === TradeType.EXACT_INPUT
                   ? parseAmount(chain === ChainId.ZORA ? '0.1' : '1', tokenIn)
-                  : parseAmount(chain === ChainId.ZORA ? '0.1' : '1', tokenOut);
+                  : parseAmount(chain === ChainId.ZORA ? '0.01' : '1', tokenOut);
 
               // Universal Router is not deployed on Gorli.
               const swapWithSimulationOptions: SwapOptions =

--- a/test/test-util/whales.ts
+++ b/test/test-util/whales.ts
@@ -36,7 +36,7 @@ export const WHALES = (token: Currency): string => {
     case nativeOnChain(ChainId.GOERLI):
       return '0x08505F42D5666225d5d73B842dAdB87CCA44d1AE';
     case nativeOnChain(ChainId.BASE):
-      return '0x428ab2ba90eba0a4be7af34c9ac451ab061ac010';
+      return '0x66e4e30cf1eb6155c1bf0422879a470e582f3a50';
     case nativeOnChain(ChainId.AVALANCHE):
       return '0x4aeFa39caEAdD662aE31ab0CE7c8C2c9c0a013E8';
     case nativeOnChain(ChainId.BNB):
@@ -102,7 +102,7 @@ export const WHALES = (token: Currency): string => {
     case USDC_ON(ChainId.BASE):
       return '0x4a3636608d7bc5776cb19eb72caa36ebb9ea683b';
     case USDC_ZORA:
-      return '0x26eF03A20AaeDA8aaFCeE4E146DC6B328195947C';
+      return '0xbC59f8F3b275AA56A90D13bAE7cCe5e6e11A3b17';
     case USDC_NATIVE_BASE:
       return '0x20fe51a9229eef2cf8ad9e89d91cab9312cf3b7a';
     case DAI_ON(ChainId.GOERLI):


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We have couple failing alpha router integ-tests failures.

- **What is the new behavior (if this is a feature change)?**
For https://github.com/Uniswap/smart-order-router/actions/runs/10619450187/job/29437060538#logs, failed test is due to its forked on the block where the test swapper's permit2 nonce is greater than one, indicated by https://app.warp.dev/block/ErFSU72zpWZFxOzeRhEq5h. We just have to find the forked block that can reset that swapper's input token's permit2's nonce back to 1. Luckily changing forked block from 2041390 to 20444945 will do.
For all other integ-tests failures, it's due to not large enough gas diff percent. Since gas is dynamic, we just have to keep adjusting the gas diff percent.
For base and zora, we have to change the whale wallet.

- **Other information**:
