### PR TITLE
feat: SOR support universal router version param as part of alpha router config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@uniswap/swap-router-contracts": "^1.3.1",
         "@uniswap/token-lists": "^1.0.0-beta.31",
         "@uniswap/universal-router": "^1.6.0",
-        "@uniswap/universal-router-sdk": "^2.2.4",
+        "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
         "@uniswap/v3-sdk": "^3.13.0",
         "@uniswap/v4-sdk": "^1.0.0",
@@ -3379,9 +3379,9 @@
       }
     },
     "node_modules/@uniswap/universal-router-sdk": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-2.2.4.tgz",
-      "integrity": "sha512-6+ErgDDtCJLM2ro/krCKtu6ucUpcaQEEPRrAPuJiMTWbR0UyR+6Otp+KdBcT9LmyzSoXuSHhIRr+6s25no1J6A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-3.0.2.tgz",
+      "integrity": "sha512-DRmUybl/XsN6buUNwpLGLdRnlEaIlrP3o3I1471YlKXhXF9Mb4m+HQqC3VSzBfyIiMBZn7SxL8M3VZIO+ofg5w==",
       "dependencies": {
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",
@@ -14746,9 +14746,9 @@
       }
     },
     "@uniswap/universal-router-sdk": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-2.2.4.tgz",
-      "integrity": "sha512-6+ErgDDtCJLM2ro/krCKtu6ucUpcaQEEPRrAPuJiMTWbR0UyR+6Otp+KdBcT9LmyzSoXuSHhIRr+6s25no1J6A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/universal-router-sdk/-/universal-router-sdk-3.0.2.tgz",
+      "integrity": "sha512-DRmUybl/XsN6buUNwpLGLdRnlEaIlrP3o3I1471YlKXhXF9Mb4m+HQqC3VSzBfyIiMBZn7SxL8M3VZIO+ofg5w==",
       "requires": {
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@uniswap/swap-router-contracts": "^1.3.1",
     "@uniswap/token-lists": "^1.0.0-beta.31",
     "@uniswap/universal-router": "^1.6.0",
-    "@uniswap/universal-router-sdk": "^2.2.4",
+    "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",
     "@uniswap/v3-sdk": "^3.13.0",
     "@uniswap/v4-sdk": "^1.0.0",

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,3 +1,5 @@
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
+
 export type ProviderConfig = {
   /**
    * The block number to use when getting data on-chain.
@@ -29,6 +31,10 @@ export type ProviderConfig = {
    * double FOT fee taken on transfer as part of universal router custody
    */
   feeTakenOnTransfer?: boolean;
+  /**
+   * The version of the universal router to use.
+   */
+  universalRouterVersion?: UniversalRouterVersion;
 };
 
 export type LocalCacheEntry<T> = {

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -338,7 +338,7 @@ export class TenderlySimulator extends Simulator {
       const approveUniversalRouterCallData =
         permit2Interface.encodeFunctionData('approve', [
           tokenIn.address,
-          UNIVERSAL_ROUTER_ADDRESS(this.chainId),
+          UNIVERSAL_ROUTER_ADDRESS(swapOptions.version, this.chainId),
           MAX_UINT160,
           Math.floor(new Date().getTime() / 1000) + 10000000,
         ]);
@@ -371,7 +371,7 @@ export class TenderlySimulator extends Simulator {
         network_id: chainId,
         input: calldata,
         estimate_gas: true,
-        to: UNIVERSAL_ROUTER_ADDRESS(this.chainId),
+        to: UNIVERSAL_ROUTER_ADDRESS(swapOptions.version, this.chainId),
         value: currencyIn.isNative ? swapRoute.methodParameters.value : '0',
         from: fromAddress,
         block_number: blockNumber,

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -139,6 +139,7 @@ import {
   V4Route,
 } from '../router';
 
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
 import { CachingV4PoolProvider } from '../../providers/v4/caching-pool-provider';
 import {
   IV4PoolProvider,
@@ -313,6 +314,11 @@ export type AlphaRouterParams = {
    * All the supported v4 chains configuration
    */
   v4Supported?: ChainId[];
+
+  /**
+   * The version of the universal router to use.
+   */
+  universalRouterVersion?: UniversalRouterVersion;
 };
 
 export class MapWithLowerCaseKey<V> extends Map<string, V> {
@@ -486,6 +492,10 @@ export type AlphaRouterConfig = {
    * This requires a suitable Native/GasToken pool to exist on V3. If one does not exist this field will return null.
    */
   gasToken?: string;
+  /**
+   * The version of the universal router to use.
+   */
+  universalRouterVersion?: UniversalRouterVersion;
 };
 
 export class AlphaRouter
@@ -524,6 +534,7 @@ export class AlphaRouter
   protected portionProvider: IPortionProvider;
   protected v2Supported?: ChainId[];
   protected v4Supported?: ChainId[];
+  protected universalRouterVersion?: UniversalRouterVersion;
 
   constructor({
     chainId,
@@ -553,6 +564,7 @@ export class AlphaRouter
     portionProvider,
     v2Supported,
     v4Supported,
+    universalRouterVersion,
   }: AlphaRouterParams) {
     this.chainId = chainId;
     this.provider = provider;
@@ -979,6 +991,8 @@ export class AlphaRouter
 
     this.v2Supported = v2Supported ?? V2_SUPPORTED;
     this.v4Supported = v4Supported ?? V4_SUPPORTED;
+    this.universalRouterVersion =
+      universalRouterVersion ?? UniversalRouterVersion.V1_2;
   }
 
   public async routeToRatio(

--- a/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
@@ -63,7 +63,8 @@ export abstract class TickBasedHeuristicGasModelFactory<
         quoteToken,
         pools.nativeAndQuoteTokenV3Pool,
         this.provider,
-        l2GasData
+        l2GasData,
+        providerConfig
       );
     };
 

--- a/src/routers/router.ts
+++ b/src/routers/router.ts
@@ -12,7 +12,10 @@ import {
   Token,
   TradeType,
 } from '@uniswap/sdk-core';
-import { SwapOptions as UniversalRouterSwapOptions } from '@uniswap/universal-router-sdk';
+import {
+  SwapOptions as UniversalRouterSwapOptions,
+  UniversalRouterVersion,
+} from '@uniswap/universal-router-sdk';
 import { Route as V2RouteRaw } from '@uniswap/v2-sdk';
 import {
   MethodParameters as SDKMethodParameters,
@@ -158,6 +161,7 @@ export enum SwapType {
 // Swap options for Universal Router and Permit2.
 export type SwapOptionsUniversalRouter = UniversalRouterSwapOptions & {
   type: SwapType.UNIVERSAL_ROUTER;
+  version: UniversalRouterVersion;
   simulate?: { fromAddress: string };
 };
 

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -29,6 +29,7 @@ import { CurrencyAmount, log, WRAPPED_NATIVE_CURRENCY } from '../util';
 
 import { estimateL1Gas, estimateL1GasCost } from '@eth-optimism/sdk';
 import { BaseProvider, TransactionRequest } from '@ethersproject/providers';
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
 import { Pair } from '@uniswap/v2-sdk';
 import { ProviderConfig } from '../providers/provider';
 import { opStackChains } from './l2FeeChains';
@@ -557,7 +558,8 @@ export const calculateL1GasFeesHelper = async (
   quoteToken: Token,
   nativePool: Pair | Pool | null,
   provider: BaseProvider,
-  l2GasData?: ArbitrumGasData
+  l2GasData?: ArbitrumGasData,
+  providerConfig?: GasModelProviderConfig
 ): Promise<{
   gasUsedL1: BigNumber;
   gasUsedL1OnL2: BigNumber;
@@ -566,6 +568,8 @@ export const calculateL1GasFeesHelper = async (
 }> => {
   const swapOptions: SwapOptionsUniversalRouter = {
     type: SwapType.UNIVERSAL_ROUTER,
+    version:
+      providerConfig?.universalRouterVersion ?? UniversalRouterVersion.V1_2,
     recipient: '0x0000000000000000000000000000000000000001',
     deadlineOrPreviousBlockhash: 100,
     slippageTolerance: new Percent(5, 10_000),

--- a/src/util/methodParameters.ts
+++ b/src/util/methodParameters.ts
@@ -317,7 +317,7 @@ export function buildSwapMethodParameters(
   if (swapConfig.type == SwapType.UNIVERSAL_ROUTER) {
     return {
       ...UniversalRouter.swapERC20CallParameters(trade, swapConfig),
-      to: UNIVERSAL_ROUTER_ADDRESS(chainId),
+      to: UNIVERSAL_ROUTER_ADDRESS(swapConfig.version, chainId),
     };
   } else if (swapConfig.type == SwapType.SWAP_ROUTER_02) {
     const { recipient, slippageTolerance, deadline, inputTokenPermit } =

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -37,7 +37,7 @@ export const routeToPools = (
     case Protocol.V4:
     case Protocol.V3:
     case Protocol.MIXED:
-      return route.pools;
+      return route.pools as (V4Pool | V3Pool | Pair)[];
     case Protocol.V2:
       return route.pairs;
     default:
@@ -160,7 +160,7 @@ export function shouldWipeoutCachedRoutes(
         return (
           (route.route as MixedRoute).pools.filter((pool) => {
             return poolIsInExcludedProtocols(
-              pool,
+              pool as V4Pool | V3Pool | Pair,
               routingConfig?.excludedProtocolsFromMixed
             );
           }).length > 0
@@ -180,7 +180,10 @@ export function excludeProtocolPoolRouteFromMixedRoute(
   return mixedRoutes.filter((route) => {
     return (
       route.pools.filter((pool) => {
-        return poolIsInExcludedProtocols(pool, excludedProtocolsFromMixed);
+        return poolIsInExcludedProtocols(
+          pool as V4Pool | V3Pool | Pair,
+          excludedProtocolsFromMixed
+        );
       }).length == 0
     );
   });

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -21,7 +21,8 @@ import {
   TradeType
 } from '@uniswap/sdk-core';
 import {
-  UNIVERSAL_ROUTER_ADDRESS as UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN
+  UNIVERSAL_ROUTER_ADDRESS as UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN,
+  UniversalRouterVersion
 } from '@uniswap/universal-router-sdk';
 import {
   Permit2Permit
@@ -119,7 +120,7 @@ import { WHALES } from '../../../test-util/whales';
 import { V4SubgraphProvider } from '../../../../build/main';
 
 const FORK_BLOCK = 20444945;
-const UNIVERSAL_ROUTER_ADDRESS = UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN(1);
+const UNIVERSAL_ROUTER_ADDRESS_V1_2 = UNIVERSAL_ROUTER_ADDRESS_BY_CHAIN(UniversalRouterVersion.V1_2, 1);
 const SLIPPAGE = new Percent(15, 100); // 5% or 10_000?
 const LARGE_SLIPPAGE = new Percent(45, 100); // 5% or 10_000?
 
@@ -317,7 +318,7 @@ describe('alpha router integration', () => {
         const aliceP2 = Permit2__factory.connect(permit2Address(ChainId.MAINNET), alice);
         const approveNarwhal = await aliceP2.approve(
           tokenIn.wrapped.address,
-          UNIVERSAL_ROUTER_ADDRESS,
+          UNIVERSAL_ROUTER_ADDRESS_V1_2,
           MAX_UINT160,
           20_000_000_000_000
         );
@@ -797,6 +798,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -857,8 +859,8 @@ describe('alpha router integration', () => {
             getQuoteToken(tokenIn, tokenOut, tradeType),
             tradeType,
             {
-
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -935,7 +937,7 @@ describe('alpha router integration', () => {
               ).toString(),
               nonce,
             },
-            spender: UNIVERSAL_ROUTER_ADDRESS,
+            spender: UNIVERSAL_ROUTER_ADDRESS_V1_2,
             sigDeadline: Math.floor(
               new Date().getTime() / 1000 + 100000
             ).toString(),
@@ -960,6 +962,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1011,7 +1014,7 @@ describe('alpha router integration', () => {
               ).toString(),
               nonce,
             },
-            spender: UNIVERSAL_ROUTER_ADDRESS,
+            spender: UNIVERSAL_ROUTER_ADDRESS_V1_2,
             sigDeadline: Math.floor(
               new Date().getTime() / 1000 + 1000
             ).toString(),
@@ -1036,6 +1039,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1088,6 +1092,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1128,6 +1133,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1221,7 +1227,7 @@ describe('alpha router integration', () => {
               ).toString(),
               nonce,
             },
-            spender: UNIVERSAL_ROUTER_ADDRESS,
+            spender: UNIVERSAL_ROUTER_ADDRESS_V1_2,
             sigDeadline: Math.floor(
               new Date().getTime() / 1000 + 1000
             ).toString(),
@@ -1246,6 +1252,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE.multiply(10),
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1294,6 +1301,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1433,6 +1441,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1472,6 +1481,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1511,6 +1521,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1559,6 +1570,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1607,6 +1619,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1665,6 +1678,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1712,6 +1726,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1761,6 +1776,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1883,7 +1899,7 @@ describe('alpha router integration', () => {
                   ).toString(),
                   nonce,
                 },
-                spender: UNIVERSAL_ROUTER_ADDRESS,
+                spender: UNIVERSAL_ROUTER_ADDRESS_V1_2,
                 sigDeadline: Math.floor(
                   new Date().getTime() / 1000 + 100000
                 ).toString(),
@@ -1914,6 +1930,7 @@ describe('alpha router integration', () => {
                 tradeType,
                 {
                   type: SwapType.UNIVERSAL_ROUTER,
+                  version: UniversalRouterVersion.V1_2,
                   recipient: wallet.address,
                   slippageTolerance: SLIPPAGE,
                   deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -1948,6 +1965,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: LARGE_SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2007,6 +2025,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2093,6 +2112,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: new Percent(50, 100),
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2150,6 +2170,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: LARGE_SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2207,6 +2228,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2264,6 +2286,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2322,6 +2345,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2381,6 +2405,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2443,6 +2468,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2594,6 +2620,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2625,6 +2652,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2675,6 +2703,7 @@ describe('alpha router integration', () => {
               tradeType,
               {
                 type: SwapType.UNIVERSAL_ROUTER,
+                version: UniversalRouterVersion.V1_2,
                 recipient: alice._address,
                 slippageTolerance: SLIPPAGE,
                 deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2727,6 +2756,7 @@ describe('alpha router integration', () => {
                 tradeType,
                 {
                   type: SwapType.UNIVERSAL_ROUTER,
+                  version: UniversalRouterVersion.V1_2,
                   recipient: alice._address,
                   slippageTolerance: LARGE_SLIPPAGE,
                   deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -2868,6 +2898,7 @@ describe('alpha router integration', () => {
                       tradeType,
                       {
                         type: SwapType.UNIVERSAL_ROUTER,
+                        version: UniversalRouterVersion.V1_2,
                         recipient: alice._address,
                         slippageTolerance: LARGE_SLIPPAGE,
                         deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -3158,6 +3189,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: new Percent(50, 100),
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -3205,6 +3237,7 @@ describe('alpha router integration', () => {
             tradeType,
             {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               recipient: alice._address,
               slippageTolerance: SLIPPAGE,
               deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -3875,6 +3908,7 @@ describe('quote for other networks', () => {
                   }
                   : {
                     type: SwapType.UNIVERSAL_ROUTER,
+                    version: UniversalRouterVersion.V1_2,
                     recipient: WHALES(tokenIn),
                     slippageTolerance: SLIPPAGE,
                     deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -3900,6 +3934,7 @@ describe('quote for other networks', () => {
               const swapOptions: SwapOptions =
                 {
                   type: SwapType.UNIVERSAL_ROUTER,
+                  version: UniversalRouterVersion.V1_2,
                   recipient: WHALES(tokenIn),
                   slippageTolerance: SLIPPAGE,
                   deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -3983,6 +4018,7 @@ describe('quote for other networks', () => {
                   }
                   : {
                     type: SwapType.UNIVERSAL_ROUTER,
+                    version: UniversalRouterVersion.V1_2,
                     recipient: WHALES(tokenIn),
                     slippageTolerance: SLIPPAGE,
                     deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -4008,6 +4044,7 @@ describe('quote for other networks', () => {
               const swapOptions: SwapOptions =
                 {
                   type: SwapType.UNIVERSAL_ROUTER,
+                  version: UniversalRouterVersion.V1_2,
                   recipient: WHALES(tokenIn),
                   slippageTolerance: SLIPPAGE,
                   deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -4084,6 +4121,7 @@ describe('quote for other networks', () => {
                   }
                   : {
                     type: SwapType.UNIVERSAL_ROUTER,
+                    version: UniversalRouterVersion.V1_2,
                     recipient: WHALES(tokenIn),
                     slippageTolerance: SLIPPAGE,
                     deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -4109,6 +4147,7 @@ describe('quote for other networks', () => {
               const swapOptions: SwapOptions =
                 {
                   type: SwapType.UNIVERSAL_ROUTER,
+                  version: UniversalRouterVersion.V1_2,
                   recipient: WHALES(tokenIn),
                   slippageTolerance: SLIPPAGE,
                   deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -4187,6 +4226,7 @@ describe('quote for other networks', () => {
                   }
                   : {
                     type: SwapType.UNIVERSAL_ROUTER,
+                    version: UniversalRouterVersion.V1_2,
                     recipient: WHALES(tokenIn),
                     slippageTolerance: SLIPPAGE,
                     deadlineOrPreviousBlockhash: parseDeadline(360),
@@ -4212,6 +4252,7 @@ describe('quote for other networks', () => {
               const swapOptions: SwapOptions =
                 {
                   type: SwapType.UNIVERSAL_ROUTER,
+                  version: UniversalRouterVersion.V1_2,
                   recipient: WHALES(tokenIn),
                   slippageTolerance: SLIPPAGE,
                   deadlineOrPreviousBlockhash: parseDeadline(360),

--- a/test/test-util/whales.ts
+++ b/test/test-util/whales.ts
@@ -56,7 +56,7 @@ export const WHALES = (token: Currency): string => {
     case WNATIVE_ON(ChainId.POLYGON):
       return '0x369582d2010b6ed950b571f4101e3bb9b554876f';
     case WNATIVE_ON(ChainId.BASE):
-      return '0x4bb6b2efe7036020ba6f02a05602546c9f25bf28';
+      return '0x0172e05392aba65366C4dbBb70D958BbF43304E4';
     case WNATIVE_ON(ChainId.OPTIMISM):
       return '0x12478d1a60a910C9CbFFb90648766a2bDD5918f5';
     case WNATIVE_ON(ChainId.BNB):

--- a/test/unit/providers/portion-provider.test.ts
+++ b/test/unit/providers/portion-provider.test.ts
@@ -1,5 +1,12 @@
 import { BigNumber } from '@ethersproject/bignumber';
-import { Currency, CurrencyAmount, Fraction, Percent, Token, TradeType, } from '@uniswap/sdk-core';
+import {
+  Currency,
+  CurrencyAmount,
+  Fraction,
+  Percent,
+  Token,
+  TradeType
+} from '@uniswap/sdk-core';
 import {
   MixedRouteWithValidQuote,
   parseAmount,
@@ -16,6 +23,7 @@ import {
   getV2RouteWithValidQuoteStub,
   getV3RouteWithValidQuoteStub
 } from './caching/route/test-util/mocked-dependencies';
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
 
 describe('portion provider', () => {
   const expectedRequestAmount = '1.01';
@@ -58,6 +66,7 @@ describe('portion provider', () => {
 
         const swapConfig: SwapOptions = {
           type: SwapType.UNIVERSAL_ROUTER,
+          version: UniversalRouterVersion.V1_2,
           slippageTolerance: new Percent(5),
           recipient: '0x123',
           fee: {
@@ -129,6 +138,7 @@ describe('portion provider', () => {
         const expectedPortionAmount = amount.multiply(new Fraction(expectedPortion.bips, 10_000));
         const swapConfig: SwapOptions = {
           type: SwapType.UNIVERSAL_ROUTER,
+          version: UniversalRouterVersion.V1_2,
           slippageTolerance: new Percent(5),
           recipient: '0x123',
           flatFee: {
@@ -199,6 +209,7 @@ describe('portion provider', () => {
 
             const swapConfig: SwapOptions = {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               slippageTolerance: new Percent(5),
               recipient: '0x123',
               fee: {
@@ -225,6 +236,7 @@ describe('portion provider', () => {
 
             const swapConfig: SwapOptions = {
               type: SwapType.UNIVERSAL_ROUTER,
+              version: UniversalRouterVersion.V1_2,
               slippageTolerance: new Percent(5),
               recipient: '0x123',
               fee: {
@@ -268,6 +280,7 @@ describe('portion provider', () => {
       ];
       const swapParams: SwapOptions = {
         type: SwapType.UNIVERSAL_ROUTER,
+        version: UniversalRouterVersion.V1_2,
         deadlineOrPreviousBlockhash: undefined,
         recipient: '0x123',
         slippageTolerance: new Percent(5),
@@ -331,6 +344,7 @@ describe('portion provider', () => {
       ];
       const swapParams: SwapOptions = {
         type: SwapType.UNIVERSAL_ROUTER,
+        version: UniversalRouterVersion.V1_2,
         deadlineOrPreviousBlockhash: undefined,
         recipient: '0x123',
         slippageTolerance: new Percent(5),

--- a/test/unit/providers/simulation-provider.test.ts
+++ b/test/unit/providers/simulation-provider.test.ts
@@ -18,11 +18,15 @@ import {
   SwapType,
   TenderlySimulator,
   USDC_MAINNET,
-  V2PoolProvider,
+  V2PoolProvider
 } from '../../../src';
-import { IPortionProvider, PortionProvider } from '../../../src/providers/portion-provider';
+import {
+  IPortionProvider,
+  PortionProvider
+} from '../../../src/providers/portion-provider';
 import { Erc20 } from '../../../src/types/other/Erc20';
 import { Permit2 } from '../../../src/types/other/Permit2';
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
 
 let tokenContract: Erc20;
 let permit2Contract: Permit2;
@@ -93,6 +97,7 @@ const quote = {
 const blockNumber = BigNumber.from(0);
 const swapOptions: SwapOptions = {
   type: SwapType.UNIVERSAL_ROUTER,
+  version: UniversalRouterVersion.V1_2,
   slippageTolerance: new Percent(5, 100),
   deadlineOrPreviousBlockhash: 10000000,
   recipient: '0x0',

--- a/test/unit/routers/alpha-router/alpha-router.test.ts
+++ b/test/unit/routers/alpha-router/alpha-router.test.ts
@@ -79,6 +79,7 @@ import {
   WETH_USDT
 } from '../../../test-util/mock-data';
 import { InMemoryRouteCachingProvider } from '../../providers/caching/route/test-util/inmemory-route-caching-provider';
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
 
 const helper = require('../../../../src/routers/alpha-router/functions/calculate-ratio-amount-in');
 
@@ -1422,6 +1423,7 @@ describe('alpha router', () => {
     test('succeeds to route and generates calldata on v3 only', async () => {
       const swapParams = {
         type: SwapType.UNIVERSAL_ROUTER,
+        version: UniversalRouterVersion.V1_2,
         deadline: Math.floor(Date.now() / 1000) + 1000000,
         recipient: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
         slippageTolerance: new Percent(500, 10_000),
@@ -1503,6 +1505,7 @@ describe('alpha router', () => {
     test('succeeds to route and generates calldata on v2 only', async () => {
       const swapParams = {
         type: SwapType.UNIVERSAL_ROUTER,
+        version: UniversalRouterVersion.V1_2,
         deadline: Math.floor(Date.now() / 1000) + 1000000,
         recipient: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
         slippageTolerance: new Percent(500, 10_000),
@@ -1577,6 +1580,7 @@ describe('alpha router', () => {
     test('succeeds to route and generates calldata on mixed only', async () => {
       const swapParams = {
         type: SwapType.UNIVERSAL_ROUTER,
+        version: UniversalRouterVersion.V1_2,
         deadline: Math.floor(Date.now() / 1000) + 1000000,
         recipient: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
         slippageTolerance: new Percent(500, 10_000),
@@ -1653,6 +1657,7 @@ describe('alpha router', () => {
     test('succeeds to route and generate calldata and simulates', async () => {
       const swapParams = {
         type: SwapType.UNIVERSAL_ROUTER,
+        version: UniversalRouterVersion.V1_2,
         deadline: Math.floor(Date.now() / 1000) + 1000000,
         recipient: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
         slippageTolerance: new Percent(500, 10_000),
@@ -2188,6 +2193,7 @@ describe('alpha router', () => {
     test('succeeds to route and generates calldata on v2 only', async () => {
       const swapParams = {
         type: SwapType.UNIVERSAL_ROUTER,
+        version: UniversalRouterVersion.V1_2,
         deadline: Math.floor(Date.now() / 1000) + 1000000,
         recipient: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
         slippageTolerance: new Percent(500, 10_000),
@@ -2258,6 +2264,7 @@ describe('alpha router', () => {
       const amount = CurrencyAmount.fromRawAmount(WRAPPED_NATIVE_CURRENCY[1], 10000);
       const swapParams = {
         type: SwapType.UNIVERSAL_ROUTER,
+        version: UniversalRouterVersion.V1_2,
         deadline: Math.floor(Date.now() / 1000) + 1000000,
         recipient: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
         slippageTolerance: new Percent(500, 10_000),


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
With V4, protocol team will deploy a new version (v2.0) of universal router. Currently, in ur-sdk, we introduced UniversalRouterVersionEnum as part of UniversalRouterAddress function param. However, SOR needs to bump up ur-sdk to adopt UniversalRouterVersionEnum.

- **What is the new behavior (if this is a feature change)?**
SOR to support passing in universal router version param as part of alpha router config

- **Other information**: