### PR TITLE
chore: update v4 quoter address and ABI

### DIFF
--- a/src/abis/v4-periphery/V4Quoter.sol/V4Quoter.json
+++ b/src/abis/v4-periphery/V4Quoter.sol/V4Quoter.json
@@ -1,303 +1,4 @@
 [
-
-  {
-    "type":"constructor",
-    "inputs":[
-      {
-        "name":"_poolManager",
-        "type":"address",
-        "internalType":"contract IPoolManager"
-      }
-    ],
-    "stateMutability":"nonpayable"
-  },
-  {
-    "type":"function",
-    "name":"_quoteExactInput",
-    "inputs":[
-      {
-        "name":"params",
-        "type":"tuple",
-        "internalType":"struct IQuoter.QuoteExactParams",
-        "components":[
-          {
-            "name":"exactCurrency",
-            "type":"address",
-            "internalType":"Currency"
-          },
-          {
-            "name":"path",
-            "type":"tuple[]",
-            "internalType":"struct PathKey[]",
-            "components":[
-              {
-                "name":"intermediateCurrency",
-                "type":"address",
-                "internalType":"Currency"
-              },
-              {
-                "name":"fee",
-                "type":"uint24",
-                "internalType":"uint24"
-              },
-              {
-                "name":"tickSpacing",
-                "type":"int24",
-                "internalType":"int24"
-              },
-              {
-                "name":"hooks",
-                "type":"address",
-                "internalType":"contract IHooks"
-              },
-              {
-                "name":"hookData",
-                "type":"bytes",
-                "internalType":"bytes"
-              }
-            ]
-          },
-          {
-            "name":"exactAmount",
-            "type":"uint128",
-            "internalType":"uint128"
-          }
-        ]
-      }
-    ],
-    "outputs":[
-      {
-        "name":"",
-        "type":"bytes",
-        "internalType":"bytes"
-      }
-    ],
-    "stateMutability":"nonpayable"
-  },
-  {
-    "type":"function",
-    "name":"_quoteExactInputSingle",
-    "inputs":[
-      {
-        "name":"params",
-        "type":"tuple",
-        "internalType":"struct IQuoter.QuoteExactSingleParams",
-        "components":[
-          {
-            "name":"poolKey",
-            "type":"tuple",
-            "internalType":"struct PoolKey",
-            "components":[
-              {
-                "name":"currency0",
-                "type":"address",
-                "internalType":"Currency"
-              },
-              {
-                "name":"currency1",
-                "type":"address",
-                "internalType":"Currency"
-              },
-              {
-                "name":"fee",
-                "type":"uint24",
-                "internalType":"uint24"
-              },
-              {
-                "name":"tickSpacing",
-                "type":"int24",
-                "internalType":"int24"
-              },
-              {
-                "name":"hooks",
-                "type":"address",
-                "internalType":"contract IHooks"
-              }
-            ]
-          },
-          {
-            "name":"zeroForOne",
-            "type":"bool",
-            "internalType":"bool"
-          },
-          {
-            "name":"exactAmount",
-            "type":"uint128",
-            "internalType":"uint128"
-          },
-          {
-            "name":"sqrtPriceLimitX96",
-            "type":"uint160",
-            "internalType":"uint160"
-          },
-          {
-            "name":"hookData",
-            "type":"bytes",
-            "internalType":"bytes"
-          }
-        ]
-      }
-    ],
-    "outputs":[
-      {
-        "name":"",
-        "type":"bytes",
-        "internalType":"bytes"
-      }
-    ],
-    "stateMutability":"nonpayable"
-  },
-  {
-    "type":"function",
-    "name":"_quoteExactOutput",
-    "inputs":[
-      {
-        "name":"params",
-        "type":"tuple",
-        "internalType":"struct IQuoter.QuoteExactParams",
-        "components":[
-          {
-            "name":"exactCurrency",
-            "type":"address",
-            "internalType":"Currency"
-          },
-          {
-            "name":"path",
-            "type":"tuple[]",
-            "internalType":"struct PathKey[]",
-            "components":[
-              {
-                "name":"intermediateCurrency",
-                "type":"address",
-                "internalType":"Currency"
-              },
-              {
-                "name":"fee",
-                "type":"uint24",
-                "internalType":"uint24"
-              },
-              {
-                "name":"tickSpacing",
-                "type":"int24",
-                "internalType":"int24"
-              },
-              {
-                "name":"hooks",
-                "type":"address",
-                "internalType":"contract IHooks"
-              },
-              {
-                "name":"hookData",
-                "type":"bytes",
-                "internalType":"bytes"
-              }
-            ]
-          },
-          {
-            "name":"exactAmount",
-            "type":"uint128",
-            "internalType":"uint128"
-          }
-        ]
-      }
-    ],
-    "outputs":[
-      {
-        "name":"",
-        "type":"bytes",
-        "internalType":"bytes"
-      }
-    ],
-    "stateMutability":"nonpayable"
-  },
-  {
-    "type":"function",
-    "name":"_quoteExactOutputSingle",
-    "inputs":[
-      {
-        "name":"params",
-        "type":"tuple",
-        "internalType":"struct IQuoter.QuoteExactSingleParams",
-        "components":[
-          {
-            "name":"poolKey",
-            "type":"tuple",
-            "internalType":"struct PoolKey",
-            "components":[
-              {
-                "name":"currency0",
-                "type":"address",
-                "internalType":"Currency"
-              },
-              {
-                "name":"currency1",
-                "type":"address",
-                "internalType":"Currency"
-              },
-              {
-                "name":"fee",
-                "type":"uint24",
-                "internalType":"uint24"
-              },
-              {
-                "name":"tickSpacing",
-                "type":"int24",
-                "internalType":"int24"
-              },
-              {
-                "name":"hooks",
-                "type":"address",
-                "internalType":"contract IHooks"
-              }
-            ]
-          },
-          {
-            "name":"zeroForOne",
-            "type":"bool",
-            "internalType":"bool"
-          },
-          {
-            "name":"exactAmount",
-            "type":"uint128",
-            "internalType":"uint128"
-          },
-          {
-            "name":"sqrtPriceLimitX96",
-            "type":"uint160",
-            "internalType":"uint160"
-          },
-          {
-            "name":"hookData",
-            "type":"bytes",
-            "internalType":"bytes"
-          }
-        ]
-      }
-    ],
-    "outputs":[
-      {
-        "name":"",
-        "type":"bytes",
-        "internalType":"bytes"
-      }
-    ],
-    "stateMutability":"nonpayable"
-  },
-  {
-    "type":"function",
-    "name":"poolManager",
-    "inputs":[
-
-    ],
-    "outputs":[
-      {
-        "name":"",
-        "type":"address",
-        "internalType":"contract IPoolManager"
-      }
-    ],
-    "stateMutability":"view"
-  },
   {
     "type":"function",
     "name":"quoteExactInput",
@@ -354,19 +55,14 @@
     ],
     "outputs":[
       {
-        "name":"deltaAmounts",
-        "type":"int128[]",
-        "internalType":"int128[]"
+        "name":"amountOut",
+        "type":"uint256",
+        "internalType":"uint256"
       },
       {
-        "name":"sqrtPriceX96AfterList",
-        "type":"uint160[]",
-        "internalType":"uint160[]"
-      },
-      {
-        "name":"initializedTicksLoadedList",
-        "type":"uint32[]",
-        "internalType":"uint32[]"
+        "name":"gasEstimate",
+        "type":"uint256",
+        "internalType":"uint256"
       }
     ],
     "stateMutability":"nonpayable"
@@ -437,19 +133,14 @@
     ],
     "outputs":[
       {
-        "name":"deltaAmounts",
-        "type":"int128[]",
-        "internalType":"int128[]"
+        "name":"amountOut",
+        "type":"uint256",
+        "internalType":"uint256"
       },
       {
-        "name":"sqrtPriceX96After",
-        "type":"uint160",
-        "internalType":"uint160"
-      },
-      {
-        "name":"initializedTicksLoaded",
-        "type":"uint32",
-        "internalType":"uint32"
+        "name":"gasEstimate",
+        "type":"uint256",
+        "internalType":"uint256"
       }
     ],
     "stateMutability":"nonpayable"
@@ -510,19 +201,14 @@
     ],
     "outputs":[
       {
-        "name":"deltaAmounts",
-        "type":"int128[]",
-        "internalType":"int128[]"
+        "name":"amountIn",
+        "type":"uint256",
+        "internalType":"uint256"
       },
       {
-        "name":"sqrtPriceX96AfterList",
-        "type":"uint160[]",
-        "internalType":"uint160[]"
-      },
-      {
-        "name":"initializedTicksLoadedList",
-        "type":"uint32[]",
-        "internalType":"uint32[]"
+        "name":"gasEstimate",
+        "type":"uint256",
+        "internalType":"uint256"
       }
     ],
     "stateMutability":"nonpayable"
@@ -593,93 +279,16 @@
     ],
     "outputs":[
       {
-        "name":"deltaAmounts",
-        "type":"int128[]",
-        "internalType":"int128[]"
+        "name":"amountIn",
+        "type":"uint256",
+        "internalType":"uint256"
       },
       {
-        "name":"sqrtPriceX96After",
-        "type":"uint160",
-        "internalType":"uint160"
-      },
-      {
-        "name":"initializedTicksLoaded",
-        "type":"uint32",
-        "internalType":"uint32"
+        "name":"gasEstimate",
+        "type":"uint256",
+        "internalType":"uint256"
       }
     ],
     "stateMutability":"nonpayable"
-  },
-  {
-    "type":"function",
-    "name":"unlockCallback",
-    "inputs":[
-      {
-        "name":"data",
-        "type":"bytes",
-        "internalType":"bytes"
-      }
-    ],
-    "outputs":[
-      {
-        "name":"",
-        "type":"bytes",
-        "internalType":"bytes"
-      }
-    ],
-    "stateMutability":"nonpayable"
-  },
-  {
-    "type":"error",
-    "name":"InsufficientAmountOut",
-    "inputs":[
-
-    ]
-  },
-  {
-    "type":"error",
-    "name":"InvalidLockCaller",
-    "inputs":[
-
-    ]
-  },
-  {
-    "type":"error",
-    "name":"InvalidQuoteBatchParams",
-    "inputs":[
-
-    ]
-  },
-  {
-    "type":"error",
-    "name":"LockFailure",
-    "inputs":[
-
-    ]
-  },
-  {
-    "type":"error",
-    "name":"NotPoolManager",
-    "inputs":[
-
-    ]
-  },
-  {
-    "type":"error",
-    "name":"NotSelf",
-    "inputs":[
-
-    ]
-  },
-  {
-    "type":"error",
-    "name":"UnexpectedRevertBytes",
-    "inputs":[
-      {
-        "name":"revertData",
-        "type":"bytes",
-        "internalType":"bytes"
-      }
-    ]
   }
 ]

--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -7,6 +7,7 @@ import FixedReverseHeap from 'mnemonist/fixed-reverse-heap';
 import Queue from 'mnemonist/queue';
 
 import { IPortionProvider } from '../../../providers/portion-provider';
+import { ProviderConfig } from '../../../providers/provider';
 import { HAS_L1_FEE, V2_SUPPORTED, V4_SUPPORTED } from '../../../util';
 import { CurrencyAmount } from '../../../util/amounts';
 import { log } from '../../../util/log';
@@ -16,7 +17,6 @@ import { SwapOptions } from '../../router';
 import { AlphaRouterConfig } from '../alpha-router';
 import { IGasModel, L1ToL2GasCosts, usdGasTokensByChain } from '../gas-models';
 
-import { ProviderConfig } from '../../../providers/provider';
 import {
   RouteWithValidQuote,
   V2RouteWithValidQuote,

--- a/src/util/addresses.ts
+++ b/src/util/addresses.ts
@@ -89,7 +89,7 @@ export const NEW_QUOTER_V2_ADDRESSES: AddressMap = {
 
 export const PROTOCOL_V4_QUOTER_ADDRESSES: AddressMap = {
   ...constructSameAddressMap('0xf3a39c86dbd13c45365e57fb90fe413371f65af8'),
-  [ChainId.SEPOLIA]: '0x8C41f1696360ca987803a4c24B8b7c36dFd61c4d',
+  [ChainId.SEPOLIA]: '0x9336CF25dDad216FD480A5422CBEa7b3BC5bDda8',
 };
 
 export const MIXED_ROUTE_QUOTER_V1_ADDRESSES: AddressMap = {

--- a/test/unit/providers/on-chain-quote-provider.test.ts
+++ b/test/unit/providers/on-chain-quote-provider.test.ts
@@ -70,7 +70,7 @@ describe('on chain quote provider', () => {
 
     it('exact in quote and then exact out quote to match original exact in currency amount', async () => {
       const providerConfig: ProviderConfig = {
-        blockNumber: 6685697,
+        blockNumber: 6724128,
       }
 
       const exactInQuotes = await onChainQuoteProvider.getQuotesManyExactIn(amountIns, v4Routes, providerConfig)


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
chore

- **What is the current behavior?** (You can also link to an open issue here)
We were pointing to the older version of v4 quoter, with obsolete ABI.

- **What is the new behavior (if this is a feature change)?**
We are pointing to refactored v4 quoter, with concise ABI, from https://github.com/Uniswap/v4-periphery/pull/349.

- **Other information**:
I deployed quoter from that PR to https://sepolia.etherscan.io/address/0x9336CF25dDad216FD480A5422CBEa7b3BC5bDda8#code, so it's likely it's not the final quoter contract, until we finish auditing. However it's worth the effort to integrate with SOR, because ABIs are unlikely to change.