### PR TITLE
fix: native currency routing quote token has to be currency type

### DIFF
--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1315,7 +1315,6 @@ export class AlphaRouter
       await partialRoutingConfig.blockNumber
     );
 
-    const quoteToken = quoteCurrency.wrapped;
     // const gasTokenAccessor = await this.tokenProvider.getTokens([routingConfig.gasToken!]);
     const gasToken = routingConfig.gasToken
       ? (
@@ -1344,7 +1343,7 @@ export class AlphaRouter
     } = await this.getGasModels(
       gasPriceWei,
       amount.currency.wrapped,
-      quoteToken,
+      quoteCurrency.wrapped,
       providerConfig
     );
 
@@ -1359,7 +1358,7 @@ export class AlphaRouter
       (await this.routeCachingProvider?.getCacheMode(
         this.chainId,
         amount,
-        quoteToken,
+        quoteCurrency,
         tradeType,
         protocols
       ));
@@ -1370,7 +1369,7 @@ export class AlphaRouter
       cachedRoutes = await this.routeCachingProvider?.getCachedRoute(
         this.chainId,
         amount,
-        quoteToken,
+        quoteCurrency,
         tradeType,
         protocols,
         await blockNumber,
@@ -1452,7 +1451,7 @@ export class AlphaRouter
         cachedRoutes,
         await blockNumber,
         amount,
-        quoteToken,
+        quoteCurrency,
         tradeType,
         routingConfig,
         v3GasModel,
@@ -1473,7 +1472,7 @@ export class AlphaRouter
         currencyIn,
         currencyOut,
         protocols,
-        quoteToken,
+        quoteCurrency,
         tradeType,
         routingConfig,
         v3GasModel,
@@ -1795,7 +1794,7 @@ export class AlphaRouter
     cachedRoutes: CachedRoutes,
     blockNumber: number,
     amount: CurrencyAmount,
-    quoteToken: Token,
+    quoteCurrency: Currency,
     tradeType: TradeType,
     routingConfig: AlphaRouterConfig,
     v3GasModel: IGasModel<V3RouteWithValidQuote>,
@@ -1876,7 +1875,7 @@ export class AlphaRouter
             v4RoutesFromCache,
             amounts,
             percents,
-            quoteToken,
+            quoteCurrency,
             tradeType,
             routingConfig,
             undefined,
@@ -1913,7 +1912,7 @@ export class AlphaRouter
               v3RoutesFromCache,
               amounts,
               percents,
-              quoteToken,
+              quoteCurrency.wrapped,
               tradeType,
               routingConfig,
               undefined,
@@ -1952,7 +1951,7 @@ export class AlphaRouter
             v2RoutesFromCache,
             amounts,
             percents,
-            quoteToken,
+            quoteCurrency.wrapped,
             tradeType,
             routingConfig,
             gasPriceWei
@@ -1988,7 +1987,7 @@ export class AlphaRouter
               mixedRoutesFromCache,
               amounts,
               percents,
-              quoteToken,
+              quoteCurrency.wrapped,
               tradeType,
               routingConfig,
               undefined,
@@ -2034,7 +2033,7 @@ export class AlphaRouter
     currencyIn: Currency,
     currencyOut: Currency,
     protocols: Protocol[],
-    quoteToken: Token,
+    quoteCurrency: Currency,
     tradeType: TradeType,
     routingConfig: AlphaRouterConfig,
     v3GasModel: IGasModel<V3RouteWithValidQuote>,
@@ -2200,7 +2199,7 @@ export class AlphaRouter
               amount,
               amounts,
               percents,
-              quoteToken,
+              quoteCurrency,
               v4CandidatePools!,
               tradeType,
               routingConfig,
@@ -2242,7 +2241,7 @@ export class AlphaRouter
                 amount,
                 amounts,
                 percents,
-                quoteToken,
+                quoteCurrency.wrapped,
                 v3CandidatePools!,
                 tradeType,
                 routingConfig,
@@ -2284,7 +2283,7 @@ export class AlphaRouter
               amount,
               amounts,
               percents,
-              quoteToken,
+              quoteCurrency.wrapped,
               v2CandidatePools!,
               tradeType,
               routingConfig,
@@ -2347,7 +2346,7 @@ export class AlphaRouter
                   amount,
                   amounts,
                   percents,
-                  quoteToken,
+                  quoteCurrency.wrapped,
                   [
                     v4CandidatePools!,
                     v3CandidatePools!,

--- a/src/routers/alpha-router/quoters/base-quoter.ts
+++ b/src/routers/alpha-router/quoters/base-quoter.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Protocol } from '@uniswap/router-sdk';
-import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
+import { ChainId, Currency, TradeType } from '@uniswap/sdk-core';
 import _ from 'lodash';
 
 import {
@@ -110,7 +110,7 @@ export abstract class BaseQuoter<
     routes: Route[],
     amounts: CurrencyAmount[],
     percents: number[],
-    quoteToken: Token,
+    quoteToken: TCurrency,
     tradeType: TradeType,
     routingConfig: AlphaRouterConfig,
     candidatePools?: CandidatePoolsBySelectionCriteria,
@@ -138,7 +138,7 @@ export abstract class BaseQuoter<
     amount: CurrencyAmount,
     amounts: CurrencyAmount[],
     percents: number[],
-    quoteToken: Token,
+    quoteToken: TCurrency,
     candidatePools: CandidatePools,
     tradeType: TradeType,
     routingConfig: AlphaRouterConfig,

--- a/src/routers/alpha-router/quoters/v4-quoter.ts
+++ b/src/routers/alpha-router/quoters/v4-quoter.ts
@@ -222,7 +222,7 @@ export class V4Quoter extends BaseQuoter<V4CandidatePools, V4Route, Currency> {
           initializedTicksCrossedList,
           quoterGasEstimate: gasEstimate,
           gasModel,
-          // TODO: make it unwrapped, once v4 gas model supports native quote currency
+          // TODO: ROUTE-306 make it unwrapped, once v4 gas model supports native quote currency
           // For now it's ok to keep it wrapped,
           // because the quote is the fairly accurate quote from the native currency routing
           quoteToken: quoteCurrency.wrapped,

--- a/src/routers/alpha-router/quoters/v4-quoter.ts
+++ b/src/routers/alpha-router/quoters/v4-quoter.ts
@@ -222,6 +222,9 @@ export class V4Quoter extends BaseQuoter<V4CandidatePools, V4Route, Currency> {
           initializedTicksCrossedList,
           quoterGasEstimate: gasEstimate,
           gasModel,
+          // TODO: make it unwrapped, once v4 gas model supports native quote currency
+          // For now it's ok to keep it wrapped,
+          // because the quote is the fairly accurate quote from the native currency routing
           quoteToken: quoteCurrency.wrapped,
           tradeType,
           v4PoolProvider: this.v4PoolProvider,

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -538,6 +538,7 @@ export function initSwapRouteFromExisting(
       : undefined,
     simulationStatus: swapRoute.simulationStatus,
     portionAmount: swapRoute.portionAmount,
+    hitsCachedRoute: swapRoute.hitsCachedRoute,
   };
 }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
native currency routing quote is token not currency. v4 native currency quote cannot work. For example, ETH -> USDC exact out quote will not route through v4 ETH/USDC pool.

- **What is the new behavior (if this is a feature change)?**
fix the quote token to be quote currency in the input path until on-chain quoter

- **Other information**:
for v4-quoter.ts output quote can be token. we will have to fix the v4 gas model to take quote token as currency type. more details in ROUTE-306