### PR TITLE
chore: more granular metrics for routes/quotes fetched

### DIFF
--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -242,11 +242,30 @@ export class MixedQuoter extends BaseQuoter<
     );
 
     metric.putMetric(
+      `MixedQuotesLoad_Chain_${this.chainId}`,
+      Date.now() - beforeQuotes
+    );
+
+    metric.putMetric(
       'MixedQuotesFetched',
       _(routesWithQuotes)
         .map(([, quotes]) => quotes.length)
         .sum(),
       MetricLoggerUnit.Count
+    );
+
+    metric.putMetric(
+      `MixedQuotesFetched_Chain_${this.chainId}`,
+      _(routesWithQuotes)
+        .map(([, quotes]) => quotes.length)
+        .sum()
+    );
+
+    metric.putMetric(`MixedRoutesFetched`, _(routesWithQuotes).sum());
+
+    metric.putMetric(
+      `MixedRoutesFetched_Chain_${this.chainId}`,
+      _(routesWithQuotes).sum()
     );
 
     const routesWithValidQuotes = [];

--- a/src/routers/alpha-router/quoters/v2-quoter.ts
+++ b/src/routers/alpha-router/quoters/v2-quoter.ts
@@ -206,11 +206,30 @@ export class V2Quoter extends BaseQuoter<V2CandidatePools, V2Route, Token> {
     );
 
     metric.putMetric(
+      `V2QuotesLoad_Chain_${this.chainId}`,
+      Date.now() - beforeQuotes
+    );
+
+    metric.putMetric(
       'V2QuotesFetched',
       _(routesWithQuotes)
         .map(([, quotes]) => quotes.length)
         .sum(),
       MetricLoggerUnit.Count
+    );
+
+    metric.putMetric(
+      `V2QuotesFetched_Chain_${this.chainId}`,
+      _(routesWithQuotes)
+        .map(([, quotes]) => quotes.length)
+        .sum()
+    );
+
+    metric.putMetric(`V2RoutesFetched`, _(routesWithQuotes).sum());
+
+    metric.putMetric(
+      `V2RoutesFetched_Chain_${this.chainId}`,
+      _(routesWithQuotes).sum()
     );
 
     const routesWithValidQuotes = [];

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -175,11 +175,30 @@ export class V3Quoter extends BaseQuoter<V3CandidatePools, V3Route, Token> {
     );
 
     metric.putMetric(
+      `V3QuotesLoad_Chain_${this.chainId}`,
+      Date.now() - beforeQuotes
+    );
+
+    metric.putMetric(
       'V3QuotesFetched',
       _(routesWithQuotes)
         .map(([, quotes]) => quotes.length)
         .sum(),
       MetricLoggerUnit.Count
+    );
+
+    metric.putMetric(
+      `V3QuotesFetched_Chain_${this.chainId}`,
+      _(routesWithQuotes)
+        .map(([, quotes]) => quotes.length)
+        .sum()
+    );
+
+    metric.putMetric(`V3RoutesFetched`, _(routesWithQuotes).sum());
+
+    metric.putMetric(
+      `V3RoutesFetched_Chain_${this.chainId}`,
+      _(routesWithQuotes).sum()
     );
 
     const routesWithValidQuotes = [];

--- a/src/routers/alpha-router/quoters/v4-quoter.ts
+++ b/src/routers/alpha-router/quoters/v4-quoter.ts
@@ -174,11 +174,30 @@ export class V4Quoter extends BaseQuoter<V4CandidatePools, V4Route, Currency> {
     );
 
     metric.putMetric(
+      `V4QuotesLoad_Chain_${this.chainId}`,
+      Date.now() - beforeQuotes
+    );
+
+    metric.putMetric(
       'V4QuotesFetched',
       _(routesWithQuotes)
         .map(([, quotes]) => quotes.length)
         .sum(),
       MetricLoggerUnit.Count
+    );
+
+    metric.putMetric(
+      `V4QuotesFetched_Chain_${this.chainId}`,
+      _(routesWithQuotes)
+        .map(([, quotes]) => quotes.length)
+        .sum()
+    );
+
+    metric.putMetric(`V4RoutesFetched`, _(routesWithQuotes).sum());
+
+    metric.putMetric(
+      `V4RoutesFetched_Chain_${this.chainId}`,
+      _(routesWithQuotes).sum()
     );
 
     const routesWithValidQuotes = [];


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds more granular metrics for routes/quotes fetched.
This will give us more visibility on onChain effort, total routes, total quotes fetched per chain.

- **What is the current behavior?** (You can also link to an open issue here)
Only logging number of quotes/latency at the top level 

- **What is the new behavior (if this is a feature change)?**
Logging quotes/routes/latency at top + per chain level.

- **Other information**:
