### PR TITLE
chore: bump SOR to 4.7.2 - fix: add v4 related split routes metrics and routeToString

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -95,8 +95,8 @@ export const routeToString = (route: SupportedRoutes): string => {
         pool.token0,
         pool.token1,
         pool.fee,
-        0,
-        ADDRESS_ZERO
+        pool.tickSpacing,
+        pool.hooks
       )}]`;
     } else {
       throw new Error(`Unsupported pool ${JSON.stringify(pool)}`);
@@ -131,7 +131,7 @@ export const routeAmountsToString = (
     const percent = new Percent(portion.numerator, portion.denominator);
     /// @dev special case for MIXED routes we want to show user friendly V2+V3 instead
     return `[${
-      protocol == Protocol.MIXED ? 'V2 + V3' : protocol
+      protocol == Protocol.MIXED ? 'V2 + V3 + V4' : protocol
     }] ${percent.toFixed(2)}% = ${routeToString(route)}`;
   });
 

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -1,4 +1,4 @@
-import { ADDRESS_ZERO, Protocol } from '@uniswap/router-sdk';
+import { Protocol } from '@uniswap/router-sdk';
 import { Currency, Percent } from '@uniswap/sdk-core';
 import { Pair } from '@uniswap/v2-sdk';
 import { Pool as V3Pool } from '@uniswap/v3-sdk';

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -50,8 +50,8 @@ export const poolToString = (pool: TPool): string => {
       pool.token0,
       pool.token1,
       pool.fee,
-      0,
-      ADDRESS_ZERO
+      pool.tickSpacing,
+      pool.hooks
     )}]`;
   } else if (pool instanceof V3Pool) {
     return ` -- ${pool.fee / 10000}% [${V3Pool.getAddress(


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
forgot to emit v4 related split routes metrics

- **What is the new behavior (if this is a feature change)?**
emit v4 related split routes metrics

- **Other information**:
this is to keep track of an edge case, that i dont expect happen frequently https://linear.app/uniswap/issue/ROUTE-303/tech-debt-split-route-can-have-different-ethweth-input-or-output#comment-a0b9a66a