### PR TITLE
chore: bump sor to 4.7.1 - fix: v4 subgraph provider add ETH base token, and custom fee tier and tick spacings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/caching-subgraph-provider.ts
+++ b/src/providers/caching-subgraph-provider.ts
@@ -1,8 +1,8 @@
 import { Protocol } from '@uniswap/router-sdk';
-import { ChainId, Token } from '@uniswap/sdk-core';
+import { ChainId, Currency, Token } from '@uniswap/sdk-core';
 
 import { SubgraphPool } from '../routers/alpha-router/functions/get-candidate-pools';
-import { WRAPPED_NATIVE_CURRENCY } from '../util';
+import { nativeOnChain, WRAPPED_NATIVE_CURRENCY } from '../util';
 
 import { ICache } from './cache';
 import { ProviderConfig } from './provider';
@@ -53,11 +53,12 @@ import {
 import { V3SubgraphPool } from './v3/subgraph-provider';
 
 type ChainTokenList = {
-  readonly [chainId in ChainId]: Token[];
+  readonly [chainId in ChainId]: Currency[];
 };
 
 export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
   [ChainId.MAINNET]: [
+    nativeOnChain(ChainId.MAINNET),
     WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET]!,
     DAI_MAINNET,
     USDC_MAINNET,
@@ -66,9 +67,13 @@ export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
     WSTETH_MAINNET,
   ],
   [ChainId.GOERLI]: [WRAPPED_NATIVE_CURRENCY[ChainId.GOERLI]!],
-  [ChainId.SEPOLIA]: [WRAPPED_NATIVE_CURRENCY[ChainId.SEPOLIA]!],
+  [ChainId.SEPOLIA]: [
+    nativeOnChain(ChainId.SEPOLIA),
+    WRAPPED_NATIVE_CURRENCY[ChainId.SEPOLIA]!,
+  ],
   //v2 not deployed on [arbitrum, polygon, celo, gnosis, moonbeam, bnb, avalanche] and their testnets
   [ChainId.OPTIMISM]: [
+    nativeOnChain(ChainId.OPTIMISM),
     WRAPPED_NATIVE_CURRENCY[ChainId.OPTIMISM]!,
     USDC_OPTIMISM,
     DAI_OPTIMISM,
@@ -77,6 +82,7 @@ export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
     OP_OPTIMISM,
   ],
   [ChainId.ARBITRUM_ONE]: [
+    nativeOnChain(ChainId.ARBITRUM_ONE),
     WRAPPED_NATIVE_CURRENCY[ChainId.ARBITRUM_ONE]!,
     WBTC_ARBITRUM,
     DAI_ARBITRUM,
@@ -89,7 +95,12 @@ export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
   [ChainId.ARBITRUM_SEPOLIA]: [],
   [ChainId.OPTIMISM_GOERLI]: [],
   [ChainId.OPTIMISM_SEPOLIA]: [],
-  [ChainId.POLYGON]: [USDC_POLYGON, WETH_POLYGON, WMATIC_POLYGON],
+  [ChainId.POLYGON]: [
+    nativeOnChain(ChainId.POLYGON),
+    USDC_POLYGON,
+    WETH_POLYGON,
+    WMATIC_POLYGON,
+  ],
   [ChainId.POLYGON_MUMBAI]: [],
   [ChainId.CELO]: [CELO, CUSD_CELO, CEUR_CELO, DAI_CELO],
   [ChainId.CELO_ALFAJORES]: [],
@@ -101,6 +112,7 @@ export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
     WBTC_MOONBEAM,
   ],
   [ChainId.BNB]: [
+    nativeOnChain(ChainId.BNB),
     WRAPPED_NATIVE_CURRENCY[ChainId.BNB],
     BUSD_BNB,
     DAI_BNB,
@@ -115,23 +127,36 @@ export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
     DAI_AVAX,
   ],
   [ChainId.BASE_GOERLI]: [],
-  [ChainId.BASE]: [WRAPPED_NATIVE_CURRENCY[ChainId.BASE], USDC_BASE],
-  [ChainId.ZORA]: [WRAPPED_NATIVE_CURRENCY[ChainId.ZORA]!],
+  [ChainId.BASE]: [
+    nativeOnChain(ChainId.BASE),
+    WRAPPED_NATIVE_CURRENCY[ChainId.BASE],
+    USDC_BASE,
+  ],
+  [ChainId.ZORA]: [
+    nativeOnChain(ChainId.ZORA),
+    WRAPPED_NATIVE_CURRENCY[ChainId.ZORA]!,
+  ],
   [ChainId.ZORA_SEPOLIA]: [WRAPPED_NATIVE_CURRENCY[ChainId.ZORA_SEPOLIA]!],
   [ChainId.ROOTSTOCK]: [WRAPPED_NATIVE_CURRENCY[ChainId.ROOTSTOCK]!],
