### PR TITLE
chore: bump to 4.7.8 - fix: return a new tenderly simulation status in case of tenderly downtime

### DIFF
--- a/src/providers/simulation-provider.ts
+++ b/src/providers/simulation-provider.ts
@@ -31,6 +31,7 @@ export enum SimulationStatus {
   Succeeded = 2,
   InsufficientBalance = 3,
   NotApproved = 4,
+  SystemDown = 5,
 }
 
 /**

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -223,7 +223,7 @@ export class FallbackTenderlySimulator extends Simulator {
           MetricLoggerUnit.Count
         );
       }
-      return { ...swapRoute, simulationStatus: SimulationStatus.Failed };
+      return { ...swapRoute, simulationStatus: SimulationStatus.SystemDown };
     }
   }
 }
@@ -440,6 +440,12 @@ export class TenderlySimulator extends Simulator {
           1,
           MetricLoggerUnit.Count
         );
+        // technically, we can also early return SimulationStatus.SystemDown when http status is not 200.
+        // in reality, when tenderly is down for whatever reason, i see it always throw during axios http request
+        // so that it hits the catch block in https://github.com/Uniswap/smart-order-router/blob/8bfec299001d3204483f761f57a38be04512a948/src/providers/tenderly-simulation-provider.ts#L226
+        // which is where we want to actually return SimulationStatus.SystemDown
+        // in other words, I've never see a TenderlySimulationUniversalRouterResponseStatus metric with a non-200 status
+        // if there's downtime, it won't log metric at https://github.com/Uniswap/smart-order-router/blob/8bfec299001d3204483f761f57a38be04512a948/src/providers/tenderly-simulation-provider.ts#L434
 
         // Validate tenderly response body
         if (

--- a/test/unit/providers/simulation-provider.test.ts
+++ b/test/unit/providers/simulation-provider.test.ts
@@ -270,7 +270,7 @@ describe('Fallback Tenderly simulator', () => {
     );
     expect(tenderlySimulator.simulateTransaction.called).toBeTruthy();
     expect(swapRouteWithGasEstimate.simulationStatus).toEqual(
-      SimulationStatus.Failed
+      SimulationStatus.SystemDown
     );
   });
   test('when eth estimate gas simulator throws, try tenderly anyway', async () => {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Right now when tenderly has system downtime, we do not differentiate from when tenderly simulation returns a failed simulated transaction, in case of the Simulation Status, as FAILED.

- **What is the new behavior (if this is a feature change)?**
In case of tenderly downtime, we return SystemDown simulation status from SOR.

- **Other information**:
It will get populated in routing to return a new simulation status as "SYSTEM_DOWN"