### PR TITLE
feat: cached routes to support native currencies

### DIFF
--- a/src/providers/caching/route/model/cached-routes.ts
+++ b/src/providers/caching/route/model/cached-routes.ts
@@ -1,5 +1,5 @@
 import { Protocol } from '@uniswap/router-sdk';
-import { ChainId, Token, TradeType } from '@uniswap/sdk-core';
+import { ChainId, Currency, TradeType } from '@uniswap/sdk-core';
 import _ from 'lodash';
 
 import { RouteWithValidQuote, SupportedRoutes } from '../../../../routers';
@@ -9,8 +9,8 @@ import { CachedRoute } from './cached-route';
 interface CachedRoutesParams {
   routes: CachedRoute<SupportedRoutes>[];
   chainId: ChainId;
-  tokenIn: Token;
-  tokenOut: Token;
+  currencyIn: Currency;
+  currencyOut: Currency;
   protocolsCovered: Protocol[];
   blockNumber: number;
   tradeType: TradeType;
@@ -27,8 +27,8 @@ interface CachedRoutesParams {
 export class CachedRoutes {
   public readonly routes: CachedRoute<SupportedRoutes>[];
   public readonly chainId: ChainId;
-  public readonly tokenIn: Token;
-  public readonly tokenOut: Token;
+  public readonly currencyIn: Currency;
+  public readonly currencyOut: Currency;
   public readonly protocolsCovered: Protocol[];
   public readonly blockNumber: number;
   public readonly tradeType: TradeType;
@@ -39,8 +39,8 @@ export class CachedRoutes {
   /**
    * @param routes
    * @param chainId
-   * @param tokenIn
-   * @param tokenOut
+   * @param currencyIn
+   * @param currencyOut
    * @param protocolsCovered
    * @param blockNumber
    * @param tradeType
@@ -50,8 +50,8 @@ export class CachedRoutes {
   constructor({
     routes,
     chainId,
-    tokenIn,
-    tokenOut,
+    currencyIn,
+    currencyOut,
     protocolsCovered,
     blockNumber,
     tradeType,
@@ -60,8 +60,8 @@ export class CachedRoutes {
   }: CachedRoutesParams) {
     this.routes = routes;
     this.chainId = chainId;
-    this.tokenIn = tokenIn;
-    this.tokenOut = tokenOut;
+    this.currencyIn = currencyIn;
+    this.currencyOut = currencyOut;
     this.protocolsCovered = protocolsCovered;
     this.blockNumber = blockNumber;
     this.tradeType = tradeType;
@@ -76,8 +76,8 @@ export class CachedRoutes {
    * @static
    * @param routes
    * @param chainId
-   * @param tokenIn
-   * @param tokenOut
+   * @param currencyIn
+   * @param currencyOut
    * @param protocolsCovered
    * @param blockNumber
    * @param tradeType
@@ -86,8 +86,8 @@ export class CachedRoutes {
   public static fromRoutesWithValidQuotes(
     routes: RouteWithValidQuote[],
     chainId: ChainId,
-    tokenIn: Token,
-    tokenOut: Token,
+    currencyIn: Currency,
+    currencyOut: Currency,
     protocolsCovered: Protocol[],
     blockNumber: number,
     tradeType: TradeType,
@@ -104,8 +104,8 @@ export class CachedRoutes {
     return new CachedRoutes({
       routes: cachedRoutes,
       chainId,
-      tokenIn,
-      tokenOut,
+      currencyIn,
+      currencyOut,
       protocolsCovered,
       blockNumber,
       tradeType,

--- a/src/providers/caching/route/route-caching-provider.ts
+++ b/src/providers/caching/route/route-caching-provider.ts
@@ -44,13 +44,7 @@ export abstract class IRouteCachingProvider {
     optimistic = false
   ): Promise<CachedRoutes | undefined> => {
     if (
-      (await this.getCacheMode(
-        chainId,
-        amount,
-        quoteToken,
-        tradeType,
-        protocols
-      )) == CacheMode.Darkmode
+      (await this.getCacheMode(chainId, amount, quoteToken, tradeType, protocols)) == CacheMode.Darkmode
     ) {
       return undefined;
     }
@@ -112,13 +106,7 @@ export abstract class IRouteCachingProvider {
         ? cachedRoutes.tokenOut
         : cachedRoutes.tokenIn;
 
-    return this.getCacheMode(
-      cachedRoutes.chainId,
-      amount,
-      quoteToken,
-      cachedRoutes.tradeType,
-      cachedRoutes.protocolsCovered
-    );
+    return this.getCacheMode(cachedRoutes.chainId, amount, quoteToken, cachedRoutes.tradeType, cachedRoutes.protocolsCovered);
   }
 
   /**
@@ -127,15 +115,13 @@ export abstract class IRouteCachingProvider {
    * @public
    * @abstract
    * @param chainId
-   * @param tokenIn
-   * @param tokenOut
-   * @param tradeType
    * @param amount
+   * @param tradeType
    */
   public abstract getCacheMode(
     chainId: ChainId,
     amount: CurrencyAmount<Currency>,
-    quoteToken: Token,
+    quoteCurrency: Currency,
     tradeType: TradeType,
     protocols: Protocol[]
   ): Promise<CacheMode>;

--- a/src/providers/caching/route/route-caching-provider.ts
+++ b/src/providers/caching/route/route-caching-provider.ts
@@ -1,5 +1,5 @@
 /**
- * Provider for getting token data from a Token List.
+ * Provider for getting currency data from a currency List.
  *
  * @export
  * @interface IRouteCachingProvider
@@ -9,7 +9,6 @@ import {
   ChainId,
   Currency,
   CurrencyAmount,
-  Token,
   TradeType,
 } from '@uniswap/sdk-core';
 
@@ -28,7 +27,7 @@ export abstract class IRouteCachingProvider {
    * @readonly
    * @param chainId
    * @param amount
-   * @param quoteToken
+   * @param quoteCurrency
    * @param tradeType
    * @param protocols
    * @param blockNumber
@@ -37,14 +36,20 @@ export abstract class IRouteCachingProvider {
     // Defined as a readonly member instead of a regular function to make it final.
     chainId: number,
     amount: CurrencyAmount<Currency>,
-    quoteToken: Token,
+    quoteCurrency: Currency,
     tradeType: TradeType,
     protocols: Protocol[],
     blockNumber: number,
     optimistic = false
   ): Promise<CachedRoutes | undefined> => {
     if (
-      (await this.getCacheMode(chainId, amount, quoteToken, tradeType, protocols)) == CacheMode.Darkmode
+      (await this.getCacheMode(
+        chainId,
+        amount,
+        quoteCurrency,
+        tradeType,
+        protocols
+      )) == CacheMode.Darkmode
     ) {
       return undefined;
     }
@@ -52,7 +57,7 @@ export abstract class IRouteCachingProvider {
     const cachedRoute = await this._getCachedRoute(
       chainId,
       amount,
-      quoteToken,
+      quoteCurrency,
       tradeType,
       protocols,
       blockNumber,
@@ -101,16 +106,22 @@ export abstract class IRouteCachingProvider {
     cachedRoutes: CachedRoutes,
     amount: CurrencyAmount<Currency>
   ): Promise<CacheMode> {
-    const quoteToken =
+    const quoteCurrency =
       cachedRoutes.tradeType == TradeType.EXACT_INPUT
-        ? cachedRoutes.tokenOut
-        : cachedRoutes.tokenIn;
+        ? cachedRoutes.currencyOut
+        : cachedRoutes.currencyIn;
 
-    return this.getCacheMode(cachedRoutes.chainId, amount, quoteToken, cachedRoutes.tradeType, cachedRoutes.protocolsCovered);
+    return this.getCacheMode(
+      cachedRoutes.chainId,
+      amount,
+      quoteCurrency,
+      cachedRoutes.tradeType,
+      cachedRoutes.protocolsCovered
+    );
   }
 
   /**
-   * Returns the CacheMode for the given combination of chainId, tokenIn, tokenOut and tradetype
+   * Returns the CacheMode for the given combination of chainId, currencyIn, currencyOut and tradetype
    *
    * @public
    * @abstract
@@ -142,7 +153,7 @@ export abstract class IRouteCachingProvider {
    *
    * @param chainId
    * @param amount
-   * @param quoteToken
+   * @param quoteCurrency
    * @param tradeType
    * @param protocols
    * @protected
@@ -150,7 +161,7 @@ export abstract class IRouteCachingProvider {
   protected abstract _getCachedRoute(
     chainId: ChainId,
     amount: CurrencyAmount<Currency>,
-    quoteToken: Token,
+    quoteCurrency: Currency,
     tradeType: TradeType,
     protocols: Protocol[],
     currentBlockNumber: number,

--- a/src/providers/token-properties-provider.ts
+++ b/src/providers/token-properties-provider.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { ChainId, Currency } from '@uniswap/sdk-core';
 
-import { getAddress, log, metric, MetricLoggerUnit } from '../util';
+import { getAddressLowerCase, log, metric, MetricLoggerUnit } from '../util';
 
 import { ICache } from './cache';
 import { ProviderConfig } from './provider';
@@ -187,7 +187,7 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
     const addressesRaw = new Set<string>();
 
     for (const currency of currencies) {
-      const address = getAddress(currency);
+      const address = getAddressLowerCase(currency);
       if (!addressesRaw.has(address)) {
         addressesRaw.add(address);
       }
@@ -202,7 +202,7 @@ export class TokenPropertiesProvider implements ITokenPropertiesProvider {
     for (const currency of currencies) {
       const addressCacheKey = this.CACHE_KEY(
         this.chainId,
-        getAddress(currency)
+        getAddressLowerCase(currency)
       );
       if (!addressesCacheKeys.has(addressCacheKey)) {
         addressesCacheKeys.add(addressCacheKey);

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -92,7 +92,7 @@ import {
   shouldWipeoutCachedRoutes,
   SWAP_ROUTER_02_ADDRESSES,
   V4_SUPPORTED,
-  WRAPPED_NATIVE_CURRENCY
+  WRAPPED_NATIVE_CURRENCY,
 } from '../../util';
 import { CurrencyAmount } from '../../util/amounts';
 import {
@@ -1357,7 +1357,13 @@ export class AlphaRouter
 
     const cacheMode =
       routingConfig.overwriteCacheMode ??
-      (await this.routeCachingProvider?.getCacheMode(this.chainId, amount, quoteToken, tradeType, protocols));
+      (await this.routeCachingProvider?.getCacheMode(
+        this.chainId,
+        amount,
+        quoteToken,
+        tradeType,
+        protocols
+      ));
 
     // Fetch CachedRoutes
     let cachedRoutes: CachedRoutes | undefined;
@@ -1617,7 +1623,7 @@ export class AlphaRouter
         this.chainId,
         tokenIn,
         tokenOut,
-        protocols.sort(), // sort it for consistency in the order of the protocols.
+        protocols.sort(),
         await blockNumber,
         tradeType,
         amount.toExact()
@@ -1942,8 +1948,8 @@ export class AlphaRouter
       quotePromises.push(
         this.v2Quoter
           .refreshRoutesThenGetQuotes(
-            cachedRoutes.tokenIn,
-            cachedRoutes.tokenOut,
+            cachedRoutes.currencyIn.wrapped,
+            cachedRoutes.currencyOut.wrapped,
             v2RoutesFromCache,
             amounts,
             percents,

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -88,10 +88,11 @@ import { IV3SubgraphProvider } from '../../providers/v3/subgraph-provider';
 import { Erc20__factory } from '../../types/other/factories/Erc20__factory';
 import {
   getAddress,
+  getAddressLowerCase,
   shouldWipeoutCachedRoutes,
   SWAP_ROUTER_02_ADDRESSES,
   V4_SUPPORTED,
-  WRAPPED_NATIVE_CURRENCY,
+  WRAPPED_NATIVE_CURRENCY
 } from '../../util';
 import { CurrencyAmount } from '../../util/amounts';
 import {
@@ -1215,10 +1216,10 @@ export class AlphaRouter
       );
 
     const feeTakenOnTransfer =
-      tokenOutProperties[getAddress(currencyOut)]?.tokenFeeResult
+      tokenOutProperties[getAddressLowerCase(currencyOut)]?.tokenFeeResult
         ?.feeTakenOnTransfer;
     const externalTransferFailed =
-      tokenOutProperties[getAddress(currencyOut)]?.tokenFeeResult
+      tokenOutProperties[getAddressLowerCase(currencyOut)]?.tokenFeeResult
         ?.externalTransferFailed;
 
     // We want to log the fee on transfer output tokens that we are taking fee or not
@@ -1226,10 +1227,10 @@ export class AlphaRouter
     // We have to make sure token out is FOT with either buy/sell fee bps > 0
     if (
       tokenOutProperties[
-        getAddress(currencyOut)
+        getAddressLowerCase(currencyOut)
       ]?.tokenFeeResult?.buyFeeBps?.gt(0) ||
       tokenOutProperties[
-        getAddress(currencyOut)
+        getAddressLowerCase(currencyOut)
       ]?.tokenFeeResult?.sellFeeBps?.gt(0)
     ) {
       if (feeTakenOnTransfer || externalTransferFailed) {
@@ -1275,9 +1276,9 @@ export class AlphaRouter
     }
 
     metric.setProperty('chainId', this.chainId);
-    metric.setProperty('pair', `${tokenIn.symbol}/${tokenOut.symbol}`);
-    metric.setProperty('tokenIn', tokenIn.address);
-    metric.setProperty('tokenOut', tokenOut.address);
+    metric.setProperty('pair', `${currencyIn.symbol}/${currencyOut.symbol}`);
+    metric.setProperty('tokenIn', getAddress(currencyIn));
+    metric.setProperty('tokenOut', getAddress(currencyOut));
     metric.setProperty(
       'tradeType',
       tradeType === TradeType.EXACT_INPUT ? 'ExactIn' : 'ExactOut'
@@ -1356,13 +1357,7 @@ export class AlphaRouter
 
     const cacheMode =
       routingConfig.overwriteCacheMode ??
-      (await this.routeCachingProvider?.getCacheMode(
-        this.chainId,
-        amount,
-        quoteToken,
-        tradeType,
-        protocols
-      ));
+      (await this.routeCachingProvider?.getCacheMode(this.chainId, amount, quoteToken, tradeType, protocols));
 
     // Fetch CachedRoutes
     let cachedRoutes: CachedRoutes | undefined;

--- a/src/util/addresses.ts
+++ b/src/util/addresses.ts
@@ -294,9 +294,17 @@ export const WETH9: {
 export const BEACON_CHAIN_DEPOSIT_ADDRESS =
   '0x00000000219ab540356cBB839Cbe05303d7705Fa';
 
-export function getAddress(currency: Currency): string {
+export function getAddressLowerCase(currency: Currency): string {
   if (currency.isToken) {
     return currency.address.toLowerCase();
+  } else {
+    return ADDRESS_ZERO;
+  }
+}
+
+export function getAddress(currency: Currency): string {
+  if (currency.isToken) {
+    return currency.address;
   } else {
     return ADDRESS_ZERO;
   }

--- a/test/unit/providers/caching/route/model/cached-routes.test.ts
+++ b/test/unit/providers/caching/route/model/cached-routes.test.ts
@@ -13,31 +13,13 @@ describe('CachedRoutes', () => {
 
   describe('#fromRoutesWithValidQuotes', () => {
     it('creates the instance', () => {
-      const cachedRoutes = CachedRoutes.fromRoutesWithValidQuotes(
-        [v3RouteWithValidQuote],
-        ChainId.MAINNET,
-        USDC,
-        DAI,
-        [Protocol.V2, Protocol.V3, Protocol.MIXED],
-        blockNumber,
-        TradeType.EXACT_INPUT,
-        '1.1'
-      );
+      const cachedRoutes = CachedRoutes.fromRoutesWithValidQuotes([v3RouteWithValidQuote], ChainId.MAINNET, USDC, DAI, [Protocol.V2, Protocol.V3, Protocol.MIXED], blockNumber, TradeType.EXACT_INPUT, '1.1');
 
       expect(cachedRoutes).toBeInstanceOf(CachedRoutes);
     });
 
     it('returns undefined when routes are empty', () => {
-      const cachedRoutes = CachedRoutes.fromRoutesWithValidQuotes(
-        [],
-        ChainId.MAINNET,
-        USDC,
-        DAI,
-        [Protocol.V2, Protocol.V3, Protocol.MIXED],
-        blockNumber,
-        TradeType.EXACT_INPUT,
-        '1.1'
-      );
+      const cachedRoutes = CachedRoutes.fromRoutesWithValidQuotes([], ChainId.MAINNET, USDC, DAI, [Protocol.V2, Protocol.V3, Protocol.MIXED], blockNumber, TradeType.EXACT_INPUT, '1.1');
 
       expect(cachedRoutes).toBeUndefined();
     });
@@ -47,16 +29,7 @@ describe('CachedRoutes', () => {
     let cachedRoutes: CachedRoutes;
 
     beforeEach(() => {
-      cachedRoutes = CachedRoutes.fromRoutesWithValidQuotes(
-        [v3RouteWithValidQuote],
-        ChainId.MAINNET,
-        USDC,
-        DAI,
-        [Protocol.V2, Protocol.V3, Protocol.MIXED],
-        blockNumber,
-        TradeType.EXACT_INPUT,
-        '1.1'
-      )!;
+      cachedRoutes = CachedRoutes.fromRoutesWithValidQuotes([v3RouteWithValidQuote], ChainId.MAINNET, USDC, DAI, [Protocol.V2, Protocol.V3, Protocol.MIXED], blockNumber, TradeType.EXACT_INPUT, '1.1')!;
     });
 
     describe('.blocksToLive', () => {

--- a/test/unit/providers/caching/route/test-util/inmemory-route-caching-provider.ts
+++ b/test/unit/providers/caching/route/test-util/inmemory-route-caching-provider.ts
@@ -41,11 +41,11 @@ export class InMemoryRouteCachingProvider extends IRouteCachingProvider {
   }
 
   async getCacheMode(
-    _chainId: ChainId,
-    _amount: CurrencyAmount<Currency>,
-    _quoteToken: Token,
-    _tradeType: TradeType,
-    _protocols: Protocol[]
+    chainId: ChainId,
+    amount: CurrencyAmount<Currency>,
+    quoteCurrency: Currency,
+    tradeType: TradeType,
+    protocols: Protocol[]
   ): Promise<CacheMode> {
     this.getCacheModeCalls += 1;
     return this.cacheMode;

--- a/test/unit/providers/caching/route/test-util/inmemory-route-caching-provider.ts
+++ b/test/unit/providers/caching/route/test-util/inmemory-route-caching-provider.ts
@@ -1,5 +1,5 @@
 import { Protocol } from '@uniswap/router-sdk';
-import { ChainId, Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core';
+import { ChainId, Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core';
 import { CachedRoutes, CacheMode, IRouteCachingProvider } from '../../../../../../src';
 
 export class InMemoryRouteCachingProvider extends IRouteCachingProvider {
@@ -15,16 +15,16 @@ export class InMemoryRouteCachingProvider extends IRouteCachingProvider {
     return this.blocksToLive;
   }
 
-  protected async _getCachedRoute(
+  protected override async _getCachedRoute(
     chainId: ChainId,
     amount: CurrencyAmount<Currency>,
-    quoteToken: Token,
+    quoteCurrency: Currency,
     tradeType: TradeType,
     protocols: Protocol[]
   ): Promise<CachedRoutes | undefined> {
     this.internalGetCacheRouteCalls += 1;
 
-    const cacheKey = `${amount.currency.wrapped.symbol}/${quoteToken.symbol}/${chainId}/${tradeType}/${protocols.sort()}`;
+    const cacheKey = `${amount.currency.wrapped.symbol}/${quoteCurrency.symbol}/${chainId}/${tradeType}/${protocols.sort()}`;
 
     return this.routesCache.get(cacheKey);
   }
@@ -34,18 +34,18 @@ export class InMemoryRouteCachingProvider extends IRouteCachingProvider {
 
     if (this.forceFail) return false;
 
-    const cacheKey = `${cachedRoutes.tokenIn.symbol}/${cachedRoutes.tokenOut.symbol}/${cachedRoutes.chainId}/${cachedRoutes.tradeType}/${cachedRoutes.protocolsCovered.sort()}`;
+    const cacheKey = `${cachedRoutes.currencyIn.symbol}/${cachedRoutes.currencyOut.symbol}/${cachedRoutes.chainId}/${cachedRoutes.tradeType}/${cachedRoutes.protocolsCovered.sort()}`;
     this.routesCache.set(cacheKey, cachedRoutes);
 
     return true;
   }
 
   async getCacheMode(
-    chainId: ChainId,
-    amount: CurrencyAmount<Currency>,
-    quoteCurrency: Currency,
-    tradeType: TradeType,
-    protocols: Protocol[]
+    _chainId: ChainId,
+    _amount: CurrencyAmount<Currency>,
+    _quoteCurrency: Currency,
+    _tradeType: TradeType,
+    _protocols: Protocol[]
   ): Promise<CacheMode> {
     this.getCacheModeCalls += 1;
     return this.cacheMode;

--- a/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
+++ b/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
@@ -102,14 +102,5 @@ export function getMixedRouteWithValidQuoteStub(
 export function getCachedRoutesStub(
   blockNumber: number
 ): CachedRoutes | undefined {
-  return CachedRoutes.fromRoutesWithValidQuotes(
-    [getV3RouteWithValidQuoteStub()],
-    ChainId.MAINNET,
-    USDC,
-    DAI,
-    [Protocol.V2, Protocol.V3, Protocol.MIXED],
-    blockNumber,
-    TradeType.EXACT_INPUT,
-    '1.1'
-  );
+  return CachedRoutes.fromRoutesWithValidQuotes([getV3RouteWithValidQuoteStub()], ChainId.MAINNET, USDC, DAI, [Protocol.V2, Protocol.V3, Protocol.MIXED], blockNumber, TradeType.EXACT_INPUT, '1.1');
 }

--- a/test/unit/routers/alpha-router/functions/routes.test.ts
+++ b/test/unit/routers/alpha-router/functions/routes.test.ts
@@ -39,8 +39,8 @@ describe('routes', () => {
   const cachedRoutesIncludeRouteWithV4Pool = new CachedRoutes({
     routes: [cachedRoute1, cachedRoute2],
     chainId: 1,
-    tokenIn: USDC_MAINNET,
-    tokenOut: DAI_MAINNET,
+    currencyIn: USDC_MAINNET,
+    currencyOut: DAI_MAINNET,
     protocolsCovered: [Protocol.V2, Protocol.V3, Protocol.V4, Protocol.MIXED],
     blockNumber: 1,
     tradeType: TradeType.EXACT_INPUT,
@@ -51,8 +51,8 @@ describe('routes', () => {
   const cachedRoutesIncludeRouteWithoutV4Pool = new CachedRoutes({
     routes: [cachedRoute1, cachedRoute3],
     chainId: 1,
-    tokenIn: USDC_MAINNET,
-    tokenOut: DAI_MAINNET,
+    currencyIn: USDC_MAINNET,
+    currencyOut: DAI_MAINNET,
     protocolsCovered: [Protocol.V2, Protocol.V3, Protocol.V4, Protocol.MIXED],
     blockNumber: 1,
     tradeType: TradeType.EXACT_INPUT,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
cached routes do not support native currency routing

- **What is the new behavior (if this is a feature change)?**
we want cached routes to support native currency routing. This is import for v4 native currency routing support.

- **Other information**:
Although we changed the method signature to accept Currency, for now we still pass in Tokens for tokenIn and tokenOut, so that this change should still remain no-op for now.