-  [ChainId.BLAST]: [WRAPPED_NATIVE_CURRENCY[ChainId.BLAST]!, USDB_BLAST],
+  [ChainId.BLAST]: [
+    nativeOnChain(ChainId.BLAST),
+    WRAPPED_NATIVE_CURRENCY[ChainId.BLAST]!,
+    USDB_BLAST,
+  ],
   [ChainId.ZKSYNC]: [
     WRAPPED_NATIVE_CURRENCY[ChainId.ZKSYNC]!,
     USDCE_ZKSYNC,
     USDC_ZKSYNC,
   ],
   [ChainId.WORLDCHAIN]: [
+    nativeOnChain(ChainId.WORLDCHAIN),
     WRAPPED_NATIVE_CURRENCY[ChainId.WORLDCHAIN]!,
     USDC_WORLDCHAIN,
     WLD_WORLDCHAIN,
     WBTC_WORLDCHAIN,
   ],
   [ChainId.ASTROCHAIN_SEPOLIA]: [
+    nativeOnChain(ChainId.ASTROCHAIN_SEPOLIA),
     WRAPPED_NATIVE_CURRENCY[ChainId.ASTROCHAIN_SEPOLIA]!,
     USDC_ASTROCHAIN_SEPOLIA,
   ],

--- a/src/providers/v4/static-subgraph-provider.ts
+++ b/src/providers/v4/static-subgraph-provider.ts
@@ -6,7 +6,6 @@ import {
   getAddress,
   getApplicableV4FeesTickspacingsHooks,
   log,
-  unparseFeeAmount,
 } from '../../util';
 import { BASES_TO_CHECK_TRADES_AGAINST } from '../caching-subgraph-provider';
 
@@ -97,7 +96,7 @@ export class StaticV4SubgraphProvider implements IV4SubgraphProvider {
 
         return {
           id: poolAddress,
-          feeTier: unparseFeeAmount(fee),
+          feeTier: fee.toString(),
           tickSpacing: tickSpacing.toString(),
           hooks: hooks,
           liquidity: liquidity.toString(),

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -95,8 +95,8 @@ import { Erc20__factory } from '../../types/other/factories/Erc20__factory';
 import {
   getAddress,
   getAddressLowerCase,
-  MIXED_SUPPORTED,
   getApplicableV4FeesTickspacingsHooks,
+  MIXED_SUPPORTED,
   shouldWipeoutCachedRoutes,
   SWAP_ROUTER_02_ADDRESSES,
   V4_SUPPORTED,

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -565,7 +565,7 @@ export async function getV4CandidatePools({
         );
         return {
           id: poolId,
-          feeTier: unparseFeeAmount(fee),
+          feeTier: fee.toString(),
           tickSpacing: tickSpacing.toString(),
           hooks: hooks,
           liquidity: '10000',

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -1,6 +1,6 @@
 import { Protocol } from '@uniswap/router-sdk';
 import { ChainId, Currency, Token, TradeType } from '@uniswap/sdk-core';
-import { ADDRESS_ZERO, FeeAmount } from '@uniswap/v3-sdk';
+import { FeeAmount } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
 import { isNativeCurrency } from '@uniswap/universal-router-sdk';
@@ -82,6 +82,7 @@ import {
   getAddress,
   getAddressLowerCase,
   getApplicableV3FeeAmounts,
+  getApplicableV4FeesTickspacingsHooks,
   nativeOnChain,
   unparseFeeAmount,
   WRAPPED_NATIVE_CURRENCY,
@@ -135,6 +136,7 @@ export type V4GetCandidatePoolsParams = {
   poolProvider: IV4PoolProvider;
   blockedTokenListProvider?: ITokenListProvider;
   chainId: ChainId;
+  v4PoolParams?: Array<[number, number, string]>;
 };
 
 export type V3GetCandidatePoolsParams = {
@@ -414,6 +416,7 @@ export async function getV4CandidatePools({
   poolProvider,
   blockedTokenListProvider,
   chainId,
+  v4PoolParams = getApplicableV4FeesTickspacingsHooks(chainId),
 }: V4GetCandidatePoolsParams): Promise<V4CandidatePools> {
   const {
     blockNumber,
@@ -549,12 +552,7 @@ export async function getV4CandidatePools({
     // Optimistically add them into the query regardless. Invalid pools ones will be dropped anyway
     // when we query the pool on-chain. Ensures that new pools for new pairs can be swapped on immediately.
     top2DirectSwapPool = _.map(
-      [
-        [FeeAmount.HIGH, 200, ADDRESS_ZERO],
-        [FeeAmount.MEDIUM, 60, ADDRESS_ZERO],
-        [FeeAmount.LOW, 10, ADDRESS_ZERO],
-        [FeeAmount.LOWEST, 1, ADDRESS_ZERO],
-      ] as Array<[number, number, string]>,
+      v4PoolParams as Array<[number, number, string]>,
       (poolParams) => {
         const [fee, tickSpacing, hooks] = poolParams;
 

--- a/src/util/amounts.ts
+++ b/src/util/amounts.ts
@@ -1,10 +1,11 @@
 import { parseUnits } from '@ethersproject/units';
+import { ADDRESS_ZERO } from '@uniswap/router-sdk';
 import {
   ChainId,
   Currency,
   CurrencyAmount as CurrencyAmountRaw,
 } from '@uniswap/sdk-core';
-import { FeeAmount } from '@uniswap/v3-sdk';
+import { FeeAmount, TICK_SPACINGS } from '@uniswap/v3-sdk';
 import JSBI from 'jsbi';
 
 export class CurrencyAmount extends CurrencyAmountRaw<Currency> {}
@@ -72,4 +73,25 @@ export function getApplicableV3FeeAmounts(chainId: ChainId): FeeAmount[] {
   }
 
   return feeAmounts;
+}
+
+export function getApplicableV4FeesTickspacingsHooks(
+  chainId: ChainId
+): Array<[number, number, string]> {
+  const feeAmounts = [
+    FeeAmount.HIGH,
+    FeeAmount.MEDIUM,
+    FeeAmount.LOW,
+    FeeAmount.LOWEST,
+  ];
+
+  if (chainId === ChainId.BASE) {
+    feeAmounts.push(FeeAmount.LOW_200, FeeAmount.LOW_300, FeeAmount.LOW_400);
+  }
+
+  return feeAmounts.map((feeAmount) => [
+    feeAmount as number,
+    TICK_SPACINGS[feeAmount],
+    ADDRESS_ZERO,
+  ]);
 }

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -50,6 +50,7 @@ import {
   DAI_ON,
   EthEstimateGasSimulator,
   FallbackTenderlySimulator,
+  getApplicableV4FeesTickspacingsHooks,
   ID_TO_NETWORK_NAME,
   ID_TO_PROVIDER,
   MethodParameters,
@@ -3599,6 +3600,13 @@ describe('quote for other networks', () => {
               multicall2Provider,
               v4SubgraphProvider,
               simulator,
+              v4PoolParams: getApplicableV4FeesTickspacingsHooks(chain).concat(
+                [
+                  [500, 10, '0x0000000000000000000000000000000000000020'],
+                  [1500, 30, '0x0000000000000000000000000000000000000020'],
+                  [3000, 60, '0x0000000000000000000000000000000000000020'],
+                ]
+              ),
             });
           } else {
             alphaRouter = new AlphaRouter({
@@ -3606,6 +3614,13 @@ describe('quote for other networks', () => {
               provider,
               multicall2Provider,
               simulator,
+              v4PoolParams: getApplicableV4FeesTickspacingsHooks(chain).concat(
+                [
+                  [500, 10, '0x0000000000000000000000000000000000000020'],
+                  [1500, 30, '0x0000000000000000000000000000000000000020'],
+                  [3000, 60, '0x0000000000000000000000000000000000000020'],
+                ]
+              ),
             });
           }
         });
@@ -3650,7 +3665,7 @@ describe('quote for other networks', () => {
 
             const tokenIn = wrappedNative;
             const tokenOut = erc1;
-            const amount = ChainId.ASTROCHAIN_SEPOLIA ?
+            const amount = chain === ChainId.ASTROCHAIN_SEPOLIA ?
               tradeType == TradeType.EXACT_INPUT ?
                 parseAmount('0.001', tokenIn):
                 parseAmount('0.001', tokenOut) :
@@ -3717,7 +3732,7 @@ describe('quote for other networks', () => {
 
             // Current WETH/USDB pool (https://blastscan.io/address/0xf52b4b69123cbcf07798ae8265642793b2e8990c) has low WETH amount
             const exactOutAmount = '1';
-            const amount = ChainId.ASTROCHAIN_SEPOLIA ?
+            const amount = chain === ChainId.ASTROCHAIN_SEPOLIA ?
               tradeType == TradeType.EXACT_INPUT ?
                 parseAmount('0.001', tokenIn):
                 parseAmount('0.001', tokenOut) :
@@ -3765,12 +3780,9 @@ describe('quote for other networks', () => {
                 ? tradeType == TradeType.EXACT_INPUT
                   ? parseAmount('10', tokenIn)
                   : parseAmount('10', tokenOut)
-                : (chain !== ChainId.SEPOLIA ? tradeType == TradeType.EXACT_INPUT
+                : tradeType == TradeType.EXACT_INPUT
                   ? parseAmount('1', tokenIn)
-                  : parseAmount('1', tokenOut) :
-                  tradeType == TradeType.EXACT_INPUT ?
-                  parseAmount('0.00000000000001', tokenIn):
-                  parseAmount('0.000001', tokenOut));
+                  : parseAmount('1', tokenOut);
 
             const swap = await alphaRouter.route(
               amount,
@@ -3796,9 +3808,12 @@ describe('quote for other networks', () => {
             const tokenIn = USDC_NATIVE_SEPOLIA;
             const tokenOut = nativeOnChain(chain);
 
+            // as of now, in sepolia v4, v4 pools having > 1eth is only the ETH/USDC pools with hook address 0x0000000000000000000000000000000000000020
+            // this means if we try an exact in 1 ETH -> USDC quote against v4 sepolia, the only way is to route through v4 ETH/USDC pools with hook address 0x0000000000000000000000000000000000000020
+            // this validates that the getApplicableV4FeesTickspacingsHooks along with the hardcoded fees + tickspacings + hook address 0x0000000000000000000000000000000000000020 are working as expected
             const amount = tradeType == TradeType.EXACT_INPUT ?
-              parseAmount('0.000001', tokenIn):
-              parseAmount('0.00000000000001', tokenOut);
+              parseAmount('1', tokenIn)
+              : parseAmount('1', tokenOut);
 
             const swap = await alphaRouter.route(
               amount,
@@ -3827,7 +3842,7 @@ describe('quote for other networks', () => {
 
             // Current WETH/USDB pool (https://blastscan.io/address/0xf52b4b69123cbcf07798ae8265642793b2e8990c) has low WETH amount
             const exactOutAmount = '1';
-            const amount = ChainId.ASTROCHAIN_SEPOLIA ?
+            const amount = chain === ChainId.ASTROCHAIN_SEPOLIA ?
               tradeType == TradeType.EXACT_INPUT ?
                 parseAmount('0.001', tokenIn):
                 parseAmount('0.001', tokenOut) :
@@ -3873,7 +3888,7 @@ describe('quote for other networks', () => {
 
             // Current WETH/USDB pool (https://blastscan.io/address/0xf52b4b69123cbcf07798ae8265642793b2e8990c) has low WETH amount
             const exactOutAmount = chain === ChainId.BLAST ? '0.002' : '1';
-            const amount = ChainId.ASTROCHAIN_SEPOLIA ?
+            const amount = chain === ChainId.ASTROCHAIN_SEPOLIA ?
               tradeType == TradeType.EXACT_INPUT ?
                 parseAmount('0.001', tokenIn):
                 parseAmount('0.001', tokenOut) :

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -3958,7 +3958,7 @@ describe('quote for other networks', () => {
               const amount =
                 tradeType == TradeType.EXACT_INPUT
                   ? parseAmount(chain === ChainId.ZORA || chain === ChainId.WORLDCHAIN || chain === ChainId.ASTROCHAIN_SEPOLIA ? '0.001' : '10', tokenIn)
-                  : parseAmount('10', tokenOut);
+                  : parseAmount(chain === ChainId.ASTROCHAIN_SEPOLIA ? '0.001' : '10', tokenOut);
 
               // Universal Router is not deployed on Gorli.
               const swapWithSimulationOptions: SwapOptions =


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Right now v4 is hardcoded with v3 fee tiers and tickspacings. Also static subgraph provider is not able to get native ETH v4 pool.

- **What is the new behavior (if this is a feature change)?**
allow routing-api to pass in more v4 custom fee tiers and tickspacings on a per-need basis. Also static subgraph should get ETH base token to get native v4 pool. Later is in case the v4 subgraph has too many bugs so that we cannot rely on live subgraph to filter by TVL.

- **Other information**:
