### PR TITLE
feat: convert token properties provider to accept currency instead of token

### DIFF
--- a/src/providers/token-properties-provider.ts
+++ b/src/providers/token-properties-provider.ts
@@ -202,7 +202,7 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
     for (const currency of currencies) {
       const addressCacheKey = this.CACHE_KEY(
         this.chainId,
-        getAddress(currency).toLowerCase()
+        getAddress(currency)
       );
       if (!addressesCacheKeys.has(addressCacheKey)) {
         addressesCacheKeys.add(addressCacheKey);

--- a/src/providers/token-properties-provider.ts
+++ b/src/providers/token-properties-provider.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
-import { ChainId, Token } from '@uniswap/sdk-core';
+import { ChainId, Currency } from '@uniswap/sdk-core';
 
-import { log, metric, MetricLoggerUnit } from '../util';
+import { getAddress, log, metric, MetricLoggerUnit } from '../util';
 
 import { ICache } from './cache';
 import { ProviderConfig } from './provider';
@@ -31,7 +31,7 @@ export type TokenPropertiesMap = Record<Address, TokenPropertiesResult>;
 
 export interface ITokenPropertiesProvider {
   getTokensProperties(
-    tokens: Token[],
+    currencies: Currency[],
     providerConfig?: ProviderConfig
   ): Promise<TokenPropertiesMap>;
 }
@@ -50,7 +50,7 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
   ) {}
 
   public async getTokensProperties(
-    tokens: Token[],
+    currencies: Currency[],
     providerConfig?: ProviderConfig
   ): Promise<TokenPropertiesMap> {
     const tokenToResult: TokenPropertiesMap = {};
@@ -60,8 +60,8 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
     }
 
     const addressesToFetchFeesOnchain: string[] = [];
-    const addressesRaw = this.buildAddressesRaw(tokens);
-    const addressesCacheKeys = this.buildAddressesCacheKeys(tokens);
+    const addressesRaw = this.buildAddressesRaw(currencies);
+    const addressesCacheKeys = this.buildAddressesCacheKeys(currencies);
 
     const tokenProperties = await this.tokenPropertiesCache.batchGet(
       addressesCacheKeys
@@ -183,11 +183,11 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
     return tokenToResult;
   }
 
-  private buildAddressesRaw(tokens: Token[]): Set<string> {
+  private buildAddressesRaw(currencies: Currency[]): Set<string> {
     const addressesRaw = new Set<string>();
 
-    for (const token of tokens) {
-      const address = token.address.toLowerCase();
+    for (const currency of currencies) {
+      const address = getAddress(currency);
       if (!addressesRaw.has(address)) {
         addressesRaw.add(address);
       }
@@ -196,13 +196,13 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
     return addressesRaw;
   }
 
-  private buildAddressesCacheKeys(tokens: Token[]): Set<string> {
+  private buildAddressesCacheKeys(currencies: Currency[]): Set<string> {
     const addressesCacheKeys = new Set<string>();
 
-    for (const token of tokens) {
+    for (const currency of currencies) {
       const addressCacheKey = this.CACHE_KEY(
         this.chainId,
-        token.address.toLowerCase()
+        getAddress(currency).toLowerCase()
       );
       if (!addressesCacheKeys.has(addressCacheKey)) {
         addressesCacheKeys.add(addressCacheKey);

--- a/src/providers/v2/pool-provider.ts
+++ b/src/providers/v2/pool-provider.ts
@@ -134,7 +134,10 @@ export class V2PoolProvider implements IV2PoolProvider {
         'getReserves',
         providerConfig
       ),
-      this.tokenPropertiesProvider.getTokensProperties(this.flatten(tokenPairs), providerConfig),
+      this.tokenPropertiesProvider.getTokensProperties(
+        this.flatten(tokenPairs),
+        providerConfig
+      ),
     ]);
 
     log.info(

--- a/src/providers/v2/pool-provider.ts
+++ b/src/providers/v2/pool-provider.ts
@@ -134,10 +134,7 @@ export class V2PoolProvider implements IV2PoolProvider {
         'getReserves',
         providerConfig
       ),
-      this.tokenPropertiesProvider.getTokensProperties(
-        this.flatten(tokenPairs),
-        providerConfig
-      ),
+      this.tokenPropertiesProvider.getTokensProperties(this.flatten(tokenPairs), providerConfig),
     ]);
 
     log.info(

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1215,10 +1215,10 @@ export class AlphaRouter
       );
 
     const feeTakenOnTransfer =
-      tokenOutProperties[getAddress(currencyOut).toLowerCase()]?.tokenFeeResult
+      tokenOutProperties[getAddress(currencyOut)]?.tokenFeeResult
         ?.feeTakenOnTransfer;
     const externalTransferFailed =
-      tokenOutProperties[getAddress(currencyOut).toLowerCase()]?.tokenFeeResult
+      tokenOutProperties[getAddress(currencyOut)]?.tokenFeeResult
         ?.externalTransferFailed;
 
     // We want to log the fee on transfer output tokens that we are taking fee or not
@@ -1226,10 +1226,10 @@ export class AlphaRouter
     // We have to make sure token out is FOT with either buy/sell fee bps > 0
     if (
       tokenOutProperties[
-        getAddress(currencyOut).toLowerCase()
+        getAddress(currencyOut)
       ]?.tokenFeeResult?.buyFeeBps?.gt(0) ||
       tokenOutProperties[
-        getAddress(currencyOut).toLowerCase()
+        getAddress(currencyOut)
       ]?.tokenFeeResult?.sellFeeBps?.gt(0)
     ) {
       if (feeTakenOnTransfer || externalTransferFailed) {

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -91,7 +91,7 @@ import {
   shouldWipeoutCachedRoutes,
   SWAP_ROUTER_02_ADDRESSES,
   V4_SUPPORTED,
-  WRAPPED_NATIVE_CURRENCY
+  WRAPPED_NATIVE_CURRENCY,
 } from '../../util';
 import { CurrencyAmount } from '../../util/amounts';
 import {
@@ -1209,7 +1209,10 @@ export class AlphaRouter
     const tokenOut = currencyOut.wrapped;
 
     const tokenOutProperties =
-      await this.tokenPropertiesProvider.getTokensProperties([currencyOut], partialRoutingConfig);
+      await this.tokenPropertiesProvider.getTokensProperties(
+        [currencyOut],
+        partialRoutingConfig
+      );
 
     const feeTakenOnTransfer =
       tokenOutProperties[getAddress(currencyOut).toLowerCase()]?.tokenFeeResult
@@ -1223,10 +1226,10 @@ export class AlphaRouter
     // We have to make sure token out is FOT with either buy/sell fee bps > 0
     if (
       tokenOutProperties[
-        tokenOut.address.toLowerCase()
+        getAddress(currencyOut).toLowerCase()
       ]?.tokenFeeResult?.buyFeeBps?.gt(0) ||
       tokenOutProperties[
-        tokenOut.address.toLowerCase()
+        getAddress(currencyOut).toLowerCase()
       ]?.tokenFeeResult?.sellFeeBps?.gt(0)
     ) {
       if (feeTakenOnTransfer || externalTransferFailed) {
@@ -1804,7 +1807,10 @@ export class AlphaRouter
     providerConfig?: ProviderConfig
   ): Promise<BestSwapRoute | null> {
     const tokenPairProperties =
-      await this.tokenPropertiesProvider.getTokensProperties([tokenIn, tokenOut], providerConfig);
+      await this.tokenPropertiesProvider.getTokensProperties(
+        [tokenIn, tokenOut],
+        providerConfig
+      );
 
     const sellTokenIsFot =
       tokenPairProperties[
@@ -2040,7 +2046,10 @@ export class AlphaRouter
     providerConfig?: ProviderConfig
   ): Promise<BestSwapRoute | null> {
     const tokenPairProperties =
-      await this.tokenPropertiesProvider.getTokensProperties([tokenIn, tokenOut], providerConfig);
+      await this.tokenPropertiesProvider.getTokensProperties(
+        [tokenIn, tokenOut],
+        providerConfig
+      );
 
     const sellTokenIsFot =
       tokenPairProperties[

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -87,10 +87,11 @@ import {
 import { IV3SubgraphProvider } from '../../providers/v3/subgraph-provider';
 import { Erc20__factory } from '../../types/other/factories/Erc20__factory';
 import {
+  getAddress,
   shouldWipeoutCachedRoutes,
   SWAP_ROUTER_02_ADDRESSES,
   V4_SUPPORTED,
-  WRAPPED_NATIVE_CURRENCY,
+  WRAPPED_NATIVE_CURRENCY
 } from '../../util';
 import { CurrencyAmount } from '../../util/amounts';
 import {
@@ -1208,16 +1209,13 @@ export class AlphaRouter
     const tokenOut = currencyOut.wrapped;
 
     const tokenOutProperties =
-      await this.tokenPropertiesProvider.getTokensProperties(
-        [tokenOut],
-        partialRoutingConfig
-      );
+      await this.tokenPropertiesProvider.getTokensProperties([currencyOut], partialRoutingConfig);
 
     const feeTakenOnTransfer =
-      tokenOutProperties[tokenOut.address.toLowerCase()]?.tokenFeeResult
+      tokenOutProperties[getAddress(currencyOut).toLowerCase()]?.tokenFeeResult
         ?.feeTakenOnTransfer;
     const externalTransferFailed =
-      tokenOutProperties[tokenOut.address.toLowerCase()]?.tokenFeeResult
+      tokenOutProperties[getAddress(currencyOut).toLowerCase()]?.tokenFeeResult
         ?.externalTransferFailed;
 
     // We want to log the fee on transfer output tokens that we are taking fee or not
@@ -1806,10 +1804,7 @@ export class AlphaRouter
     providerConfig?: ProviderConfig
   ): Promise<BestSwapRoute | null> {
     const tokenPairProperties =
-      await this.tokenPropertiesProvider.getTokensProperties(
-        [tokenIn, tokenOut],
-        providerConfig
-      );
+      await this.tokenPropertiesProvider.getTokensProperties([tokenIn, tokenOut], providerConfig);
 
     const sellTokenIsFot =
       tokenPairProperties[
@@ -2045,10 +2040,7 @@ export class AlphaRouter
     providerConfig?: ProviderConfig
   ): Promise<BestSwapRoute | null> {
     const tokenPairProperties =
-      await this.tokenPropertiesProvider.getTokensProperties(
-        [tokenIn, tokenOut],
-        providerConfig
-      );
+      await this.tokenPropertiesProvider.getTokensProperties([tokenIn, tokenOut], providerConfig);
 
     const sellTokenIsFot =
       tokenPairProperties[

--- a/src/util/addresses.ts
+++ b/src/util/addresses.ts
@@ -1,13 +1,14 @@
 import {
   ChainId,
   CHAIN_TO_ADDRESSES_MAP,
+  Currency,
   SWAP_ROUTER_02_ADDRESSES as SWAP_ROUTER_02_ADDRESSES_HELPER,
-  Token, Currency
+  Token,
 } from '@uniswap/sdk-core';
 import { FACTORY_ADDRESS } from '@uniswap/v3-sdk';
 
-import { NETWORKS_WITH_SAME_UNISWAP_ADDRESSES } from './chains';
 import { ADDRESS_ZERO } from '@uniswap/router-sdk';
+import { NETWORKS_WITH_SAME_UNISWAP_ADDRESSES } from './chains';
 
 export const BNB_TICK_LENS_ADDRESS =
   CHAIN_TO_ADDRESSES_MAP[ChainId.BNB].tickLensAddress;

--- a/src/util/addresses.ts
+++ b/src/util/addresses.ts
@@ -296,7 +296,7 @@ export const BEACON_CHAIN_DEPOSIT_ADDRESS =
 
 export function getAddress(currency: Currency): string {
   if (currency.isToken) {
-    return currency.address;
+    return currency.address.toLowerCase();
   } else {
     return ADDRESS_ZERO;
   }

--- a/src/util/addresses.ts
+++ b/src/util/addresses.ts
@@ -2,11 +2,12 @@ import {
   ChainId,
   CHAIN_TO_ADDRESSES_MAP,
   SWAP_ROUTER_02_ADDRESSES as SWAP_ROUTER_02_ADDRESSES_HELPER,
-  Token,
+  Token, Currency
 } from '@uniswap/sdk-core';
 import { FACTORY_ADDRESS } from '@uniswap/v3-sdk';
 
 import { NETWORKS_WITH_SAME_UNISWAP_ADDRESSES } from './chains';
+import { ADDRESS_ZERO } from '@uniswap/router-sdk';
 
 export const BNB_TICK_LENS_ADDRESS =
   CHAIN_TO_ADDRESSES_MAP[ChainId.BNB].tickLensAddress;
@@ -291,3 +292,11 @@ export const WETH9: {
 
 export const BEACON_CHAIN_DEPOSIT_ADDRESS =
   '0x00000000219ab540356cBB839Cbe05303d7705Fa';
+
+export function getAddress(currency: Currency): string {
+  if (currency.isToken) {
+    return currency.address;
+  } else {
+    return ADDRESS_ZERO;
+  }
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature 

- **What is the current behavior?** (You can also link to an open issue here)
token properties provider accepts token. In case of native currencies for v4 pools, we'd like to be able to accept native currency type.

- **What is the new behavior (if this is a feature change)?**
We modify token properties provider to accept currencies.

- **Other information**:
