### PR TITLE
fix: v4 subgraph not properly including native currency in v4 candidate pools

### DIFF
--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -111,6 +111,13 @@ export const USDC_SEPOLIA = new Token(
   'USDC',
   'USDC Token'
 );
+export const USDC_NATIVE_SEPOLIA = new Token(
+  ChainId.SEPOLIA,
+  '0x1c7d4b196cb0c7b01d743fbc6116a902379c7238',
+  6,
+  'USDC',
+  'USDC Token'
+);
 export const DAI_SEPOLIA = new Token(
   ChainId.SEPOLIA,
   '0x7AF17A48a6336F7dc1beF9D485139f7B6f4FB5C8',

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -80,14 +80,15 @@ import {
 import {
   getAddress,
   getAddressLowerCase,
-  getApplicableV3FeeAmounts,
+  getApplicableV3FeeAmounts, nativeOnChain,
   unparseFeeAmount,
-  WRAPPED_NATIVE_CURRENCY,
+  WRAPPED_NATIVE_CURRENCY
 } from '../../../util';
 import { parseFeeAmount } from '../../../util/amounts';
 import { log } from '../../../util/log';
 import { metric, MetricLoggerUnit } from '../../../util/metric';
 import { AlphaRouterConfig } from '../alpha-router';
+import { isNativeCurrency } from '@uniswap/universal-router-sdk';
 
 export type SubgraphPool = V2SubgraphPool | V3SubgraphPool | V4SubgraphPool;
 export type CandidatePoolsBySelectionCriteria = {
@@ -765,10 +766,11 @@ export async function getV4CandidatePools({
 
   const tokenPairsRaw = _.map<
     V4SubgraphPool,
-    [Token, Token, number, number, string] | undefined
+    [Currency, Currency, number, number, string] | undefined
   >(subgraphPools, (subgraphPool) => {
-    const tokenA = tokenAccessor.getTokenByAddress(subgraphPool.token0.id);
-    const tokenB = tokenAccessor.getTokenByAddress(subgraphPool.token1.id);
+    // native currency is not erc20 token, therefore there's no way to retrieve native currency metadata as the erc20 token.
+    const tokenA = isNativeCurrency(subgraphPool.token0.id) ? nativeOnChain(chainId) : tokenAccessor.getTokenByAddress(subgraphPool.token0.id);
+    const tokenB = isNativeCurrency(subgraphPool.token1.id) ? nativeOnChain(chainId) : tokenAccessor.getTokenByAddress(subgraphPool.token1.id);
     let fee: FeeAmount;
     try {
       fee = Number(subgraphPool.feeTier);

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -3,6 +3,7 @@ import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
 import { ADDRESS_ZERO, FeeAmount } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
+import { isNativeCurrency } from '@uniswap/universal-router-sdk';
 import {
   DAI_OPTIMISM_SEPOLIA,
   ITokenListProvider,
@@ -80,15 +81,15 @@ import {
 import {
   getAddress,
   getAddressLowerCase,
-  getApplicableV3FeeAmounts, nativeOnChain,
+  getApplicableV3FeeAmounts,
+  nativeOnChain,
   unparseFeeAmount,
-  WRAPPED_NATIVE_CURRENCY
+  WRAPPED_NATIVE_CURRENCY,
 } from '../../../util';
 import { parseFeeAmount } from '../../../util/amounts';
 import { log } from '../../../util/log';
 import { metric, MetricLoggerUnit } from '../../../util/metric';
 import { AlphaRouterConfig } from '../alpha-router';
-import { isNativeCurrency } from '@uniswap/universal-router-sdk';
 
 export type SubgraphPool = V2SubgraphPool | V3SubgraphPool | V4SubgraphPool;
 export type CandidatePoolsBySelectionCriteria = {
@@ -769,8 +770,12 @@ export async function getV4CandidatePools({
     [Currency, Currency, number, number, string] | undefined
   >(subgraphPools, (subgraphPool) => {
     // native currency is not erc20 token, therefore there's no way to retrieve native currency metadata as the erc20 token.
-    const tokenA = isNativeCurrency(subgraphPool.token0.id) ? nativeOnChain(chainId) : tokenAccessor.getTokenByAddress(subgraphPool.token0.id);
-    const tokenB = isNativeCurrency(subgraphPool.token1.id) ? nativeOnChain(chainId) : tokenAccessor.getTokenByAddress(subgraphPool.token1.id);
+    const tokenA = isNativeCurrency(subgraphPool.token0.id)
+      ? nativeOnChain(chainId)
+      : tokenAccessor.getTokenByAddress(subgraphPool.token0.id);
+    const tokenB = isNativeCurrency(subgraphPool.token1.id)
+      ? nativeOnChain(chainId)
+      : tokenAccessor.getTokenByAddress(subgraphPool.token1.id);
     let fee: FeeAmount;
     try {
       fee = Number(subgraphPool.feeTier);

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -3774,6 +3774,34 @@ describe('quote for other networks', () => {
             expect(swap).not.toBeNull();
           });
 
+          it(`erc20 -> ${native}`, async () => {
+            if (chain !== ChainId.SEPOLIA) {
+              return;
+            }
+
+            const tokenIn = USDC_NATIVE_SEPOLIA;
+            const tokenOut = nativeOnChain(chain);
+
+            const amount = tradeType == TradeType.EXACT_INPUT ?
+              parseAmount('0.000001', tokenIn):
+              parseAmount('0.00000000000001', tokenOut);
+
+            const swap = await alphaRouter.route(
+              amount,
+              getQuoteToken(tokenIn, tokenOut, tradeType),
+              tradeType,
+              undefined,
+              {
+                // @ts-ignore[TS7053] - complaining about switch being non exhaustive
+                ...DEFAULT_ROUTING_CONFIG_BY_CHAIN[chain],
+                protocols: chain === ChainId.SEPOLIA ? [Protocol.V4] : [Protocol.V3, Protocol.V2],
+                universalRouterVersion: UniversalRouterVersion.V2_0
+              }
+            );
+            expect(swap).toBeDefined();
+            expect(swap).not.toBeNull();
+          });
+
           it(`has quoteGasAdjusted values`, async () => {
             if (chain === ChainId.SEPOLIA && !erc1.equals(V4_SEPOLIA_TEST_A)) {
               // Sepolia doesn't have sufficient liquidity on DAI pools yet


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Native currency routing has a bug of not properly considering the native currency candidate pools in v4

- **What is the new behavior (if this is a feature change)?**
We will consider native currency pools in candidate pool. Native currency is not ERC20 token, so we cannot get metadata for the native currency. Therefore we should not filter out native currency

- **Other information**:
Added ETH -> USDC quote for v4 in sepolia. 