### PR TITLE
fix: Don't force add direct swap AMPL pools for V3 in candidate pools

### DIFF
--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -65,6 +65,13 @@ export const DAI_MAINNET = new Token(
   'DAI',
   'Dai Stablecoin'
 );
+export const AMPL_MAINNET = new Token(
+  ChainId.MAINNET,
+  '0xD46bA6D942050d489DBd938a2C909A5d5039A161',
+  9,
+  'AMPL',
+  'AMPL'
+);
 export const FEI_MAINNET = new Token(
   ChainId.MAINNET,
   '0x956F47F50A910163D8BF957Cf5846D573E7f87CA',

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -992,13 +992,16 @@ export async function getV3CandidatePools({
     .value();
 
   if (top2DirectSwapPool.length == 0 && topNDirectSwaps > 0) {
-    // We don't want to re-add AMPL token pools for V3.
+    // We don't want to re-add AMPL token pools for V3 in Mainnet.
     // TODO: ROUTE-347, Remove this check once we have a better way to sync filters from subgraph cronjob <> routing path.
     if (
-      tokenIn.address.toLowerCase() !==
-        '0xd46ba6d942050d489dbd938a2c909a5d5039a161' &&
-      tokenOut.address.toLowerCase() !==
-        '0xd46ba6d942050d489dbd938a2c909a5d5039a161'
+      !(
+        chainId == ChainId.MAINNET &&
+        (tokenIn.address.toLowerCase() ===
+          '0xd46ba6d942050d489dbd938a2c909a5d5039a161' ||
+          tokenOut.address.toLowerCase() ===
+            '0xd46ba6d942050d489dbd938a2c909a5d5039a161')
+      )
     ) {
       // If we requested direct swap pools but did not find any in the subgraph query.
       // Optimistically add them into the query regardless. Invalid pools ones will be dropped anyway

--- a/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
+++ b/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
@@ -489,7 +489,7 @@ describe('get candidate pools', () => {
           buildMockV3PoolAccessor([...poolsOnSubgraph, DAI_WETH_LOW])
         );
 
-        await getV3CandidatePools({
+        const candidatePools = await getV3CandidatePools({
           tokenIn: WRAPPED_NATIVE_CURRENCY[1]!,
           tokenOut: AMPL_MAINNET,
           routeType: TradeType.EXACT_INPUT,
@@ -507,9 +507,7 @@ describe('get candidate pools', () => {
           chainId: ChainId.MAINNET,
         });
 
-        expect(
-          mockV3PoolProvider.getPools.calledWithExactly([], { blockNumber: undefined })
-        ).toBeTruthy();
+        expect(candidatePools.candidatePools.selections.topByDirectSwapPool.length).toEqual(0);
       }
     });
 

--- a/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
+++ b/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
@@ -8,6 +8,7 @@ import sinon from 'sinon';
 import { USDC_BASE } from '../../../../../build/main';
 import {
   AlphaRouterConfig,
+  AMPL_MAINNET,
   CachingTokenListProvider,
   DAI_MAINNET as DAI, sortsBefore,
   TokenProvider,
@@ -454,6 +455,60 @@ describe('get candidate pools', () => {
             [DAI, WRAPPED_NATIVE_CURRENCY[1]!, FeeAmount.LOW, 10, ADDRESS_ZERO],
             [DAI, WRAPPED_NATIVE_CURRENCY[1]!, FeeAmount.LOWEST, 1, ADDRESS_ZERO],
           ], { blockNumber: undefined })
+        ).toBeTruthy();
+      }
+    });
+
+    test(`AMPL token pools are not added by force to direct swap pools even if they dont exist in the subgraph for protocol ${protocol}`, async () => {
+      if (protocol === Protocol.V3) {
+        // Mock so that DAI_WETH exists on chain, but not in the subgraph
+        const poolsOnSubgraph = [
+          USDC_DAI_LOW,
+          USDC_DAI_MEDIUM,
+          USDC_WETH_LOW,
+          WETH9_USDT_LOW,
+          DAI_USDT_LOW,
+        ];
+
+        const subgraphPools: V3SubgraphPool[] = _.map(
+          poolsOnSubgraph,
+          poolToV3SubgraphPool
+        );
+
+        mockV3SubgraphProvider.getPools.resolves(subgraphPools);
+
+        const DAI_WETH_LOW = new V3Pool(
+          DAI,
+          WRAPPED_NATIVE_CURRENCY[1]!,
+          FeeAmount.LOW,
+          encodeSqrtRatioX96(1, 1),
+          10,
+          0
+        );
+        mockV3PoolProvider.getPools.resolves(
+          buildMockV3PoolAccessor([...poolsOnSubgraph, DAI_WETH_LOW])
+        );
+
+        await getV3CandidatePools({
+          tokenIn: WRAPPED_NATIVE_CURRENCY[1]!,
+          tokenOut: AMPL_MAINNET,
+          routeType: TradeType.EXACT_INPUT,
+          routingConfig: {
+            ...ROUTING_CONFIG,
+            v3PoolSelection: {
+              ...ROUTING_CONFIG.v3PoolSelection,
+              topNDirectSwaps: 1,
+            },
+          },
+          poolProvider: mockV3PoolProvider,
+          subgraphProvider: mockV3SubgraphProvider,
+          tokenProvider: mockTokenProvider,
+          blockedTokenListProvider: mockBlockTokenListProvider,
+          chainId: ChainId.MAINNET,
+        });
+
+        expect(
+          mockV3PoolProvider.getPools.calledWithExactly([], { blockNumber: undefined })
         ).toBeTruthy();
       }
     });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix: 
We do filter out AMPL pools from subgraph query but direct swap pools are re-added by get-candidate-pools logic.
This PR prevents AMPL direct swap pools from getting re-added.

This is CX ask.