### PR TITLE
chore(sor): bump version to 3.55 - base additional fee tiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.54.0",
+  "version": "3.55.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "3.54.0",
+      "version": "3.55.0",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "3.54.0",
+  "version": "3.55.0",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bumps sor version to include https://github.com/Uniswap/smart-order-router/pull/704

- **What is the current behavior?** (You can also link to an open issue here)
4 fee tiers supported

- **What is the new behavior (if this is a feature change)?**
3 additional fee tiers introduced

- **Other information**:
