### PR TITLE
chore: missing v4 in `base-command.ts`

### DIFF
--- a/cli/base-command.ts
+++ b/cli/base-command.ts
@@ -17,6 +17,7 @@ import {
   CachingTokenListProvider,
   CachingTokenProviderWithFallback,
   CachingV3PoolProvider,
+  CachingV4PoolProvider,
   CHAIN_IDS_LIST,
   EIP1559GasPriceProvider,
   EthEstimateGasSimulator,
@@ -44,7 +45,8 @@ import {
   UniswapMulticallProvider,
   V2PoolProvider,
   V3PoolProvider,
-  V3RouteWithValidQuote
+  V3RouteWithValidQuote,
+  V4PoolProvider
 } from '../src';
 import {
   LegacyGasPriceProvider
@@ -291,6 +293,11 @@ export abstract class BaseCommand extends Command {
         new V3PoolProvider(chainId, multicall2Provider),
         new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false }))
       );
+      const v4PoolProvider = new CachingV4PoolProvider(
+        chainId,
+        new V4PoolProvider(chainId, multicall2Provider),
+        new NodeJSCache(new NodeCache({ stdTTL: 360, useClones: false }))
+      );
       const tokenFeeFetcher = new OnChainTokenFeeFetcher(
         chainId,
         provider
@@ -312,6 +319,7 @@ export abstract class BaseCommand extends Command {
         process.env.TENDERLY_NODE_API_KEY!,
         v2PoolProvider,
         v3PoolProvider,
+        v4PoolProvider,
         provider,
         portionProvider,
         { [ChainId.ARBITRUM_ONE]: 1 },
@@ -325,6 +333,7 @@ export abstract class BaseCommand extends Command {
         provider,
         v2PoolProvider,
         v3PoolProvider,
+        v4PoolProvider,
         portionProvider
       );
 
@@ -394,7 +403,7 @@ export abstract class BaseCommand extends Command {
         Math.min(estimatedGasUsedUSD.currency.decimals, 6)
       )}`
     );
-    if(estimatedGasUsedGasToken) {
+    if (estimatedGasUsedGasToken) {
       this.logger.info(
         `Gas Used gas token: ${estimatedGasUsedGasToken.toFixed(
           Math.min(estimatedGasUsedGasToken.currency.decimals, 6)


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Resolves an issue where routes do not work with Cli.
- **What is the current behavior?** (You can also link to an open issue here)
v4PoolProvider is not defined in `base-commnad.ts`.
- **What is the new behavior (if this is a feature change)?**
It works by newly defining v4PoolProvider and passing it as an argument to the necessary functions.
- **Other information**:
