### PR TITLE
feat: upgrade v3-sdk version + support additional fee tiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@uniswap/universal-router": "^1.6.0",
         "@uniswap/universal-router-sdk": "^3.0.2",
         "@uniswap/v2-sdk": "^4.3.2",
-        "@uniswap/v3-sdk": "^3.13.0",
+        "@uniswap/v3-sdk": "^3.14.0",
         "@uniswap/v4-sdk": "^1.0.0",
         "async-retry": "^1.3.1",
         "await-timeout": "^1.1.1",
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/@uniswap/v3-sdk": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/v3-sdk/-/v3-sdk-3.13.1.tgz",
-      "integrity": "sha512-MCc96HrUZy17DINwrGnMtCvr+yXQlWUJJVaIiRRKe1DQzSuv97/G4lzM+zAaSymrxbR2qnHHWL5vMFjmwzCN9Q==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-sdk/-/v3-sdk-3.14.0.tgz",
+      "integrity": "sha512-/fnHYnCpzp8Ruwn9/Tm2Xv2oSykNajwCRwgfdD0K/2euwdlKaNCMpGqCP1XZsugLbEEemCNjFpc3i6YAk2IdYg==",
       "dependencies": {
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/solidity": "^5.0.9",
@@ -14826,9 +14826,9 @@
       }
     },
     "@uniswap/v3-sdk": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@uniswap/v3-sdk/-/v3-sdk-3.13.1.tgz",
