### PR TITLE
chore: Add AQTIS token to default allowlist

### DIFF
--- a/src/providers/token-validator-provider.ts
+++ b/src/providers/token-validator-provider.ts
@@ -16,6 +16,8 @@ import { ProviderConfig } from './provider';
 export const DEFAULT_ALLOWLIST = new Set<string>([
   // RYOSHI. Does not allow transfers between contracts so fails validation.
   '0x777E2ae845272a2F540ebf6a3D03734A5a8f618e'.toLowerCase(),
+  // AQTIS. Validation fails
+  '0x6FF2241756549B5816A177659E766EAf14B34429'.toLowerCase()
 ]);
 
 export enum TokenValidationResult {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Enables routing for AQTIS V3 Pool.



- **What is the current behavior?** (You can also link to an open issue here)
Executing the following command:
```
./bin/cli quote --tokenIn 0x6ff2241756549b5816a177659e766eaf14b34429 --tokenOut 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 --amount 1000000000000000 --exactIn --recipient 0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B --protocols v3
```
Returns: `Could not find route. Run in debug mode for more info.`


- **What is the new behavior (if this is a feature change)?**
After the following change, it returns the correct v3 route path.


- **Other information**:

Previously we had v2 pool for [AQTIS](https://etherscan.io/address/0x6ff2241756549b5816a177659e766eaf14b34429) token, which had transfer fee tax. We eliminated this for V3 Pool.
Another thing to note is that if you change the following number:
https://github.com/KovacZan/smart-order-router/blob/617314a85b84ee954e036407766598653c0e7ab6/src/providers/token-validator-provider.ts#L34
to `20` or `1000000000000000` you get the correct v3 route.