### PR TITLE
Revert "feat(breaking): top-level alpha router native currencyIn, currencyIn, quoteCurrency support (#715)"

### DIFF
--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -29,7 +29,6 @@ import { MixedRouteQuoterV2__factory } from '../types/other/factories/MixedRoute
 import { V4Quoter__factory } from '../types/other/factories/V4Quoter__factory';
 import { IQuoterV2__factory } from '../types/v3/factories/IQuoterV2__factory';
 import {
-  getAddress,
   ID_TO_NETWORK_NAME,
   metric,
   MetricLoggerUnit,
@@ -644,7 +643,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
             case Protocol.V4:
               return [
                 {
-                  exactCurrency: getAddress(amount.currency),
+                  exactCurrency: amount.currency.wrapped.address,
                   path: encodedRoute as PathKey[],
                   exactAmount: amount.quotient.toString(),
                 },

--- a/src/providers/v4/pool-provider.ts
+++ b/src/providers/v4/pool-provider.ts
@@ -1,12 +1,13 @@
+import { ADDRESS_ZERO } from '@uniswap/router-sdk';
 import { ChainId, Currency } from '@uniswap/sdk-core';
 import { Pool } from '@uniswap/v4-sdk';
 import retry, { Options as RetryOptions } from 'async-retry';
+import { log, STATE_VIEW_ADDRESSES } from '../../util';
+import { IMulticallProvider, Result } from '../multicall-provider';
+import { ProviderConfig } from '../provider';
 
 import { StateView__factory } from '../../types/other/factories/StateView__factory';
-import { getAddress, log, STATE_VIEW_ADDRESSES } from '../../util';
-import { IMulticallProvider, Result } from '../multicall-provider';
 import { ILiquidity, ISlot0, PoolProvider } from '../pool-provider';
-import { ProviderConfig } from '../provider';
 
 type V4ISlot0 = ISlot0 & {
   poolId: string;
@@ -153,8 +154,12 @@ export class V4PoolProvider
     const [currency0, currency1] = sortsBefore(currencyA, currencyB)
       ? [currencyA, currencyB]
       : [currencyB, currencyA];
-    const currency0Addr = getAddress(currency0);
-    const currency1Addr = getAddress(currency1);
+    const currency0Addr = currency0.isNative
+      ? ADDRESS_ZERO
+      : currency0.wrapped.address;
+    const currency1Addr = currency1.isNative
+      ? ADDRESS_ZERO
+      : currency1.wrapped.address;
 
     const cacheKey = `${this.chainId}/${currency0Addr}/${currency1Addr}/${fee}/${tickSpacing}/${hooks}`;
 

--- a/src/providers/v4/static-subgraph-provider.ts
+++ b/src/providers/v4/static-subgraph-provider.ts
@@ -3,7 +3,7 @@ import { ADDRESS_ZERO, FeeAmount } from '@uniswap/v3-sdk';
 import { Pool } from '@uniswap/v4-sdk';
 import _ from 'lodash';
 
-import { getAddress, log, unparseFeeAmount } from '../../util';
+import { log, unparseFeeAmount } from '../../util';
 import { BASES_TO_CHECK_TRADES_AGAINST } from '../caching-subgraph-provider';
 
 import JSBI from 'jsbi';
@@ -93,10 +93,10 @@ export class StaticV4SubgraphProvider implements IV4SubgraphProvider {
           hooks: hooks,
           liquidity: liquidity.toString(),
           token0: {
-            id: getAddress(token0),
+            id: token0.wrapped.address,
           },
           token1: {
-            id: getAddress(token1),
+            id: token1.wrapped.address,
           },
           // As a very rough proxy we just use liquidity for TVL.
           tvlETH: liquidityNumber,

--- a/src/routers/alpha-router/entities/route-with-valid-quote.ts
+++ b/src/routers/alpha-router/entities/route-with-valid-quote.ts
@@ -1,11 +1,11 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Protocol } from '@uniswap/router-sdk';
 import { Currency, Token, TradeType } from '@uniswap/sdk-core';
-import { Pair } from '@uniswap/v2-sdk';
 import { Pool as V3Pool } from '@uniswap/v3-sdk';
 import { Pool as V4Pool } from '@uniswap/v4-sdk';
 import _ from 'lodash';
 
+import { Pair } from '@uniswap/v2-sdk';
 import { IV4PoolProvider } from '../../../providers';
 import { IV2PoolProvider } from '../../../providers/v2/pool-provider';
 import { IV3PoolProvider } from '../../../providers/v3/pool-provider';
@@ -269,7 +269,7 @@ export type V4RouteWithValidQuoteParams = {
   quoterGasEstimate: BigNumber;
   percent: number;
   route: V4Route;
-  quoteCurrency: Currency;
+  quoteToken: Token;
   gasModel: IGasModel<V4RouteWithValidQuote>;
   tradeType: TradeType;
   v4PoolProvider: IV4PoolProvider;
@@ -286,7 +286,7 @@ export class V4RouteWithValidQuote implements IV4RouteWithValidQuote {
   public quoterGasEstimate: BigNumber; // TODO: not available in v4 quoter v1
   public percent: number;
   public route: V4Route;
-  public quoteCurrency: Currency;
+  public quoteToken: Token;
   public gasModel: IGasModel<V4RouteWithValidQuote>;
   public gasEstimate: BigNumber;
   public gasCostInToken: CurrencyAmount;
@@ -313,7 +313,7 @@ export class V4RouteWithValidQuote implements IV4RouteWithValidQuote {
     percent,
     route,
     gasModel,
-    quoteCurrency,
+    quoteToken,
     tradeType,
     v4PoolProvider,
   }: V4RouteWithValidQuoteParams) {
@@ -322,14 +322,11 @@ export class V4RouteWithValidQuote implements IV4RouteWithValidQuote {
     this.sqrtPriceX96AfterList = sqrtPriceX96AfterList;
     this.initializedTicksCrossedList = initializedTicksCrossedList;
     this.quoterGasEstimate = quoterGasEstimate;
-    this.quote = CurrencyAmount.fromRawAmount(
-      quoteCurrency,
-      rawQuote.toString()
-    );
+    this.quote = CurrencyAmount.fromRawAmount(quoteToken, rawQuote.toString());
     this.percent = percent;
     this.route = route;
     this.gasModel = gasModel;
-    this.quoteCurrency = quoteCurrency;
+    this.quoteToken = quoteToken;
     this.tradeType = tradeType;
 
     const { gasEstimate, gasCostInToken, gasCostInUSD, gasCostInGasToken } =
@@ -374,7 +371,7 @@ export type MixedRouteWithValidQuoteParams = {
   percent: number;
   route: MixedRoute;
   mixedRouteGasModel: IGasModel<MixedRouteWithValidQuote>;
-  quoteCurrency: Currency;
+  quoteToken: Token;
   tradeType: TradeType;
   v4PoolProvider: IV4PoolProvider;
   v3PoolProvider: IV3PoolProvider;
@@ -400,7 +397,7 @@ export class MixedRouteWithValidQuote implements IMixedRouteWithValidQuote {
   public quoterGasEstimate: BigNumber;
   public percent: number;
   public route: MixedRoute;
-  public quoteCurrency: Currency;
+  public quoteToken: Token;
   public gasModel: IGasModel<MixedRouteWithValidQuote>;
   public gasEstimate: BigNumber;
   public gasCostInToken: CurrencyAmount;
@@ -427,7 +424,7 @@ export class MixedRouteWithValidQuote implements IMixedRouteWithValidQuote {
     percent,
     route,
     mixedRouteGasModel,
-    quoteCurrency,
+    quoteToken,
     tradeType,
     v4PoolProvider,
     v3PoolProvider,
@@ -438,14 +435,11 @@ export class MixedRouteWithValidQuote implements IMixedRouteWithValidQuote {
     this.sqrtPriceX96AfterList = sqrtPriceX96AfterList;
     this.initializedTicksCrossedList = initializedTicksCrossedList;
     this.quoterGasEstimate = quoterGasEstimate;
-    this.quote = CurrencyAmount.fromRawAmount(
-      quoteCurrency,
-      rawQuote.toString()
-    );
+    this.quote = CurrencyAmount.fromRawAmount(quoteToken, rawQuote.toString());
     this.percent = percent;
     this.route = route;
     this.gasModel = mixedRouteGasModel;
-    this.quoteCurrency = quoteCurrency;
+    this.quoteToken = quoteToken;
     this.tradeType = tradeType;
 
     const { gasEstimate, gasCostInToken, gasCostInUSD, gasCostInGasToken } =

--- a/src/routers/alpha-router/functions/best-swap-route.ts
+++ b/src/routers/alpha-router/functions/best-swap-route.ts
@@ -18,7 +18,6 @@ import { AlphaRouterConfig } from '../alpha-router';
 import { IGasModel, L1ToL2GasCosts, usdGasTokensByChain } from '../gas-models';
 
 import {
-  MixedRouteWithValidQuote,
   RouteWithValidQuote,
   V2RouteWithValidQuote,
   V3RouteWithValidQuote,
@@ -493,13 +492,8 @@ export async function getBestSwapRouteBy(
     gasUsedL1OnL2: BigNumber.from(0),
     gasCostL1USD: CurrencyAmount.fromRawAmount(usdToken, 0),
     gasCostL1QuoteToken: CurrencyAmount.fromRawAmount(
-      bestSwap[0] &&
-        (bestSwap[0] instanceof V4RouteWithValidQuote ||
-          bestSwap[0] instanceof MixedRouteWithValidQuote)
-        ? // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-          bestSwap[0]?.quoteCurrency!
-        : // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-          bestSwap[0]?.quoteToken!,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+      bestSwap[0]?.quoteToken!,
       0
     ),
   };

--- a/src/routers/alpha-router/functions/compute-all-routes.ts
+++ b/src/routers/alpha-router/functions/compute-all-routes.ts
@@ -21,6 +21,7 @@ export function computeAllV4Routes(
   pools: V4Pool[],
   maxHops: number
 ): V4Route[] {
+  // TODO: ROUTE-217 - Support native currency routing in V4
   return computeAllRoutes<V4Pool, V4Route, Currency>(
     currencyIn,
     currencyOut,
@@ -153,6 +154,7 @@ export function computeAllRoutes<
         ? curPool.token1
         : curPool.token0;
 
+      // TODO: ROUTE-217 - Support native currency routing in V4
       if (tokensVisited.has(getAddressLowerCase(currentTokenOut))) {
         continue;
       }

--- a/src/routers/alpha-router/gas-models/v4/v4-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/v4/v4-heuristic-gas-model.ts
@@ -54,7 +54,7 @@ export class V4HeuristicGasModelFactory
       routeWithValidQuote.initializedTicksCrossedList
     );
 
-    const baseGasUse = routeWithValidQuote.quoterGasEstimate
+    const baseGasUse = routeWithValidQuote.gasEstimate
       // we still need the gas override for native wrap/unwrap, because quoter doesn't simulate on universal router level
       .add(providerConfig?.additionalGasOverhead ?? BigNumber.from(0));
 

--- a/src/routers/alpha-router/quoters/base-quoter.ts
+++ b/src/routers/alpha-router/quoters/base-quoter.ts
@@ -1,7 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Protocol } from '@uniswap/router-sdk';
-import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
-import { ChainId, Currency, TradeType } from '@uniswap/sdk-core';
+import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
 import _ from 'lodash';
 
 import {
@@ -30,6 +29,7 @@ import {
 } from '../functions/get-candidate-pools';
 import { IGasModel } from '../gas-models';
 
+import { TPool } from '@uniswap/router-sdk/dist/utils/TPool';
 import { GetQuotesResult, GetRoutesResult } from './model/results';
 
 /**
@@ -110,7 +110,7 @@ export abstract class BaseQuoter<
     routes: Route[],
     amounts: CurrencyAmount[],
     percents: number[],
-    quoteToken: TCurrency,
+    quoteToken: Token,
     tradeType: TradeType,
     routingConfig: AlphaRouterConfig,
     candidatePools?: CandidatePoolsBySelectionCriteria,
@@ -138,7 +138,7 @@ export abstract class BaseQuoter<
     amount: CurrencyAmount,
     amounts: CurrencyAmount[],
     percents: number[],
-    quoteToken: TCurrency,
+    quoteToken: Token,
     candidatePools: CandidatePools,
     tradeType: TradeType,
     routingConfig: AlphaRouterConfig,

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -290,7 +290,7 @@ export class MixedQuoter extends BaseQuoter<
           initializedTicksCrossedList,
           quoterGasEstimate: gasEstimate,
           mixedRouteGasModel: gasModel,
-          quoteCurrency: quoteCurrency,
+          quoteToken: quoteCurrency.wrapped,
           tradeType,
           v4PoolProvider: this.v4PoolProvider,
           v3PoolProvider: this.v3PoolProvider,

--- a/src/routers/alpha-router/quoters/v4-quoter.ts
+++ b/src/routers/alpha-router/quoters/v4-quoter.ts
@@ -222,7 +222,7 @@ export class V4Quoter extends BaseQuoter<V4CandidatePools, V4Route, Currency> {
           initializedTicksCrossedList,
           quoterGasEstimate: gasEstimate,
           gasModel,
-          quoteCurrency: quoteCurrency,
+          quoteToken: quoteCurrency.wrapped,
           tradeType,
           v4PoolProvider: this.v4PoolProvider,
         });

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -32,7 +32,6 @@ import {
 } from '../routers';
 import {
   CurrencyAmount,
-  getAddress,
   getApplicableV3FeeAmounts,
   log,
   WRAPPED_NATIVE_CURRENCY,
@@ -407,15 +406,13 @@ export function initSwapRouteFromExisting(
           percent: route.percent,
           route: route.route,
           gasModel: route.gasModel,
-          quoteCurrency: route.quoteCurrency.isNative
-            ? route.quoteCurrency
-            : new Token(
-                route.quoteCurrency.chainId,
-                getAddress(route.quoteCurrency),
-                route.quoteCurrency.decimals,
-                route.quoteCurrency.symbol,
-                route.quoteCurrency.name
-              ),
+          quoteToken: new Token(
+            currencyIn.chainId,
+            route.quoteToken.address,
+            route.quoteToken.decimals,
+            route.quoteToken.symbol,
+            route.quoteToken.name
+          ),
           tradeType: tradeType,
           v4PoolProvider: v4PoolProvider,
         });
@@ -483,15 +480,13 @@ export function initSwapRouteFromExisting(
           route: route.route,
           mixedRouteGasModel: route.gasModel,
           v2PoolProvider,
-          quoteCurrency: route.quoteCurrency.isNative
-            ? route.quoteCurrency
-            : new Token(
-                route.quoteCurrency.chainId,
-                getAddress(route.quoteCurrency),
-                route.quoteCurrency.decimals,
-                route.quoteCurrency.symbol,
-                route.quoteCurrency.name
-              ),
+          quoteToken: new Token(
+            currencyIn.chainId,
+            route.quoteToken.address,
+            route.quoteToken.decimals,
+            route.quoteToken.symbol,
+            route.quoteToken.name
+          ),
           tradeType: tradeType,
           v3PoolProvider: v3PoolProvider,
           v4PoolProvider: v4PoolProvider,

--- a/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
+++ b/test/unit/providers/caching/route/test-util/mocked-dependencies.ts
@@ -90,7 +90,7 @@ export function getMixedRouteWithValidQuoteStub(
     percent: 100,
     route,
     mixedRouteGasModel: getMockedMixedGasModel(),
-    quoteCurrency: DAI,
+    quoteToken: DAI,
     tradeType: TradeType.EXACT_INPUT,
     v4PoolProvider: getMockedV4PoolProvider(),
     v3PoolProvider: getMockedV3PoolProvider(),

--- a/test/unit/routers/alpha-router/alpha-router.test.ts
+++ b/test/unit/routers/alpha-router/alpha-router.test.ts
@@ -1,13 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { BaseProvider } from '@ethersproject/providers';
 import { Protocol, SwapRouter } from '@uniswap/router-sdk';
-import {
-  ChainId,
-  Ether,
-  Fraction,
-  Percent,
-  TradeType
-} from '@uniswap/sdk-core';
+import { ChainId, Fraction, Percent, TradeType } from '@uniswap/sdk-core';
 import { Pair } from '@uniswap/v2-sdk';
 import { encodeSqrtRatioX96, Pool as V3Pool, Position } from '@uniswap/v3-sdk';
 import { Pool as V4Pool } from '@uniswap/v4-sdk';
@@ -85,7 +79,6 @@ import {
   DAI_USDT_LOW,
   DAI_USDT_MEDIUM,
   DAI_USDT_V4_LOW,
-  ETH_USDT_V4_LOW,
   MOCK_ZERO_DEC_TOKEN,
   mockBlock,
   mockBlockBN,
@@ -93,7 +86,6 @@ import {
   pairToV2SubgraphPool,
   poolToV3SubgraphPool,
   poolToV4SubgraphPool,
-  UNI_ETH_V4_MEDIUM,
   USDC_DAI,
   USDC_DAI_LOW,
   USDC_DAI_MEDIUM,
@@ -234,8 +226,6 @@ describe('alpha router', () => {
       WETH9_USDT_V4_LOW,
       DAI_USDT_V4_LOW,
       USDC_USDT_V4_MEDIUM,
-      ETH_USDT_V4_LOW,
-      UNI_ETH_V4_MEDIUM,
     ];
     mockV4PoolProvider.getPools.resolves(buildMockV4PoolAccessor(v4MockPools));
     mockV4PoolProvider.getPoolId.callsFake((cA, cB, fee, tickSpacing, hooks) => ({
@@ -380,7 +370,7 @@ describe('alpha router', () => {
       return {
         gasEstimate: BigNumber.from(10000),
         gasCostInToken: CurrencyAmount.fromRawAmount(
-          r.quoteCurrency,
+          r.quoteToken,
           r.quote.multiply(new Fraction(95, 100)).quotient
         ),
         gasCostInUSD: CurrencyAmount.fromRawAmount(
@@ -423,7 +413,7 @@ describe('alpha router', () => {
         return {
           gasEstimate: BigNumber.from(10000),
           gasCostInToken: CurrencyAmount.fromRawAmount(
-            r.quoteCurrency,
+            r.quoteToken,
             r.quote.multiply(new Fraction(95, 100)).quotient
           ),
           gasCostInUSD: CurrencyAmount.fromRawAmount(
@@ -495,7 +485,6 @@ describe('alpha router', () => {
       multicall2Provider: mockMulticallProvider as any,
       v4SubgraphProvider: mockV4SubgraphProvider,
       v4PoolProvider: mockV4PoolProvider,
-      v4GasModelFactory: mockV4GasModelFactory,
       v3SubgraphProvider: mockV3SubgraphProvider,
       v3PoolProvider: mockV3PoolProvider,
       onChainQuoteProvider: mockOnChainQuoteProvider,
@@ -1112,114 +1101,6 @@ describe('alpha router', () => {
         { ...ROUTING_CONFIG }
       );
       expect(swapTo).toBeDefined();
-    });
-
-    test('succeeds to route on mixed only', async () => {
-      const amount = CurrencyAmount.fromRawAmount(USDC, 10000);
-      const swap = await alphaRouter.route(
-        amount,
-        Ether.onChain(ChainId.MAINNET),
-        TradeType.EXACT_INPUT,
-        undefined,
-        { ...ROUTING_CONFIG, protocols: [Protocol.MIXED] }
-      )
-      expect(swap).toBeDefined();
-
-      expect(mockFallbackTenderlySimulator.simulate.called).toBeFalsy();
-      expect(mockProvider.getBlockNumber.called).toBeTruthy();
-      expect(mockGasPriceProvider.getGasPrice.called).toBeTruthy();
-
-      sinon.assert.calledWith(
-        mockOnChainQuoteProvider.getQuotesManyExactIn,
-        sinon.match((value) => {
-          return value instanceof Array && value.length == 4;
-        }),
-        sinon.match.array,
-        sinon.match({ blockNumber: sinon.match.defined })
-      );
-      /// Should not be calling onChainQuoteProvider for mixedRoutes
-      sinon.assert.callCount(mockOnChainQuoteProvider.getQuotesManyExactIn, 1);
-
-      expect(
-        swap!.quote.currency.equals(Ether.onChain(ChainId.MAINNET))
-      ).toBeTruthy();
-      expect(
-        swap!.quoteGasAdjusted.currency.equals(Ether.onChain(ChainId.MAINNET))
-      ).toBeTruthy();
-
-      expect(swap!.quote.greaterThan(swap!.quoteGasAdjusted)).toBeTruthy();
-      expect(swap!.estimatedGasUsed.toString()).toEqual('10000');
-      expect(
-        swap!.estimatedGasUsedQuoteToken.currency.equals(
-          Ether.onChain(ChainId.MAINNET)
-        )
-      ).toBeTruthy();
-      expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
-      ).toBeTruthy();
-      expect(swap!.gasPriceWei.toString()).toEqual(
-        mockGasPriceWeiBN.toString()
-      );
-      expect(swap!.route).toHaveLength(1);
-      expect(swap!.trade).toBeDefined();
-      expect(swap!.methodParameters).not.toBeDefined();
-      expect(swap!.blockNumber.toString()).toEqual(mockBlockBN.toString());
-    });
-
-    test('succeeds to route on v4 only', async () => {
-      const amount = CurrencyAmount.fromRawAmount(USDC, 10000);
-      const swap = await alphaRouter.route(
-        amount,
-        Ether.onChain(ChainId.MAINNET),
-        TradeType.EXACT_INPUT,
-        undefined,
-        { ...ROUTING_CONFIG, protocols: [Protocol.V4] }
-      )
-      expect(swap).toBeDefined();
-
-      expect(mockFallbackTenderlySimulator.simulate.called).toBeFalsy();
-      expect(mockProvider.getBlockNumber.called).toBeTruthy();
-      expect(mockGasPriceProvider.getGasPrice.called).toBeTruthy();
-
-      sinon.assert.calledWith(
-        mockOnChainQuoteProvider.getQuotesManyExactIn,
-        sinon.match((value) => {
-          return value instanceof Array && value.length == 4;
-        }),
-        sinon.match.array,
-        sinon.match({ blockNumber: sinon.match.defined })
-      );
-      /// Should not be calling onChainQuoteProvider for mixedRoutes
-      sinon.assert.callCount(mockOnChainQuoteProvider.getQuotesManyExactIn, 1);
-
-      expect(
-        swap!.quote.currency.equals(Ether.onChain(ChainId.MAINNET))
-      ).toBeTruthy();
-      expect(
-        swap!.quoteGasAdjusted.currency.equals(Ether.onChain(ChainId.MAINNET))
-      ).toBeTruthy();
-
-      expect(swap!.quote.greaterThan(swap!.quoteGasAdjusted)).toBeTruthy();
-      expect(swap!.estimatedGasUsed.toString()).toEqual('10000');
-      expect(
-        swap!.estimatedGasUsedQuoteToken.currency.equals(
-          Ether.onChain(ChainId.MAINNET)
-        )
-      ).toBeTruthy();
-      expect(
-        swap!.estimatedGasUsedUSD.currency.equals(USDC) ||
-        swap!.estimatedGasUsedUSD.currency.equals(USDT) ||
-        swap!.estimatedGasUsedUSD.currency.equals(DAI)
-      ).toBeTruthy();
-      expect(swap!.gasPriceWei.toString()).toEqual(
-        mockGasPriceWeiBN.toString()
-      );
-      expect(swap!.route).toHaveLength(1);
-      expect(swap!.trade).toBeDefined();
-      expect(swap!.methodParameters).not.toBeDefined();
-      expect(swap!.blockNumber.toString()).toEqual(mockBlockBN.toString());
     });
 
     test('succeeds to route on v3 only', async () => {

--- a/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
+++ b/test/unit/routers/alpha-router/gas-models/mixed-route-gas-model.test.ts
@@ -221,7 +221,7 @@ describe('mixed route gas model tests', () => {
         WRAPPED_NATIVE_CURRENCY[1],
         DAI_MAINNET
       ),
-      quoteCurrency: DAI_MAINNET,
+      quoteToken: DAI_MAINNET,
       initializedTicksCrossedList: [1],
     });
 
@@ -269,7 +269,7 @@ describe('mixed route gas model tests', () => {
         USDC_MAINNET,
         WRAPPED_NATIVE_CURRENCY[1]
       ),
-      quoteCurrency: WRAPPED_NATIVE_CURRENCY[1],
+      quoteToken: WRAPPED_NATIVE_CURRENCY[1],
       initializedTicksCrossedList: [1],
     });
 

--- a/test/unit/routers/alpha-router/gas-models/test-util/mocked-dependencies.ts
+++ b/test/unit/routers/alpha-router/gas-models/test-util/mocked-dependencies.ts
@@ -45,7 +45,7 @@ export function getMockedMixedGasModel(): IGasModel<MixedRouteWithValidQuote> {
   mockMixedGasModel.estimateGasCost.callsFake((r) => {
     return {
       gasEstimate: BigNumber.from(10000),
-      gasCostInToken: CurrencyAmount.fromRawAmount(r.quoteCurrency, 0),
+      gasCostInToken: CurrencyAmount.fromRawAmount(r.quoteToken, 0),
       gasCostInUSD: CurrencyAmount.fromRawAmount(USDC, 0),
     };
   });

--- a/test/unit/routers/alpha-router/util/gas-factory-helpers.test.ts
+++ b/test/unit/routers/alpha-router/util/gas-factory-helpers.test.ts
@@ -111,7 +111,7 @@ describe('gas factory helpers tests', () => {
       const mockPoolProvider = getMockedV3PoolProvider();
 
       const amountToken = WRAPPED_NATIVE_CURRENCY[1];
-      const quoteCurrency = DAI_MAINNET;
+      const quoteToken = DAI_MAINNET;
       const gasToken = USDC_MAINNET;
       const providerConfig = {
         gasToken
@@ -119,7 +119,7 @@ describe('gas factory helpers tests', () => {
 
       const pools = await getPools(
         amountToken,
-        quoteCurrency,
+        quoteToken,
         mockPoolProvider,
         providerConfig,
         gasToken
@@ -130,27 +130,27 @@ describe('gas factory helpers tests', () => {
         gasPriceWei,
         pools,
         amountToken,
-        quoteToken: quoteCurrency,
+        quoteToken,
         v2poolProvider: getMockedV2PoolProvider(),
         l2GasDataProvider: undefined,
         providerConfig
       });
 
       const mockSwapRoute: SwapRoute = {
-        quote: CurrencyAmount.fromRawAmount(quoteCurrency, 100),
-        quoteGasAdjusted: CurrencyAmount.fromRawAmount(quoteCurrency, 100),
+        quote: CurrencyAmount.fromRawAmount(quoteToken, 100),
+        quoteGasAdjusted: CurrencyAmount.fromRawAmount(quoteToken, 100),
         // these are all 0 before the function is called
         estimatedGasUsed: BigNumber.from(0),
-        estimatedGasUsedQuoteToken: CurrencyAmount.fromRawAmount(quoteCurrency, 0),
-        estimatedGasUsedUSD: CurrencyAmount.fromRawAmount(quoteCurrency, 0),
+        estimatedGasUsedQuoteToken: CurrencyAmount.fromRawAmount(quoteToken, 0),
+        estimatedGasUsedUSD: CurrencyAmount.fromRawAmount(quoteToken, 0),
         estimatedGasUsedGasToken: undefined,
         gasPriceWei,
         trade: new Trade({
           v4Routes: [],
           v3Routes: [{
-            routev3: new Route([DAI_WETH_MEDIUM], amountToken, quoteCurrency),
+            routev3: new Route([DAI_WETH_MEDIUM], amountToken, quoteToken),
             inputAmount: CurrencyAmount.fromRawAmount(amountToken, 1),
-            outputAmount: CurrencyAmount.fromRawAmount(quoteCurrency, 100),
+            outputAmount: CurrencyAmount.fromRawAmount(quoteToken, 100),
           }],
           v2Routes: [],
           mixedRoutes: [],
@@ -159,12 +159,12 @@ describe('gas factory helpers tests', () => {
         route: [new V3RouteWithValidQuote({
           amount: CurrencyAmount.fromRawAmount(amountToken, 1),
           rawQuote: BigNumber.from('100'),
-          quoteToken: quoteCurrency,
+          quoteToken,
           sqrtPriceX96AfterList: [],
           initializedTicksCrossedList: [1],
           quoterGasEstimate: BigNumber.from(100000),
           percent: 100,
-          route: new V3Route([DAI_WETH_MEDIUM], amountToken, quoteCurrency),
+          route: new V3Route([DAI_WETH_MEDIUM], amountToken, quoteToken),
           tradeType: TradeType.EXACT_INPUT,
           v3PoolProvider: mockPoolProvider,
           gasModel: v3GasModel,
@@ -187,7 +187,7 @@ describe('gas factory helpers tests', () => {
         quoteGasAdjusted
       } = await calculateGasUsed(chainId, mockSwapRoute, simulatedGasUsed, getMockedV2PoolProvider(), mockPoolProvider, sinon.createStubInstance(BaseProvider), providerConfig);
 
-      expect(estimatedGasUsedQuoteToken.currency.equals(quoteCurrency)).toBe(true);
+      expect(estimatedGasUsedQuoteToken.currency.equals(quoteToken)).toBe(true);
       expect(estimatedGasUsedQuoteToken.toExact()).not.toEqual('0');
       expect(estimatedGasUsedUSD.toExact()).not.toEqual('0');
       expect(estimatedGasUsedGasToken?.currency.equals(gasToken)).toBe(true);
@@ -202,7 +202,7 @@ describe('gas factory helpers tests', () => {
       } = await calculateGasUsed(chainId, mockSwapRoute, simulatedGasUsed, getMockedV2PoolProvider(), mockPoolProvider, sinon.createStubInstance(BaseProvider), providerConfig);
 
       // Arbitrum gas data should not affect the quote gas or USD amounts
-      expect(estimatedGasUsedQuoteTokenArb.currency.equals(quoteCurrency)).toBe(true);
+      expect(estimatedGasUsedQuoteTokenArb.currency.equals(quoteToken)).toBe(true);
       expect(estimatedGasUsedUSDArb.equalTo(estimatedGasUsedUSD)).toBe(true);
       expect(estimatedGasUsedGasTokenArb?.currency.equals(gasToken)).toBe(true);
       expect(quoteGasAdjustedArb.equalTo(quoteGasAdjusted)).toBe(true);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Revert https://github.com/Uniswap/smart-order-router/pull/715

- **What is the current behavior?** (You can also link to an open issue here)
mixed routes part of the PR caused regression, when quote token is native currency, when it was trying to quote against gas token https://github.com/Uniswap/smart-order-router/pull/715/files#diff-fe1277629ea700a6f1ec3b7e45e13fa05da63f1372b433736a9c9d2284c75ad0R461. In prod it throws `Invariant failed: CURRENCY`

- **What is the new behavior (if this is a feature change)?**
we revert https://github.com/Uniswap/smart-order-router/pull/715. Then we will break down the PR into finer PRs. we already know that only mixed routing part has issue, so we will break apart mixed routing changes from other changes.

- **Other information**:
