### PR TITLE
chore: bump sor to 4.8.5 - fix: Use syntheticGasCostInTermsOfQuoteTok…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.8.4",
+  "version": "4.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.8.4",
+      "version": "4.8.5",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.8.4",
+  "version": "4.8.5",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
…en only if within 30% of gasCostInTermsOfQuoteToken

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bump sor to 4.8.5 - inlcudes https://github.com/Uniswap/smart-order-router/pull/776
