### PR TITLE
chore: add gas estimation quality metric

### DIFF
--- a/src/providers/eth-estimate-gas-provider.ts
+++ b/src/providers/eth-estimate-gas-provider.ts
@@ -127,11 +127,7 @@ export class EthEstimateGasSimulator extends Simulator {
       providerConfig
     );
 
-    logGasEstimationVsSimulationMetrics(
-      route,
-      estimatedGasUsedUSD,
-      this.chainId
-    );
+    logGasEstimationVsSimulationMetrics(route, estimatedGasUsed, this.chainId);
 
     return {
       ...initSwapRouteFromExisting(

--- a/src/providers/eth-estimate-gas-provider.ts
+++ b/src/providers/eth-estimate-gas-provider.ts
@@ -12,6 +12,7 @@ import { BEACON_CHAIN_DEPOSIT_ADDRESS, log } from '../util';
 import {
   calculateGasUsed,
   initSwapRouteFromExisting,
+  logGasEstimationVsSimulationMetrics,
 } from '../util/gas-factory-helpers';
 
 import { IPortionProvider } from './portion-provider';
@@ -125,6 +126,13 @@ export class EthEstimateGasSimulator extends Simulator {
       this.provider,
       providerConfig
     );
+
+    logGasEstimationVsSimulationMetrics(
+      route,
+      estimatedGasUsedUSD,
+      this.chainId
+    );
+
     return {
       ...initSwapRouteFromExisting(
         route,

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -29,6 +29,7 @@ import { APPROVE_TOKEN_FOR_TRANSFER } from '../util/callData';
 import {
   calculateGasUsed,
   initSwapRouteFromExisting,
+  logGasEstimationVsSimulationMetrics,
 } from '../util/gas-factory-helpers';
 
 import { EthEstimateGasSimulator } from './eth-estimate-gas-provider';
@@ -691,46 +692,11 @@ export class TenderlySimulator extends Simulator {
       providerConfig
     );
 
-    // Log metrics about the diff between original estimatedGasUsed based on heuristics and the simulated gas used.
-    // This will help us track the quality of our gas estimation quality per chain.
-    // Wrap in try-catch to avoid failing the simulation if the logging fails for any reason.
-    try {
-      // Log the diff between original estimatedGasUsed and the simulated gas used
-      const originalEstimatedGasUsedUsd = swapRoute.estimatedGasUsedUSD;
-      const diff = estimatedGasUsedUSD.subtract(swapRoute.estimatedGasUsedUSD);
-      log.info(
-        {
-          originalEstimatedGasUsedUsd: originalEstimatedGasUsedUsd.toString(),
-          estimatedGasUsedUSD: estimatedGasUsedUSD.toString(),
-          diff: diff.toString(),
-        },
-        'Gas used diff in USD'
-      );
-      metric.putMetric(
-        `TenderlySimulationGasUsedDiffUSD_Chain_${chainId}`,
-        Number(diff.toExact()),
-        MetricLoggerUnit.Count
-      );
-      const misEstimatePercent = diff
-        .divide(originalEstimatedGasUsedUsd)
-        .multiply(100);
-      log.info(
-        {
-          misEstimatePercent: misEstimatePercent.toString(),
-        },
-        'Gas used mis-estimate percent'
-      );
-      metric.putMetric(
-        `TenderlySimulationGasUsedMisEstimatePercent_Chain_${chainId}`,
-        Number(misEstimatePercent.toExact()),
-        MetricLoggerUnit.Count
-      );
-    } catch (err) {
-      log.error(
-        { err: err },
-        'Failed to log diff between original estimatedGasUsed and the simulated gas used'
-      );
-    }
+    logGasEstimationVsSimulationMetrics(
+      swapRoute,
+      estimatedGasUsedUSD,
+      chainId
+    );
 
     return {
       ...initSwapRouteFromExisting(

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -692,11 +692,7 @@ export class TenderlySimulator extends Simulator {
       providerConfig
     );
 
-    logGasEstimationVsSimulationMetrics(
-      swapRoute,
-      estimatedGasUsedUSD,
-      chainId
-    );
+    logGasEstimationVsSimulationMetrics(swapRoute, estimatedGasUsed, chainId);
 
     return {
       ...initSwapRouteFromExisting(

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -697,30 +697,28 @@ export const calculateL1GasFeesHelper = async (
 // This will help us track the quality of our gas estimation quality per chain.
 export const logGasEstimationVsSimulationMetrics = (
   route: SwapRoute,
-  simulatedGasUsedUSDAmount: CurrencyAmount,
+  simulationGasUsed: BigNumber,
   chainId: ChainId
 ) => {
   try {
     // Log the diff between original estimatedGasUsed and the simulated gas used
-    const originalEstimatedGasUsedUSD = Number(
-      route.estimatedGasUsedUSD.toExact()
-    );
-    const simulatedGasUsedUSD = Number(simulatedGasUsedUSDAmount.toExact());
-    const absDiff = Math.abs(originalEstimatedGasUsedUSD - simulatedGasUsedUSD);
+    const estimatedGasUsed = route.estimatedGasUsed.toNumber();
+    const simulatedGasUsed = simulationGasUsed.toNumber();
+    const absDiff = Math.abs(estimatedGasUsed - simulatedGasUsed);
     log.info(
       {
-        estimatedGasUsedUSD: originalEstimatedGasUsedUSD,
-        simulatedGasUsedUSD: simulatedGasUsedUSD,
+        estimatedGasUsed: estimatedGasUsed,
+        simulatedGasUsed: simulatedGasUsed,
         absDiff: absDiff,
       },
-      'Gas used diff in USD'
+      'Gas used diff between estimatedGasUsed and simulatedGasUsed'
     );
     metric.putMetric(
-      `TenderlySimulationGasUsedDiffUSD_Chain_${chainId}`,
+      `TenderlySimulationGasUsedDiff_Chain_${chainId}`,
       absDiff,
       MetricLoggerUnit.Count
     );
-    const misEstimatePercent = (absDiff / originalEstimatedGasUsedUSD) * 100;
+    const misEstimatePercent = (absDiff / estimatedGasUsed) * 100;
     log.info(
       {
         misEstimatePercent: misEstimatePercent,

--- a/src/util/gas-factory-helpers.ts
+++ b/src/util/gas-factory-helpers.ts
@@ -704,29 +704,41 @@ export const logGasEstimationVsSimulationMetrics = (
     // Log the diff between original estimatedGasUsed and the simulated gas used
     const estimatedGasUsed = route.estimatedGasUsed.toNumber();
     const simulatedGasUsed = simulationGasUsed.toNumber();
+    const diff = estimatedGasUsed - simulatedGasUsed;
     const absDiff = Math.abs(estimatedGasUsed - simulatedGasUsed);
+    const misEstimatePercent = (diff / estimatedGasUsed) * 100;
+    const misEstimateAbsPercent = (absDiff / estimatedGasUsed) * 100;
+
     log.info(
       {
         estimatedGasUsed: estimatedGasUsed,
         simulatedGasUsed: simulatedGasUsed,
         absDiff: absDiff,
+        diff: diff,
       },
       'Gas used diff between estimatedGasUsed and simulatedGasUsed'
     );
-    metric.putMetric(
-      `TenderlySimulationGasUsedDiff_Chain_${chainId}`,
-      absDiff,
-      MetricLoggerUnit.Count
-    );
-    const misEstimatePercent = (absDiff / estimatedGasUsed) * 100;
     log.info(
       {
-        misEstimatePercent: misEstimatePercent,
+        misEstimateAbsPercent: misEstimateAbsPercent,
       },
       'Gas used mis-estimate percent'
     );
+
     metric.putMetric(
-      `TenderlySimulationGasUsedMisEstimatePercent_Chain_${chainId}`,
+      `TenderlySimulationGasUsed_AbsDiff_Chain_${chainId}`,
+      absDiff,
+      MetricLoggerUnit.Count
+    );
+    metric.putMetric(
+      `TenderlySimulationGasUsed_MisEstimateAbsPercent_Chain_${chainId}`,
+      misEstimateAbsPercent,
+      MetricLoggerUnit.Count
+    );
+
+    const label = diff >= 0 ? 'OverEstimate' : 'UnderEstimate';
+    metric.putMetric(
+      `TenderlySimulationGasUsed_${label}Percent_Chain_${chainId}`,
       misEstimatePercent,
       MetricLoggerUnit.Count
     );


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 
Introduces metrics for gas estimation quality.
Compares original gas estimate vs simulation gas estimate.


```
INFO:  Gas used diff between estimatedGasUsed and simulatedGasUsed
  estimatedGasUsed: 6364814
  simulatedGasUsed: 7582384
  absDiff: 1217570
  diff: -1217570

INFO:  Gas used mis-estimate percent
  misEstimateAbsPercent: 19.12970276900472

INFO:  [Metric]: TenderlySimulationGasUsed_AbsDiff_Chain_1: 1217570 | Count
  chainId: 1
  networkName: "mainnet"
  pair: "ETH/UNI"
  tokenIn: "0x0000000000000000000000000000000000000000"
  tokenOut: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
  tradeType: "ExactIn"
  key: "TenderlySimulationGasUsed_AbsDiff_Chain_1"
  value: 1217570
  unit: "Count"

INFO:  [Metric]: TenderlySimulationGasUsed_MisEstimateAbsPercent_Chain_1: 19.12970276900472 | Count
  chainId: 1
  networkName: "mainnet"
  pair: "ETH/UNI"
  tokenIn: "0x0000000000000000000000000000000000000000"
  tokenOut: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
  tradeType: "ExactIn"
  key: "TenderlySimulationGasUsed_MisEstimateAbsPercent_Chain_1"
  value: 19.12970276900472
  unit: "Count"

INFO:  [Metric]: TenderlySimulationGasUsed_UnderEstimatePercent_Chain_1: -19.12970276900472 | Count
  chainId: 1
  networkName: "mainnet"
  pair: "ETH/UNI"
  tokenIn: "0x0000000000000000000000000000000000000000"
  tokenOut: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
  tradeType: "ExactIn"
  key: "TenderlySimulationGasUsed_UnderEstimatePercent_Chain_1"
  value: -19.12970276900472
  unit: "Count"
```