### PR TITLE
chore: bump sor to 4.7.0 - feat: SOR level implementation to support 1) expanding mixed quoter v1 to L2s 2) support migrate mixed quoter v1 to mixed quoter v2 across chains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.6.2",
+  "version": "4.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.6.2",
+      "version": "4.7.0",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.6.2",
+  "version": "4.7.0",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -95,6 +95,7 @@ import { Erc20__factory } from '../../types/other/factories/Erc20__factory';
 import {
   getAddress,
   getAddressLowerCase,
+  MIXED_SUPPORTED,
   shouldWipeoutCachedRoutes,
   SWAP_ROUTER_02_ADDRESSES,
   V4_SUPPORTED,
@@ -318,6 +319,11 @@ export type AlphaRouterParams = {
   v4Supported?: ChainId[];
 
   /**
+   * All the supported mixed chains configuration
+   */
+  mixedSupported?: ChainId[];
+
+  /**
    * The version of the universal router to use.
    */
   universalRouterVersion?: UniversalRouterVersion;
@@ -536,6 +542,7 @@ export class AlphaRouter
   protected portionProvider: IPortionProvider;
   protected v2Supported?: ChainId[];
   protected v4Supported?: ChainId[];
+  protected mixedSupported?: ChainId[];
   protected universalRouterVersion?: UniversalRouterVersion;
 
   constructor({
@@ -566,6 +573,7 @@ export class AlphaRouter
     portionProvider,
     v2Supported,
     v4Supported,
+    mixedSupported,
     universalRouterVersion,
   }: AlphaRouterParams) {
     this.chainId = chainId;
@@ -997,6 +1005,7 @@ export class AlphaRouter
 
     this.v2Supported = v2Supported ?? V2_SUPPORTED;
     this.v4Supported = v4Supported ?? V4_SUPPORTED;
+    this.mixedSupported = mixedSupported ?? MIXED_SUPPORTED;
     this.universalRouterVersion =
       universalRouterVersion ?? UniversalRouterVersion.V1_2;
   }
@@ -2078,9 +2087,8 @@ export class AlphaRouter
       protocols.includes(Protocol.MIXED) ||
       (noProtocolsSpecified && v2SupportedInChain && v4SupportedInChain);
     const mixedProtocolAllowed =
-      [ChainId.MAINNET, ChainId.SEPOLIA, ChainId.GOERLI].includes(
-        this.chainId
-      ) && tradeType === TradeType.EXACT_INPUT;
+      this.mixedSupported?.includes(this.chainId) &&
+      tradeType === TradeType.EXACT_INPUT;
 
     const beforeGetCandidates = Date.now();
 

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -621,21 +621,27 @@ export class AlphaRouter
                 quoteMinSuccessRate: 0.1,
               };
             },
-            {
-              gasLimitOverride: 3_000_000,
-              multicallChunk: 45,
+            (_) => {
+              return {
+                gasLimitOverride: 3_000_000,
+                multicallChunk: 45,
+              };
             },
-            {
-              gasLimitOverride: 3_000_000,
-              multicallChunk: 45,
+            (_) => {
+              return {
+                gasLimitOverride: 3_000_000,
+                multicallChunk: 45,
+              };
             },
-            {
-              baseBlockOffset: -10,
-              rollback: {
-                enabled: true,
-                attemptsBeforeRollback: 1,
-                rollbackBlockOffset: -10,
-              },
+            (_) => {
+              return {
+                baseBlockOffset: -10,
+                rollback: {
+                  enabled: true,
+                  attemptsBeforeRollback: 1,
+                  rollbackBlockOffset: -10,
+                },
+              };
             }
           );
           break;
@@ -661,21 +667,27 @@ export class AlphaRouter
                 quoteMinSuccessRate: 0.1,
               };
             },
-            {
-              gasLimitOverride: 3_000_000,
-              multicallChunk: 45,
+            (_) => {
+              return {
+                gasLimitOverride: 3_000_000,
+                multicallChunk: 45,
+              };
             },
-            {
-              gasLimitOverride: 3_000_000,
-              multicallChunk: 45,
+            (_) => {
+              return {
+                gasLimitOverride: 3_000_000,
+                multicallChunk: 45,
+              };
             },
-            {
-              baseBlockOffset: -10,
-              rollback: {
-                enabled: true,
-                attemptsBeforeRollback: 1,
-                rollbackBlockOffset: -10,
-              },
+            (_) => {
+              return {
+                baseBlockOffset: -10,
+                rollback: {
+                  enabled: true,
+                  attemptsBeforeRollback: 1,
+                  rollbackBlockOffset: -10,
+                },
+              };
             }
           );
           break;
@@ -696,21 +708,27 @@ export class AlphaRouter
                 quoteMinSuccessRate: 0.1,
               };
             },
-            {
-              gasLimitOverride: 6_000_000,
-              multicallChunk: 13,
+            (_) => {
+              return {
+                gasLimitOverride: 6_000_000,
+                multicallChunk: 13,
+              };
             },
-            {
-              gasLimitOverride: 6_000_000,
-              multicallChunk: 13,
+            (_) => {
+              return {
+                gasLimitOverride: 6_000_000,
+                multicallChunk: 13,
+              };
             },
-            {
-              baseBlockOffset: -10,
-              rollback: {
-                enabled: true,
-                attemptsBeforeRollback: 1,
-                rollbackBlockOffset: -10,
-              },
+            (_) => {
+              return {
+                baseBlockOffset: -10,
+                rollback: {
+                  enabled: true,
+                  attemptsBeforeRollback: 1,
+                  rollbackBlockOffset: -10,
+                },
+              };
             }
           );
           break;
@@ -733,13 +751,17 @@ export class AlphaRouter
                 quoteMinSuccessRate: 0.1,
               };
             },
-            {
-              gasLimitOverride: 30_000_000,
-              multicallChunk: 6,
+            (_) => {
+              return {
+                gasLimitOverride: 30_000_000,
+                multicallChunk: 6,
+              };
             },
-            {
-              gasLimitOverride: 30_000_000,
-              multicallChunk: 6,
+            (_) => {
+              return {
+                gasLimitOverride: 30_000_000,
+                multicallChunk: 6,
+              };
             }
           );
           break;
@@ -761,13 +783,17 @@ export class AlphaRouter
                 quoteMinSuccessRate: 0.1,
               };
             },
-            {
-              gasLimitOverride: 5_000_000,
-              multicallChunk: 5,
+            (_) => {
+              return {
+                gasLimitOverride: 5_000_000,
+                multicallChunk: 5,
+              };
             },
-            {
-              gasLimitOverride: 6_250_000,
-              multicallChunk: 4,
+            (_) => {
+              return {
+                gasLimitOverride: 6_250_000,
+                multicallChunk: 4,
+              };
             }
           );
           break;
@@ -781,9 +807,9 @@ export class AlphaRouter
             this.multicall2Provider,
             RETRY_OPTIONS[chainId],
             (_) => BATCH_PARAMS[chainId]!,
-            GAS_ERROR_FAILURE_OVERRIDES[chainId],
-            SUCCESS_RATE_FAILURE_OVERRIDES[chainId],
-            BLOCK_NUMBER_CONFIGS[chainId]
+            (_) => GAS_ERROR_FAILURE_OVERRIDES[chainId]!,
+            (_) => SUCCESS_RATE_FAILURE_OVERRIDES[chainId]!,
+            (_) => BLOCK_NUMBER_CONFIGS[chainId]!
           );
           break;
         default:
@@ -793,9 +819,9 @@ export class AlphaRouter
             this.multicall2Provider,
             DEFAULT_RETRY_OPTIONS,
             (_) => DEFAULT_BATCH_PARAMS,
-            DEFAULT_GAS_ERROR_FAILURE_OVERRIDES,
-            DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
-            DEFAULT_BLOCK_NUMBER_CONFIGS
+            (_) => DEFAULT_GAS_ERROR_FAILURE_OVERRIDES,
+            (_) => DEFAULT_SUCCESS_RATE_FAILURE_OVERRIDES,
+            (_) => DEFAULT_BLOCK_NUMBER_CONFIGS
           );
           break;
       }

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -46,6 +46,12 @@ export const V2_SUPPORTED = [
 
 export const V4_SUPPORTED = [ChainId.SEPOLIA];
 
+export const MIXED_SUPPORTED = [
+  ChainId.MAINNET,
+  ChainId.SEPOLIA,
+  ChainId.GOERLI,
+];
+
 export const HAS_L1_FEE = [
   ChainId.OPTIMISM,
   ChainId.OPTIMISM_GOERLI,

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -40,8 +40,6 @@ export const V2_SUPPORTED = [
   ChainId.BASE,
   ChainId.BNB,
   ChainId.AVALANCHE,
-  ChainId.WORLDCHAIN,
-  ChainId.ASTROCHAIN_SEPOLIA,
 ];
 
 export const V4_SUPPORTED = [ChainId.SEPOLIA];

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -132,7 +132,7 @@ const GAS_ESTIMATE_DEVIATION_PERCENT: { [chainId in ChainId]: number } = {
   [ChainId.MAINNET]: 50,
   [ChainId.GOERLI]: 62,
   [ChainId.SEPOLIA]: 75,
-  [ChainId.OPTIMISM]: 61,
+  [ChainId.OPTIMISM]: 71,
   [ChainId.OPTIMISM_GOERLI]: 30,
   [ChainId.OPTIMISM_SEPOLIA]: 30,
   [ChainId.ARBITRUM_ONE]: 53,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
right now, mixed routing is only supported on L1 (plus L1 testnet).

- **What is the new behavior (if this is a feature change)?**
we want to be able to expand mixed routing support to L2s. There are multiple stages:
1) routing-api to shadow sample mixed routing against mixed quoter v1 across L2s. There's no accuracy to compare, just make sure routing-api shadow mixed routing success rate is high - existing metrics in routing-api `ON_CHAIN_QUOTE_PROVIDER_${this.EXACT_IN_METRIC}_TRAFFIC_TARGET_FAILED_CHAIN_ID_${this.chainId}`
2) routing-api to live traffic switch mixed routing against mixed quoter v1  across L2s. Again there's no accuracy to compare, but we can live switch gradually per chain. We will check the quote endpoint success rate doesn;'t drop.
3) routing-api to shadow sampling mixed routing against mixed quoter v2. mixed quoter v2 contains v4 pools, but v4 is only deployed to sepolia, hence this can only happen after we deployed v4 to production nets. There are accuracy comparison.
4) routing-api to live traffic switch mixed routing against mixed quoter v2. We will check the quote endpoint success rate doesn;'t drop.

- **Other information**:
routing-api needs some changes as well, in order to achieve 1-4

