### PR TITLE
chore: bump router-sdk to 1.11.2 and use TPool from router-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.13.0",
         "@uniswap/permit2-sdk": "^1.3.0",
-        "@uniswap/router-sdk": "^1.10.0",
+        "@uniswap/router-sdk": "^1.11.2",
         "@uniswap/sdk-core": "^5.3.0",
         "@uniswap/swap-router-contracts": "^1.3.1",
         "@uniswap/token-lists": "^1.0.0-beta.31",
@@ -3297,9 +3297,9 @@
       }
     },
     "node_modules/@uniswap/router-sdk": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/router-sdk/-/router-sdk-1.10.0.tgz",
-      "integrity": "sha512-XKDc46DDVqFOGwDqUFe6QkQMUue3FNsycxwKrbtBXbfw8eDpWrXIi7XpYF+5C/RI8TeRDpRvzorToJTw4DvaIA==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/router-sdk/-/router-sdk-1.11.2.tgz",
+      "integrity": "sha512-mHTzODhbGCEpKXlS0FI+rm3IdU1YAz+WSnwHJk1eAWzaanCIvU7UDGFEtjg2d+MztrfX7CjUvSjZS53cQX9A0g==",
       "dependencies": {
         "@ethersproject/abi": "^5.5.0",
         "@uniswap/sdk-core": "^5.3.1",
@@ -14665,9 +14665,9 @@
       }
     },
     "@uniswap/router-sdk": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/router-sdk/-/router-sdk-1.10.0.tgz",
-      "integrity": "sha512-XKDc46DDVqFOGwDqUFe6QkQMUue3FNsycxwKrbtBXbfw8eDpWrXIi7XpYF+5C/RI8TeRDpRvzorToJTw4DvaIA==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/router-sdk/-/router-sdk-1.11.2.tgz",
+      "integrity": "sha512-mHTzODhbGCEpKXlS0FI+rm3IdU1YAz+WSnwHJk1eAWzaanCIvU7UDGFEtjg2d+MztrfX7CjUvSjZS53cQX9A0g==",
       "requires": {
         "@ethersproject/abi": "^5.5.0",
         "@uniswap/sdk-core": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/brotli": "^1.3.4",
     "@uniswap/default-token-list": "^11.13.0",
     "@uniswap/permit2-sdk": "^1.3.0",
-    "@uniswap/router-sdk": "^1.10.0",
+    "@uniswap/router-sdk": "^1.11.2",
     "@uniswap/sdk-core": "^5.3.0",
     "@uniswap/swap-router-contracts": "^1.3.1",
     "@uniswap/token-lists": "^1.0.0-beta.31",

--- a/src/routers/alpha-router/functions/compute-all-routes.ts
+++ b/src/routers/alpha-router/functions/compute-all-routes.ts
@@ -3,6 +3,7 @@ import { Pair } from '@uniswap/v2-sdk';
 import { Pool as V3Pool } from '@uniswap/v3-sdk';
 import { Pool as V4Pool } from '@uniswap/v4-sdk';
 
+import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 import { log } from '../../../util/log';
 import { poolToString, routeToString } from '../../../util/routes';
 import {
@@ -12,7 +13,6 @@ import {
   V3Route,
   V4Route,
 } from '../../router';
-import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 
 export function computeAllV4Routes(
   tokenIn: Currency,

--- a/src/routers/alpha-router/functions/compute-all-routes.ts
+++ b/src/routers/alpha-router/functions/compute-all-routes.ts
@@ -12,6 +12,7 @@ import {
   V3Route,
   V4Route,
 } from '../../router';
+import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 
 export function computeAllV4Routes(
   tokenIn: Currency,
@@ -68,13 +69,13 @@ export function computeAllV2Routes(
 export function computeAllMixedRoutes(
   tokenIn: Token,
   tokenOut: Token,
-  parts: (V4Pool | V3Pool | Pair)[],
+  parts: TPool[],
   maxHops: number
 ): MixedRoute[] {
-  const routesRaw = computeAllRoutes<V4Pool | V3Pool | Pair, MixedRoute>(
+  const routesRaw = computeAllRoutes<TPool, MixedRoute>(
     tokenIn,
     tokenOut,
-    (route: (V4Pool | V3Pool | Pair)[], tokenIn: Token, tokenOut: Token) => {
+    (route: TPool[], tokenIn: Token, tokenOut: Token) => {
       return new MixedRoute(route, tokenIn, tokenOut);
     },
     parts,
@@ -91,13 +92,13 @@ export function computeAllMixedRoutes(
 }
 
 export function computeAllRoutes<
-  TPool extends Pair | V3Pool | V4Pool,
+  TypePool extends TPool,
   TRoute extends SupportedRoutes
 >(
   tokenIn: Token,
   tokenOut: Token,
-  buildRoute: (route: TPool[], tokenIn: Token, tokenOut: Token) => TRoute,
-  pools: TPool[],
+  buildRoute: (route: TypePool[], tokenIn: Token, tokenOut: Token) => TRoute,
+  pools: TypePool[],
   maxHops: number
 ): TRoute[] {
   const poolsUsed = Array<boolean>(pools.length).fill(false);
@@ -106,7 +107,7 @@ export function computeAllRoutes<
   const computeRoutes = (
     tokenIn: Token,
     tokenOut: Token,
-    currentRoute: TPool[],
+    currentRoute: TypePool[],
     poolsUsed: boolean[],
     tokensVisited: Set<string>,
     _previousTokenOut?: Token

--- a/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
@@ -28,6 +28,7 @@ import {
   BASE_SWAP_COST as BASE_SWAP_COST_V2,
   COST_PER_EXTRA_HOP as COST_PER_EXTRA_HOP_V2,
 } from '../v2/v2-heuristic-gas-model';
+import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 
 /**
  * Computes a gas estimate for a mixed route swap using heuristics.
@@ -186,7 +187,7 @@ export class MixedRouteHeuristicGasModelFactory extends IOnChainGasModelFactory<
     const route = routeWithValidQuote.route;
 
     const res = partitionMixedRouteByProtocol(route);
-    res.map((section: (Pair | V3Pool | V4Pool)[]) => {
+    res.map((section: TPool[]) => {
       if (section.every((pool) => pool instanceof V3Pool)) {
         baseGasUse = baseGasUse.add(BASE_SWAP_COST(chainId));
         baseGasUse = baseGasUse.add(COST_PER_HOP(chainId).mul(section.length));

--- a/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/mixedRoute/mixed-route-heuristic-gas-model.ts
@@ -6,6 +6,7 @@ import { Pool as V3Pool } from '@uniswap/v3-sdk';
 import { Pool as V4Pool } from '@uniswap/v4-sdk';
 import JSBI from 'jsbi';
 
+import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 import { WRAPPED_NATIVE_CURRENCY } from '../../../..';
 import { log } from '../../../../util';
 import { CurrencyAmount } from '../../../../util/amounts';
@@ -28,7 +29,6 @@ import {
   BASE_SWAP_COST as BASE_SWAP_COST_V2,
   COST_PER_EXTRA_HOP as COST_PER_EXTRA_HOP_V2,
 } from '../v2/v2-heuristic-gas-model';
-import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 
 /**
  * Computes a gas estimate for a mixed route swap using heuristics.

--- a/src/routers/alpha-router/quoters/base-quoter.ts
+++ b/src/routers/alpha-router/quoters/base-quoter.ts
@@ -1,9 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Protocol } from '@uniswap/router-sdk';
 import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
-import { Pair } from '@uniswap/v2-sdk';
-import { Pool as V3Pool } from '@uniswap/v3-sdk';
-import { Pool as V4Pool } from '@uniswap/v4-sdk';
 import _ from 'lodash';
 
 import {
@@ -31,8 +28,8 @@ import {
 } from '../functions/get-candidate-pools';
 import { IGasModel } from '../gas-models';
 
-import { GetQuotesResult, GetRoutesResult } from './model/results';
 import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
+import { GetQuotesResult, GetRoutesResult } from './model/results';
 
 /**
  * Interface for a Quoter.

--- a/src/routers/alpha-router/quoters/base-quoter.ts
+++ b/src/routers/alpha-router/quoters/base-quoter.ts
@@ -32,6 +32,7 @@ import {
 import { IGasModel } from '../gas-models';
 
 import { GetQuotesResult, GetRoutesResult } from './model/results';
+import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 
 /**
  * Interface for a Quoter.
@@ -186,7 +187,7 @@ export abstract class BaseQuoter<
     });
   }
 
-  protected async applyTokenValidatorToPools<T extends V4Pool | V3Pool | Pair>(
+  protected async applyTokenValidatorToPools<T extends TPool>(
     pools: T[],
     isInvalidFn: (
       token: Currency,

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -1,9 +1,9 @@
 import { ADDRESS_ZERO, Protocol } from '@uniswap/router-sdk';
 import { Currency, Percent } from '@uniswap/sdk-core';
-import _ from 'lodash';
 import { Pair } from '@uniswap/v2-sdk';
 import { Pool as V3Pool } from '@uniswap/v3-sdk';
 import { Pool as V4Pool } from '@uniswap/v4-sdk';
+import _ from 'lodash';
 
 import {
   AlphaRouterConfig,
@@ -13,9 +13,9 @@ import { MixedRoute, SupportedRoutes } from '../routers/router';
 
 import { V3_CORE_FACTORY_ADDRESSES } from './addresses';
 
+import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 import { CurrencyAmount } from '.';
 import { CachedRoutes } from '../providers';
-import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 
 export const routeToTokens = (route: SupportedRoutes): Currency[] => {
   switch (route.protocol) {
@@ -31,9 +31,7 @@ export const routeToTokens = (route: SupportedRoutes): Currency[] => {
   }
 };
 
-export const routeToPools = (
-  route: SupportedRoutes
-): TPool[] => {
+export const routeToPools = (route: SupportedRoutes): TPool[] => {
   switch (route.protocol) {
     case Protocol.V4:
     case Protocol.V3:
@@ -181,10 +179,7 @@ export function excludeProtocolPoolRouteFromMixedRoute(
   return mixedRoutes.filter((route) => {
     return (
       route.pools.filter((pool) => {
-        return poolIsInExcludedProtocols(
-          pool,
-          excludedProtocolsFromMixed
-        );
+        return poolIsInExcludedProtocols(pool, excludedProtocolsFromMixed);
       }).length == 0
     );
   });

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -1,9 +1,9 @@
 import { ADDRESS_ZERO, Protocol } from '@uniswap/router-sdk';
 import { Currency, Percent } from '@uniswap/sdk-core';
+import _ from 'lodash';
 import { Pair } from '@uniswap/v2-sdk';
 import { Pool as V3Pool } from '@uniswap/v3-sdk';
 import { Pool as V4Pool } from '@uniswap/v4-sdk';
-import _ from 'lodash';
 
 import {
   AlphaRouterConfig,
@@ -15,6 +15,7 @@ import { V3_CORE_FACTORY_ADDRESSES } from './addresses';
 
 import { CurrencyAmount } from '.';
 import { CachedRoutes } from '../providers';
+import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 
 export const routeToTokens = (route: SupportedRoutes): Currency[] => {
   switch (route.protocol) {
@@ -32,12 +33,12 @@ export const routeToTokens = (route: SupportedRoutes): Currency[] => {
 
 export const routeToPools = (
   route: SupportedRoutes
-): (V4Pool | V3Pool | Pair)[] => {
+): TPool[] => {
   switch (route.protocol) {
     case Protocol.V4:
     case Protocol.V3:
     case Protocol.MIXED:
-      return route.pools as (V4Pool | V3Pool | Pair)[];
+      return route.pools;
     case Protocol.V2:
       return route.pairs;
     default:
@@ -45,7 +46,7 @@ export const routeToPools = (
   }
 };
 
-export const poolToString = (pool: V4Pool | V3Pool | Pair): string => {
+export const poolToString = (pool: TPool): string => {
   if (pool instanceof V4Pool) {
     return ` -- ${pool.fee / 10000}% [${V4Pool.getPoolId(
       pool.token0,
@@ -160,7 +161,7 @@ export function shouldWipeoutCachedRoutes(
         return (
           (route.route as MixedRoute).pools.filter((pool) => {
             return poolIsInExcludedProtocols(
-              pool as V4Pool | V3Pool | Pair,
+              pool,
               routingConfig?.excludedProtocolsFromMixed
             );
           }).length > 0
@@ -181,7 +182,7 @@ export function excludeProtocolPoolRouteFromMixedRoute(
     return (
       route.pools.filter((pool) => {
         return poolIsInExcludedProtocols(
-          pool as V4Pool | V3Pool | Pair,
+          pool,
           excludedProtocolsFromMixed
         );
       }).length == 0
@@ -190,7 +191,7 @@ export function excludeProtocolPoolRouteFromMixedRoute(
 }
 
 function poolIsInExcludedProtocols(
-  pool: V4Pool | V3Pool | Pair,
+  pool: TPool,
   excludedProtocolsFromMixed?: Protocol[]
 ): boolean {
   if (pool instanceof V4Pool) {

--- a/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
@@ -37,6 +37,7 @@ import {
   getMockedV3PoolProvider,
 } from './test-util/mocked-dependencies';
 import { getPools } from './test-util/helpers';
+import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 
 describe('mixed route gas model tests', () => {
   const gasPriceWei = BigNumber.from(1000000000);
@@ -53,7 +54,7 @@ describe('mixed route gas model tests', () => {
     const route = routeWithValidQuote.route;
 
     const res = partitionMixedRouteByProtocol(route);
-    res.map((section: (Pair | V3Pool | V4Pool)[]) => {
+    res.map((section: TPool[]) => {
       if (section.every((pool) => pool instanceof V3Pool)) {
         baseGasUse = baseGasUse.add(BASE_SWAP_COST(chainId));
         baseGasUse = baseGasUse.add(COST_PER_HOP(chainId).mul(section.length));


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Chore

- **What is the current behavior?** (You can also link to an open issue here)
We don't use TPool from router-sdk. As a result, we have repeated TPool type across SOR code.

- **What is the new behavior (if this is a feature change)?**
We use TPool from router-sdk

- **Other information**:
