### PR TITLE
feat: mixed route support native currency routing based on whether v4 pool is involved

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -2341,11 +2341,10 @@ export class AlphaRouter
                   v4Candidates: v4CandidatePools,
                 });
 
-              // TODO: ROUTE-291 - special treat mixed route native currency routing, only when the route contains v4 pools
               return this.mixedQuoter
                 .getRoutesThenQuotes(
-                  tokenIn,
-                  tokenOut,
+                  currencyIn,
+                  currencyOut,
                   amount,
                   amounts,
                   percents,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
mixed route cannot support non-native currency routing for v2 and v3 only.

- **What is the new behavior (if this is a feature change)?**
we will be able to support non-native currency routing for v2 and v3 only.

- **Other information**:
this is for backward compatibility with existing mixed routing against v2 and v3