### PR TITLE
fix: await set cached routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.7.5",
+  "version": "4.7.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.7.5",
+      "version": "4.7.6",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.7.5",
+  "version": "4.7.6",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1710,7 +1710,7 @@ export class AlphaRouter
               amount.toExact()
             );
 
-            this.setCachedRoutesAndLog(
+            await this.setCachedRoutesAndLog(
               amount,
               currencyIn,
               currencyOut,
@@ -1772,7 +1772,7 @@ export class AlphaRouter
         amount.toExact()
       );
 
-      this.setCachedRoutesAndLog(
+      await this.setCachedRoutesAndLog(
         amount,
         currencyIn,
         currencyOut,
@@ -1911,9 +1911,7 @@ export class AlphaRouter
     routesToCache?: CachedRoutes
   ): Promise<void> {
     if (routesToCache) {
-      // Attempt to insert the entry in cache. This is fire and forget promise.
-      // The catch method will prevent any exception from blocking the normal code execution.
-      this.routeCachingProvider
+      await this.routeCachingProvider
         ?.setCachedRoute(routesToCache, amount)
         .then((success) => {
           const status = success ? 'success' : 'rejected';


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We fire and forget the set cached routes

- **What is the new behavior (if this is a feature change)?**
We await on set cached routes in both old and new code paths.

- **Other information**:
