### PR TITLE
fix: div by zero on syntheticGasCostInTermsOfQuoteToken

### DIFF
--- a/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
@@ -189,8 +189,16 @@ export abstract class TickBasedHeuristicGasModelFactory<
             gasCostInTermsOfAmountToken
           );
         } catch (err) {
-          // If the quote fails (division by zero), set syntheticGasCostInTermsOfQuoteToken to null
-          syntheticGasCostInTermsOfQuoteToken = null;
+          if (
+            err instanceof RangeError &&
+            err.message.includes('Division by zero')
+          ) {
+            // If the quote fails (division by zero), set syntheticGasCostInTermsOfQuoteToken to null
+            syntheticGasCostInTermsOfQuoteToken = null;
+          } else {
+            // any other error, throw
+            throw err;
+          }
         }
 
         // Note that the syntheticGasCost being lessThan the original quoted value is not always strictly better


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes division by zero exception when `gasCostInTermsOfAmountToken` is zero

```
{"name":"quote","requestId":"a54ba5b5-5a11-4cda-8c63-3775099f5bad","hostname":"169.254.29.161","pid":12,"quoteId":"a54ba","tokenInAddress":"0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e","chainId":42220,"tokenOutAddress":"0xcebA9300f2b948710d2653dD7B07f33A8B32118C","amount":"10","type":"exactIn","activityId":"ead33689-86ae-4a04-b4fc-40b43a985a04","level":50,"err":{
"message":"Division by zero",
"name":"RangeError",
"stack":"RangeError: Division by zero\n    
at Function.divide (/node_modules/jsbi/lib/jsbi.ts:228:31)\n    
at e.get (/node_modules/@uniswap/sdk-core/src/entities/fractions/fraction.ts:43:17)\n    
at e (/node_modules/@uniswap/sdk-core/src/entities/fractions/currencyAmount.ts:42:41)\n    
at Function.e.fromFractionalAmount (/node_modules/@uniswap/sdk-core/src/entities/fractions/currencyAmount.ts:37:12)\n    
at e.a.quote (/node_modules/@uniswap/sdk-core/src/entities/fractions/price.ts:70:27)\n    
at _De.<anonymous> (/node_modules/@uniswap/smart-order-router/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts:186:68)\n    
at XDe (/node_modules/@uniswap/smart-order-router/src/routers/alpha-router/entities/route-with-valid-quote.ts:238:21)\n    
at yRe.getQuotes (/node_modules/@uniswap/smart-order-router/src/routers/alpha-router/quoters/v3-quoter.ts:217:37)\n    
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    
at async Promise.all (index 0)"},"msg":"Unexpected error in handler","time":"2024-09-04T19:26:38.101Z","v":0}
```