### PR TITLE
feat: exclude certain protocol versions from mixed routing

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -87,6 +87,7 @@ import {
 import { IV3SubgraphProvider } from '../../providers/v3/subgraph-provider';
 import { Erc20__factory } from '../../types/other/factories/Erc20__factory';
 import {
+  shouldWipeoutCachedRoutes,
   SWAP_ROUTER_02_ADDRESSES,
   V4_SUPPORTED,
   WRAPPED_NATIVE_CURRENCY
@@ -165,7 +166,7 @@ import {
   SubgraphPool,
   V2CandidatePools,
   V3CandidatePools,
-  V4CandidatePools,
+  V4CandidatePools
 } from './functions/get-candidate-pools';
 import { NATIVE_OVERHEAD } from './gas-models/gas-costs';
 import {
@@ -399,6 +400,10 @@ export type AlphaRouterConfig = {
    * will be used.
    */
   protocols?: Protocol[];
+  /**
+   * The protocols-version pools to be excluded from the mixed routes.
+   */
+  excludedProtocolsFromMixed?: Protocol[];
   /**
    * Config for selecting which pools to consider routing via on V2.
    */
@@ -1354,6 +1359,10 @@ export class AlphaRouter
         await blockNumber,
         routingConfig.optimisticCachedRoutes
       );
+    }
+
+    if (shouldWipeoutCachedRoutes(routingConfig.excludedProtocolsFromMixed, cachedRoutes)) {
+      cachedRoutes = undefined;
     }
 
     metric.putMetric(

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1361,12 +1361,7 @@ export class AlphaRouter
       );
     }
 
-    if (
-      shouldWipeoutCachedRoutes(
-        cachedRoutes,
-        routingConfig.excludedProtocolsFromMixed
-      )
-    ) {
+    if (shouldWipeoutCachedRoutes(cachedRoutes, routingConfig)) {
       cachedRoutes = undefined;
     }
 

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -90,7 +90,7 @@ import {
   shouldWipeoutCachedRoutes,
   SWAP_ROUTER_02_ADDRESSES,
   V4_SUPPORTED,
-  WRAPPED_NATIVE_CURRENCY
+  WRAPPED_NATIVE_CURRENCY,
 } from '../../util';
 import { CurrencyAmount } from '../../util/amounts';
 import {
@@ -166,7 +166,7 @@ import {
   SubgraphPool,
   V2CandidatePools,
   V3CandidatePools,
-  V4CandidatePools
+  V4CandidatePools,
 } from './functions/get-candidate-pools';
 import { NATIVE_OVERHEAD } from './gas-models/gas-costs';
 import {
@@ -1361,7 +1361,12 @@ export class AlphaRouter
       );
     }
 
-    if (shouldWipeoutCachedRoutes(routingConfig.excludedProtocolsFromMixed, cachedRoutes)) {
+    if (
+      shouldWipeoutCachedRoutes(
+        cachedRoutes,
+        routingConfig.excludedProtocolsFromMixed
+      )
+    ) {
       cachedRoutes = undefined;
     }
 

--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -500,7 +500,11 @@ export async function getBestSwapRouteBy(
   // If swapping on an L2 that includes a L1 security fee, calculate the fee and include it in the gas adjusted quotes
   if (HAS_L1_FEE.includes(chainId)) {
     // ROUTE-249: consoliate L1 + L2 gas fee adjustment within best-swap-route
-    if (v2GasModel == undefined && v3GasModel == undefined && v4GasModel == undefined) {
+    if (
+      v2GasModel == undefined &&
+      v3GasModel == undefined &&
+      v4GasModel == undefined
+    ) {
       throw new Error("Can't compute L1 gas fees.");
     } else {
       // Before v2 deploy everywhere, a quote on L2 can only go through v3 protocol,

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -14,11 +14,12 @@ import {
   TokenValidationResult,
 } from '../../../providers';
 import {
-  CurrencyAmount, excludeProtocolPoolRouteFromMixedRoute,
+  CurrencyAmount,
+  excludeProtocolPoolRouteFromMixedRoute,
   log,
   metric,
   MetricLoggerUnit,
-  routeToString
+  routeToString,
 } from '../../../util';
 import { MixedRoute } from '../../router';
 import { AlphaRouterConfig } from '../alpha-router';
@@ -154,7 +155,10 @@ export class MixedQuoter extends BaseQuoter<
       maxSwapsPerPath
     );
 
-    const protocolExcludedRoutes = excludeProtocolPoolRouteFromMixedRoute(routes, routingConfig.excludedProtocolsFromMixed);
+    const protocolExcludedRoutes = excludeProtocolPoolRouteFromMixedRoute(
+      routes,
+      routingConfig.excludedProtocolsFromMixed
+    );
 
     metric.putMetric(
       'MixedGetRoutesLoad',

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -14,11 +14,11 @@ import {
   TokenValidationResult,
 } from '../../../providers';
 import {
-  CurrencyAmount,
+  CurrencyAmount, excludeProtocolPoolRouteFromMixedRoute,
   log,
   metric,
   MetricLoggerUnit,
-  routeToString,
+  routeToString
 } from '../../../util';
 import { MixedRoute } from '../../router';
 import { AlphaRouterConfig } from '../alpha-router';
@@ -154,6 +154,8 @@ export class MixedQuoter extends BaseQuoter<
       maxSwapsPerPath
     );
 
+    const protocolExcludedRoutes = excludeProtocolPoolRouteFromMixedRoute(routes, routingConfig.excludedProtocolsFromMixed);
+
     metric.putMetric(
       'MixedGetRoutesLoad',
       Date.now() - beforeGetRoutes,
@@ -161,7 +163,7 @@ export class MixedQuoter extends BaseQuoter<
     );
 
     return {
-      routes,
+      routes: protocolExcludedRoutes,
       candidatePools,
     };
   }

--- a/src/util/methodParameters.ts
+++ b/src/util/methodParameters.ts
@@ -4,14 +4,10 @@ import {
   SwapRouter as SwapRouter02,
   Trade,
 } from '@uniswap/router-sdk';
+import { ChainId, Currency, TradeType } from '@uniswap/sdk-core';
 import {
-  ChainId,
-  Currency,
-  TradeType,
-} from '@uniswap/sdk-core';
-import {
-  UNIVERSAL_ROUTER_ADDRESS,
   SwapRouter as UniversalRouter,
+  UNIVERSAL_ROUTER_ADDRESS,
 } from '@uniswap/universal-router-sdk';
 import { Route as V2RouteRaw } from '@uniswap/v2-sdk';
 import { Route as V3RouteRaw } from '@uniswap/v3-sdk';
@@ -23,12 +19,12 @@ import {
   MethodParameters,
   MixedRouteWithValidQuote,
   RouteWithValidQuote,
-  SWAP_ROUTER_02_ADDRESSES,
   SwapOptions,
   SwapType,
+  SWAP_ROUTER_02_ADDRESSES,
   V2RouteWithValidQuote,
   V3RouteWithValidQuote,
-  V4RouteWithValidQuote
+  V4RouteWithValidQuote,
 } from '..';
 
 export function buildTrade<TTradeType extends TradeType>(

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -6,11 +6,12 @@ import { Pool as V4Pool } from '@uniswap/v4-sdk';
 import _ from 'lodash';
 
 import { RouteWithValidQuote } from '../routers/alpha-router';
-import { SupportedRoutes } from '../routers/router';
+import { MixedRoute, SupportedRoutes } from '../routers/router';
 
 import { V3_CORE_FACTORY_ADDRESSES } from './addresses';
 
 import { CurrencyAmount } from '.';
+import { CachedRoutes } from '../providers';
 
 export const routeToTokens = (route: SupportedRoutes): Currency[] => {
   switch (route.protocol) {
@@ -134,3 +135,44 @@ export const routeAmountsToString = (
 
   return _.join(routeStrings, ', ');
 };
+
+export function shouldWipeoutCachedRoutes(excludedProtocolsFromMixed?: Protocol[], cachedRoutes?: CachedRoutes): boolean {
+  const containsExcludedProtocolPools = cachedRoutes?.routes.find((route) => {
+    switch (route.protocol) {
+      case Protocol.MIXED:
+        return (route.route as MixedRoute).pools.filter((pool) =>
+          {
+            if (pool instanceof V4Pool) {
+              return excludedProtocolsFromMixed?.includes(Protocol.V4);
+            } else if (pool instanceof V3Pool) {
+              return excludedProtocolsFromMixed?.includes(Protocol.V3);
+            } else if (pool instanceof Pair) {
+              return excludedProtocolsFromMixed?.includes(Protocol.V2);
+            } else {
+              return false;
+            }
+          }
+        ).length > 0;
+      default:
+        return false;
+    }
+  });
+
+  return containsExcludedProtocolPools !== undefined;
+}
+
+export function excludeProtocolPoolRouteFromMixedRoute(mixedRoutes: MixedRoute[], excludedProtocolsFromMixed?: Protocol[]): MixedRoute[] {
+  return mixedRoutes.filter((route) => {
+    return route.pools.filter((pool) => {
+      if (pool instanceof V4Pool) {
+        return excludedProtocolsFromMixed?.includes(Protocol.V4);
+      } else if (pool instanceof V3Pool) {
+        return excludedProtocolsFromMixed?.includes(Protocol.V3);
+      } else if (pool instanceof Pair) {
+        return excludedProtocolsFromMixed?.includes(Protocol.V2);
+      } else {
+        return false;
+      }
+    }).length == 0;
+  });
+}

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -143,7 +143,7 @@ const GAS_ESTIMATE_DEVIATION_PERCENT: { [chainId in ChainId]: number } = {
   [ChainId.MOONBEAM]: 30,
   [ChainId.BNB]: 82,
   [ChainId.AVALANCHE]: 45,
-  [ChainId.BASE]: 50,
+  [ChainId.BASE]: 53,
   [ChainId.BASE_GOERLI]: 30,
   [ChainId.ZORA]: 50,
   [ChainId.ZORA_SEPOLIA]: 30,

--- a/test/unit/providers/token-fee-fetcher.test.ts
+++ b/test/unit/providers/token-fee-fetcher.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../src/providers/token-fee-fetcher';
 import { BITBOY, BOYS, BULLET, DFNDR } from '../../test-util/mock-data';
 import dotenv from 'dotenv';
+import { ProviderConfig } from '../../../src/providers/provider';
 const each = require("jest-each").default;
 
 dotenv.config();
@@ -16,11 +17,14 @@ describe('TokenFeeFetcher', () => {
     [ChainId.MAINNET, WETH9[ChainId.MAINNET]!, DFNDR, true, false],
     [ChainId.BASE, WETH9[ChainId.BASE]!, BOYS, false, false],
   ]).it('Fetch non-FOT and FOT, should only return FOT', async (chain: ChainId, inputToken: Token, outputToken: Token, feeTakenOnTransfer?: boolean, externalTransferFailed?: boolean) => {
+    const providerConfig: ProviderConfig = {
+      blockNumber: chain === ChainId.MAINNET ? 20686752 : 19395859,
+    }
     const chainProvider = ID_TO_PROVIDER(chain);
     const provider = new JsonRpcProvider(chainProvider, chain);
 
     const tokenFeeFetcher = new OnChainTokenFeeFetcher(chain, provider);
-    const tokenFeeMap = await tokenFeeFetcher.fetchFees([inputToken.address, outputToken.address])
+    const tokenFeeMap = await tokenFeeFetcher.fetchFees([inputToken.address, outputToken.address], providerConfig)
 
     expect(tokenFeeMap).not.toContain(inputToken.address)
     expect(tokenFeeMap[outputToken.address]).toBeDefined()

--- a/test/unit/routers/alpha-router/functions/routes.test.ts
+++ b/test/unit/routers/alpha-router/functions/routes.test.ts
@@ -1,0 +1,85 @@
+import {
+  CachedRoute,
+  CachedRoutes,
+  DAI_MAINNET, excludeProtocolPoolRouteFromMixedRoute,
+  MixedRoute,
+  shouldWipeoutCachedRoutes,
+  USDC_MAINNET
+} from '../../../../../src';
+import { Protocol } from '@uniswap/router-sdk';
+import { TradeType } from '@uniswap/sdk-core';
+import {
+  USDC_DAI,
+  USDC_DAI_LOW,
+  USDC_DAI_MEDIUM,
+  USDC_DAI_V4_LOW
+} from '../../../../test-util/mock-data';
+
+describe('routes', () => {
+  const mixedRoutes1 = new MixedRoute([USDC_DAI, USDC_DAI_LOW], USDC_MAINNET, DAI_MAINNET);
+  const cachedRoute1 = new CachedRoute({
+    route: mixedRoutes1,
+    percent: 50,
+  });
+  const mixedRoutes2 = new MixedRoute([USDC_DAI_V4_LOW, USDC_DAI_LOW], USDC_MAINNET, DAI_MAINNET);
+  const cachedRoute2 = new CachedRoute({
+    route: mixedRoutes2,
+    percent: 50,
+  });
+  const mixedRoutes3 = new MixedRoute([USDC_DAI, USDC_DAI_LOW, USDC_DAI_MEDIUM], USDC_MAINNET, DAI_MAINNET);
+  const cachedRoute3 = new CachedRoute({
+    route: mixedRoutes3,
+    percent: 50,
+  });
+
+  const cachedRoutesIncludeRouteWithV4Pool = new CachedRoutes({
+    routes: [cachedRoute1, cachedRoute2],
+    chainId: 1,
+    tokenIn: USDC_MAINNET,
+    tokenOut: DAI_MAINNET,
+    protocolsCovered: [Protocol.V2, Protocol.V3, Protocol.V4, Protocol.MIXED],
+    blockNumber: 1,
+    tradeType: TradeType.EXACT_INPUT,
+    originalAmount: '100',
+    blocksToLive: 100
+  });
+
+  const cachedRoutesIncludeRouteWithoutV4Pool = new CachedRoutes({
+    routes: [cachedRoute1, cachedRoute3],
+    chainId: 1,
+    tokenIn: USDC_MAINNET,
+    tokenOut: DAI_MAINNET,
+    protocolsCovered: [Protocol.V2, Protocol.V3, Protocol.V4, Protocol.MIXED],
+    blockNumber: 1,
+    tradeType: TradeType.EXACT_INPUT,
+    originalAmount: '100',
+    blocksToLive: 100
+  });
+
+  test(`do not exclude any cached route for empty excluded protocols list`, async () => {
+    expect(shouldWipeoutCachedRoutes(cachedRoutesIncludeRouteWithV4Pool, [])).toBeFalsy();
+  });
+
+  test(`exclude cached route for V4 protocol`, async () => {
+    expect(shouldWipeoutCachedRoutes(cachedRoutesIncludeRouteWithV4Pool, [Protocol.V4])).toBeTruthy();
+  });
+
+  test(`do not exclude cached route for V4 protocol`, async () => {
+    expect(shouldWipeoutCachedRoutes(cachedRoutesIncludeRouteWithoutV4Pool, [Protocol.V4])).toBeFalsy();
+  });
+
+  test(`do not exclude any mixed route for empty excluded protocols list`, async () => {
+    const newMixedRoutes = excludeProtocolPoolRouteFromMixedRoute([mixedRoutes1, mixedRoutes2, mixedRoutes3], []);
+    expect(newMixedRoutes).toStrictEqual([mixedRoutes1, mixedRoutes2, mixedRoutes3]);
+  });
+
+  test(`exclude mixed route for V4 protocol`, async () => {
+    const newMixedRoutes = excludeProtocolPoolRouteFromMixedRoute([mixedRoutes1, mixedRoutes2, mixedRoutes3], [Protocol.V4]);
+    expect(newMixedRoutes).toStrictEqual([mixedRoutes1, mixedRoutes3]);
+  });
+
+  test(`do not exclude mixed route for V4 protocol`, async () => {
+    const newMixedRoutes = excludeProtocolPoolRouteFromMixedRoute([mixedRoutes1, mixedRoutes3], [Protocol.V4]);
+    expect(newMixedRoutes).toStrictEqual([mixedRoutes1, mixedRoutes3]);
+  });
+});

--- a/test/unit/routers/alpha-router/functions/routes.test.ts
+++ b/test/unit/routers/alpha-router/functions/routes.test.ts
@@ -1,19 +1,24 @@
 import {
+  AlphaRouterConfig,
   CachedRoute,
   CachedRoutes,
-  DAI_MAINNET, excludeProtocolPoolRouteFromMixedRoute,
+  DAI_MAINNET,
+  excludeProtocolPoolRouteFromMixedRoute,
   MixedRoute,
   shouldWipeoutCachedRoutes,
   USDC_MAINNET
 } from '../../../../../src';
 import { Protocol } from '@uniswap/router-sdk';
-import { TradeType } from '@uniswap/sdk-core';
+import { ChainId, TradeType } from '@uniswap/sdk-core';
 import {
   USDC_DAI,
   USDC_DAI_LOW,
   USDC_DAI_MEDIUM,
   USDC_DAI_V4_LOW
 } from '../../../../test-util/mock-data';
+import {
+  DEFAULT_ROUTING_CONFIG_BY_CHAIN
+} from '../../../../../src/routers/alpha-router/config';
 
 describe('routes', () => {
   const mixedRoutes1 = new MixedRoute([USDC_DAI, USDC_DAI_LOW], USDC_MAINNET, DAI_MAINNET);
@@ -57,15 +62,37 @@ describe('routes', () => {
   });
 
   test(`do not exclude any cached route for empty excluded protocols list`, async () => {
-    expect(shouldWipeoutCachedRoutes(cachedRoutesIncludeRouteWithV4Pool, [])).toBeFalsy();
+    const routingConfig: AlphaRouterConfig = {
+      // @ts-ignore[TS7053] - complaining about switch being non exhaustive
+      ...DEFAULT_ROUTING_CONFIG_BY_CHAIN[ChainId.MAINNET],
+      protocols: [Protocol.V2, Protocol.V3, Protocol.V4, Protocol.MIXED],
+      excludedProtocolsFromMixed: [],
+      optimisticCachedRoutes: false,
+    };
+
+    expect(shouldWipeoutCachedRoutes(cachedRoutesIncludeRouteWithV4Pool, routingConfig)).toBeFalsy();
   });
 
   test(`exclude cached route for V4 protocol`, async () => {
-    expect(shouldWipeoutCachedRoutes(cachedRoutesIncludeRouteWithV4Pool, [Protocol.V4])).toBeTruthy();
+    const routingConfig: AlphaRouterConfig = {
+      // @ts-ignore[TS7053] - complaining about switch being non exhaustive
+      ...DEFAULT_ROUTING_CONFIG_BY_CHAIN[ChainId.MAINNET],
+      protocols: [Protocol.V2, Protocol.V3, Protocol.V4, Protocol.MIXED],
+      excludedProtocolsFromMixed: [Protocol.V4],
+      optimisticCachedRoutes: false,
+    };
+    expect(shouldWipeoutCachedRoutes(cachedRoutesIncludeRouteWithV4Pool, routingConfig)).toBeTruthy();
   });
 
   test(`do not exclude cached route for V4 protocol`, async () => {
-    expect(shouldWipeoutCachedRoutes(cachedRoutesIncludeRouteWithoutV4Pool, [Protocol.V4])).toBeFalsy();
+    const routingConfig: AlphaRouterConfig = {
+      // @ts-ignore[TS7053] - complaining about switch being non exhaustive
+      ...DEFAULT_ROUTING_CONFIG_BY_CHAIN[ChainId.MAINNET],
+      protocols: [Protocol.V2, Protocol.V3, Protocol.V4, Protocol.MIXED],
+      excludedProtocolsFromMixed: [Protocol.V4],
+      optimisticCachedRoutes: false,
+    };
+    expect(shouldWipeoutCachedRoutes(cachedRoutesIncludeRouteWithoutV4Pool, routingConfig)).toBeFalsy();
   });
 
   test(`do not exclude any mixed route for empty excluded protocols list`, async () => {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
For mixed protocol version request, we don't have the ability to exclude a certain route with a certain pool version. Some clients would love to still request mixed routes, but they don't want any of the mixed route to go through any v4 pools.

- **What is the new behavior (if this is a feature change)?**
We will expose a new additional generic field `excludedProtocolsFromMixed` to be able to exclude certain protocol version pool routes from the mixed routes.

- **Other information**:
We can be somewhat limited in scope in the protocol exclusions here. If someone says I don't want pure v3-pool routes returned from SOR, then they simply don't need to request `v3` in the request protocol versions array. Likewise for any other version specific protocol request. This eases the implementation complexity, meanwhile we still have a bit of flexibility, in case in future client wants to exclude other protocol version from mixed routing.

Also from routing-api perspective, it will accept a new query string param called 'mixedExcludeV4' and hardcode `excludedProtocolsFromMixed` to be `[V4]`, since at routing-api layer it can be more opinionated.

Once we implement mixed routing with v4 support in SOR, we can add additional alpha router integ tests to verify.