-      "integrity": "sha512-MCc96HrUZy17DINwrGnMtCvr+yXQlWUJJVaIiRRKe1DQzSuv97/G4lzM+zAaSymrxbR2qnHHWL5vMFjmwzCN9Q==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-sdk/-/v3-sdk-3.14.0.tgz",
+      "integrity": "sha512-/fnHYnCpzp8Ruwn9/Tm2Xv2oSykNajwCRwgfdD0K/2euwdlKaNCMpGqCP1XZsugLbEEemCNjFpc3i6YAk2IdYg==",
       "requires": {
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/solidity": "^5.0.9",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@uniswap/universal-router": "^1.6.0",
     "@uniswap/universal-router-sdk": "^3.0.2",
     "@uniswap/v2-sdk": "^4.3.2",
-    "@uniswap/v3-sdk": "^3.13.0",
+    "@uniswap/v3-sdk": "^3.14.0",
     "@uniswap/v4-sdk": "^1.0.0",
     "async-retry": "^1.3.1",
     "await-timeout": "^1.1.1",

--- a/src/providers/v3/static-subgraph-provider.ts
+++ b/src/providers/v3/static-subgraph-provider.ts
@@ -4,10 +4,7 @@ import { FeeAmount, Pool } from '@uniswap/v3-sdk';
 import JSBI from 'jsbi';
 import _ from 'lodash';
 
-import {
-  getApplicableV3FeeAmounts,
-  unparseFeeAmount,
-} from '../../util/amounts';
+import { unparseFeeAmount } from '../../util/amounts';
 import { WRAPPED_NATIVE_CURRENCY } from '../../util/chains';
 import { log } from '../../util/log';
 import { ProviderConfig } from '../provider';
@@ -227,11 +224,12 @@ export class StaticV3SubgraphProvider implements IV3SubgraphProvider {
           tokenA.address !== tokenB.address && !tokenA.equals(tokenB)
       )
       .flatMap<[Token, Token, FeeAmount]>(([tokenA, tokenB]) => {
-        const feeAmounts = getApplicableV3FeeAmounts(this.chainId);
-        const entries: [Token, Token, FeeAmount][] = feeAmounts.map(
-          (feeAmount) => [tokenA, tokenB, feeAmount]
-        );
-        return entries;
+        return [
+          [tokenA, tokenB, FeeAmount.LOWEST],
+          [tokenA, tokenB, FeeAmount.LOW],
+          [tokenA, tokenB, FeeAmount.MEDIUM],
+          [tokenA, tokenB, FeeAmount.HIGH],
+        ];
       })
       .value();
 

--- a/src/providers/v3/static-subgraph-provider.ts
+++ b/src/providers/v3/static-subgraph-provider.ts
@@ -4,7 +4,10 @@ import { FeeAmount, Pool } from '@uniswap/v3-sdk';
 import JSBI from 'jsbi';
 import _ from 'lodash';
 
-import { unparseFeeAmount } from '../../util/amounts';
+import {
+  getApplicableV3FeeAmounts,
+  unparseFeeAmount,
+} from '../../util/amounts';
 import { WRAPPED_NATIVE_CURRENCY } from '../../util/chains';
 import { log } from '../../util/log';
 import { ProviderConfig } from '../provider';
@@ -224,12 +227,11 @@ export class StaticV3SubgraphProvider implements IV3SubgraphProvider {
           tokenA.address !== tokenB.address && !tokenA.equals(tokenB)
       )
       .flatMap<[Token, Token, FeeAmount]>(([tokenA, tokenB]) => {
-        return [
-          [tokenA, tokenB, FeeAmount.LOWEST],
-          [tokenA, tokenB, FeeAmount.LOW],
-          [tokenA, tokenB, FeeAmount.MEDIUM],
-          [tokenA, tokenB, FeeAmount.HIGH],
-        ];
+        const feeAmounts = getApplicableV3FeeAmounts(this.chainId);
+        const entries: [Token, Token, FeeAmount][] = feeAmounts.map(
+          (feeAmount) => [tokenA, tokenB, feeAmount]
+        );
+        return entries;
       })
       .value();
 

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -77,7 +77,11 @@ import {
   IV3SubgraphProvider,
   V3SubgraphPool,
 } from '../../../providers/v3/subgraph-provider';
-import { unparseFeeAmount, WRAPPED_NATIVE_CURRENCY } from '../../../util';
+import {
+  getApplicableV3FeeAmounts,
+  unparseFeeAmount,
+  WRAPPED_NATIVE_CURRENCY,
+} from '../../../util';
 import { parseFeeAmount } from '../../../util/amounts';
 import { log } from '../../../util/log';
 import { metric, MetricLoggerUnit } from '../../../util/metric';
@@ -983,7 +987,7 @@ export async function getV3CandidatePools({
     // Optimistically add them into the query regardless. Invalid pools ones will be dropped anyway
     // when we query the pool on-chain. Ensures that new pools for new pairs can be swapped on immediately.
     top2DirectSwapPool = _.map(
-      [FeeAmount.HIGH, FeeAmount.MEDIUM, FeeAmount.LOW, FeeAmount.LOWEST],
+      getApplicableV3FeeAmounts(chainId),
       (feeAmount) => {
         const { token0, token1, poolAddress } = poolProvider.getPoolAddress(
           tokenIn,

--- a/src/util/amounts.ts
+++ b/src/util/amounts.ts
@@ -71,10 +71,11 @@ export function getApplicableV3FeeAmounts(chainId: ChainId): FeeAmount[] {
 
   if (chainId === ChainId.BASE) {
     // TODO: enable new entries once https://github.com/Uniswap/sdks/pull/99 is in
-    // feeAmounts.push(FeeAmount.LOW_200);
-    // feeAmounts.push(FeeAmount.LOW_300);
-    // feeAmounts.push(FeeAmount.LOW_400);
-    // feeAmounts.push(FeeAmount.LOW);
+    // feeAmounts.push(
+    //   FeeAmount.LOW_200,
+    //   FeeAmount.LOW_300,
+    //   FeeAmount.LOW_400
+    // );
   }
 
   return feeAmounts;

--- a/src/util/amounts.ts
+++ b/src/util/amounts.ts
@@ -25,13 +25,12 @@ export function parseFeeAmount(feeAmountStr: string) {
       return FeeAmount.MEDIUM;
     case '500':
       return FeeAmount.LOW;
-    // TODO: enable new entries once https://github.com/Uniswap/sdks/pull/99 is in
-    // case '400':
-    //   return FeeAmount.LOW_400;
-    //  case '300':
-    //   return FeeAmount.LOW_300;
-    // case '200':
-    //   return FeeAmount.LOW_200;
+    case '400':
+      return FeeAmount.LOW_400;
+    case '300':
+      return FeeAmount.LOW_300;
+    case '200':
+      return FeeAmount.LOW_200;
     case '100':
       return FeeAmount.LOWEST;
     default:
@@ -47,13 +46,12 @@ export function unparseFeeAmount(feeAmount: FeeAmount) {
       return '3000';
     case FeeAmount.LOW:
       return '500';
-    // TODO: enable new entries once https://github.com/Uniswap/sdks/pull/99 is in
-    // case FeeAmount.LOW_400:
-    //   return '400';
-    // case FeeAmount.LOW_300:
-    //   return '300';
-    // case FeeAmount.LOW_200:
-    //   return '200';
+    case FeeAmount.LOW_400:
+      return '400';
+    case FeeAmount.LOW_300:
+      return '300';
+    case FeeAmount.LOW_200:
+      return '200';
     case FeeAmount.LOWEST:
       return '100';
     default:
@@ -70,12 +68,7 @@ export function getApplicableV3FeeAmounts(chainId: ChainId): FeeAmount[] {
   ];
 
   if (chainId === ChainId.BASE) {
-    // TODO: enable new entries once https://github.com/Uniswap/sdks/pull/99 is in
-    // feeAmounts.push(
-    //   FeeAmount.LOW_200,
-    //   FeeAmount.LOW_300,
-    //   FeeAmount.LOW_400
-    // );
+    feeAmounts.push(FeeAmount.LOW_200, FeeAmount.LOW_300, FeeAmount.LOW_400);
   }
 
   return feeAmounts;

--- a/src/util/amounts.ts
+++ b/src/util/amounts.ts
@@ -1,5 +1,6 @@
 import { parseUnits } from '@ethersproject/units';
 import {
+  ChainId,
   Currency,
   CurrencyAmount as CurrencyAmountRaw,
 } from '@uniswap/sdk-core';
@@ -24,6 +25,13 @@ export function parseFeeAmount(feeAmountStr: string) {
       return FeeAmount.MEDIUM;
     case '500':
       return FeeAmount.LOW;
+    // TODO: enable new entries once https://github.com/Uniswap/sdks/pull/99 is in
+    // case '400':
+    //   return FeeAmount.LOW_400;
+    //  case '300':
+    //   return FeeAmount.LOW_300;
+    // case '200':
+    //   return FeeAmount.LOW_200;
     case '100':
       return FeeAmount.LOWEST;
     default:
@@ -39,9 +47,35 @@ export function unparseFeeAmount(feeAmount: FeeAmount) {
       return '3000';
     case FeeAmount.LOW:
       return '500';
+    // TODO: enable new entries once https://github.com/Uniswap/sdks/pull/99 is in
+    // case FeeAmount.LOW_400:
+    //   return '400';
+    // case FeeAmount.LOW_300:
+    //   return '300';
+    // case FeeAmount.LOW_200:
+    //   return '200';
     case FeeAmount.LOWEST:
       return '100';
     default:
       throw new Error(`Fee amount ${feeAmount} not supported.`);
   }
+}
+
+export function getApplicableV3FeeAmounts(chainId: ChainId): FeeAmount[] {
+  const feeAmounts = [
+    FeeAmount.HIGH,
+    FeeAmount.MEDIUM,
+    FeeAmount.LOW,
+    FeeAmount.LOWEST,
+  ];
+
+  if (chainId === ChainId.BASE) {
+    // TODO: enable new entries once https://github.com/Uniswap/sdks/pull/99 is in
+    // feeAmounts.push(FeeAmount.LOW_200);
+    // feeAmounts.push(FeeAmount.LOW_300);
+    // feeAmounts.push(FeeAmount.LOW_400);
+    // feeAmounts.push(FeeAmount.LOW);
+  }
+
+  return feeAmounts;
 }

--- a/test/test-util/mock-data.ts
+++ b/test/test-util/mock-data.ts
@@ -231,6 +231,14 @@ export const USDC_DAI_LOW = new V3Pool(
   10,
   0
 );
+export const USDC_DAI_LOW_200 = new V3Pool(
+  USDC,
+  DAI,
+  FeeAmount.LOW_200,
+  encodeSqrtRatioX96(1, 1),
+  10,
+  0
+);
 export const USDC_DAI_MEDIUM = new V3Pool(
   USDC,
   DAI,

--- a/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
+++ b/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
@@ -233,36 +233,6 @@ describe('get candidate pools', () => {
       }
     });
 
-
-    test(`succeeds to get top pools by liquidity for protocol ${protocol} (including LOW_200)`, async () => {
-      if (protocol === Protocol.V3) {
-        await getV3CandidatePools({
-          tokenIn: USDC,
-          tokenOut: DAI,
-          routeType: TradeType.EXACT_INPUT,
-          routingConfig: {
-            ...ROUTING_CONFIG,
-            v3PoolSelection: {
-              ...ROUTING_CONFIG.v3PoolSelection,
-              topN: 2,
-            },
-          },
-          poolProvider: mockV3PoolProvider,
-          subgraphProvider: mockV3SubgraphProvider,
-          tokenProvider: mockTokenProvider,
-          blockedTokenListProvider: mockBlockTokenListProvider,
-          chainId: ChainId.MAINNET,
-        });
-
-        expect(
-          mockV3PoolProvider.getPools.calledWithExactly([
-            [USDC, WRAPPED_NATIVE_CURRENCY[1]!, FeeAmount.LOW],
-            [WRAPPED_NATIVE_CURRENCY[1]!, USDT, FeeAmount.LOW],
-          ], { blockNumber: undefined })
-        ).toBeTruthy();
-      }
-    });
-
     test(`succeeds to get top pools directly swapping token in for token out for protocol ${protocol}`, async () => {
       if (protocol === Protocol.V3) {
         await getV3CandidatePools({

--- a/test/unit/util/amount.test.ts
+++ b/test/unit/util/amount.test.ts
@@ -1,0 +1,21 @@
+import { ChainId } from '@uniswap/sdk-core';
+import { FeeAmount } from '@uniswap/v3-sdk';
+import { parseFeeAmount } from '../../../build/main';
+import { getApplicableV3FeeAmounts, unparseFeeAmount } from '../../../src';
+
+describe('amount', () => {
+  it('validate FeeAmount enum helpers', async () => {
+    // Check that all enumes can be unparsed and parsed.
+    const feeAmountValues = Object.values(FeeAmount).filter(value => typeof value === 'number');
+    for (const feeAmount of feeAmountValues) {
+      const feeAmountStr = unparseFeeAmount(feeAmount as FeeAmount);
+      expect(feeAmountStr).toBeDefined();
+      const feeAmountParsed = parseFeeAmount(feeAmountStr);
+      expect(feeAmountParsed).toBeDefined();
+    }
+
+    // Check that we get expected fee amounts lists lengths
+    expect(getApplicableV3FeeAmounts(ChainId.MAINNET).length).toEqual(4);
+    expect(getApplicableV3FeeAmounts(ChainId.BASE).length).toEqual(7);
+  });
+});


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Upgrades to latest v3-sdk
Adding support for additional fee tiers
Those tiers will be supported for all chains if returned in subgraph, but they will be added by default only for Base.

- **What is the current behavior?** (You can also link to an open issue here)
Supporting 4 fee tiers

- **What is the new behavior (if this is a feature change)?**
Supporting 3 additional fee tiers

- **Other information**:
See related [v3-sdk PR](https://github.com/Uniswap/sdks/pull/99)