### PR TITLE
chore: bump sor to 4.8.4 - fix(subgraph): include all VIRTUAL/* poolsin V2 Base subgraph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.8.3",
+      "version": "4.8.4",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bump sor to 4.8.4 to include https://github.com/Uniswap/smart-order-router/pull/773