### PR TITLE
fix: Use syntheticGasCostInTermsOfQuoteToken only if within 30% of gasCostInTermsOfQuoteToken

### DIFF
--- a/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
@@ -213,7 +213,7 @@ export abstract class TickBasedHeuristicGasModelFactory<
               gasCostInTermsOfQuoteToken.asFraction
             ) &&
             gasCostInTermsOfQuoteToken.subtract(syntheticGasCostInTermsOfQuoteToken)
-              .lessThan(gasCostInTermsOfQuoteToken.multiply(0.3))
+              .lessThan(gasCostInTermsOfQuoteToken.multiply(0.3).asFraction)
           ))
         ) {
           log.info(

--- a/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { BaseProvider } from '@ethersproject/providers';
-import { ChainId, Price } from '@uniswap/sdk-core';
+import { ChainId, Percent, Price } from '@uniswap/sdk-core';
 import { Pool } from '@uniswap/v3-sdk';
 import { CurrencyAmount, log, WRAPPED_NATIVE_CURRENCY } from '../../../util';
 import { calculateL1GasFeesHelper } from '../../../util/gas-factory-helpers';
@@ -213,7 +213,7 @@ export abstract class TickBasedHeuristicGasModelFactory<
               gasCostInTermsOfQuoteToken.asFraction
             ) &&
             gasCostInTermsOfQuoteToken.subtract(syntheticGasCostInTermsOfQuoteToken)
-              .lessThan(gasCostInTermsOfQuoteToken.multiply(0.3).asFraction)
+              .lessThan(gasCostInTermsOfQuoteToken.multiply(new Percent(30, 100)).asFraction)
           ))
         ) {
           log.info(

--- a/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
+++ b/src/routers/alpha-router/gas-models/tick-based-heuristic-gas-model.ts
@@ -205,12 +205,16 @@ export abstract class TickBasedHeuristicGasModelFactory<
         // Note that the syntheticGasCost being lessThan the original quoted value is not always strictly better
         // e.g. the scenario where the amountToken/ETH pool is very illiquid as well and returns an extremely small number
         // however, it is better to have the gasEstimation be almost 0 than almost infinity, as the user will still receive a quote
+        // Only use syntheticGasCostInTermsOfQuoteToken if it's within 30% of the original gasCostInTermsOfQuoteToken as a safeguard.
         if (
           syntheticGasCostInTermsOfQuoteToken !== null &&
-          (gasCostInTermsOfQuoteToken === null ||
+          (gasCostInTermsOfQuoteToken === null || (
             syntheticGasCostInTermsOfQuoteToken.lessThan(
               gasCostInTermsOfQuoteToken.asFraction
-            ))
+            ) &&
+            gasCostInTermsOfQuoteToken.subtract(syntheticGasCostInTermsOfQuoteToken)
+              .lessThan(gasCostInTermsOfQuoteToken.multiply(0.3))
+          ))
         ) {
           log.info(
             {

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -140,7 +140,7 @@ const GAS_ESTIMATE_DEVIATION_PERCENT: { [chainId in ChainId]: number } = {
   [ChainId.MAINNET]: 50,
   [ChainId.GOERLI]: 62,
   [ChainId.SEPOLIA]: 75,
-  [ChainId.OPTIMISM]: 71,
+  [ChainId.OPTIMISM]: 75,
   [ChainId.OPTIMISM_GOERLI]: 30,
   [ChainId.OPTIMISM_SEPOLIA]: 30,
   [ChainId.ARBITRUM_ONE]: 53,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Addresses bug where we use bad synthetic gas estimate to calculate gas.