### PR TITLE
fix: pass latest to tenderly node

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -781,7 +781,7 @@ export class TenderlySimulator extends Simulator {
       this.chainId,
       this.tenderlyNodeApiKey
     );
-    const blockNumber = swap.block_number
+    const blockNumber = swap.block_number && this.chainId !== ChainId.MAINNET
       ? BigNumber.from(swap.block_number).toHexString().replace('0x0', '0x')
       : 'latest';
     const body: TenderlyNodeEstimateGasBundleBody = {

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -781,9 +781,11 @@ export class TenderlySimulator extends Simulator {
       this.chainId,
       this.tenderlyNodeApiKey
     );
-    const blockNumber = swap.block_number && this.chainId !== ChainId.MAINNET
-      ? BigNumber.from(swap.block_number).toHexString().replace('0x0', '0x')
-      : 'latest';
+    // TODO: ROUTE-362 - Revisit tenderly node simulation hardcode latest block number
+    // https://linear.app/uniswap/issue/ROUTE-362/revisit-tenderly-node-simulation-hardcode-latest-block-number
+    const blockNumber = // swap.block_number
+      // ? BigNumber.from(swap.block_number).toHexString().replace('0x0', '0x')
+      'latest';
     const body: TenderlyNodeEstimateGasBundleBody = {
       id: 1,
       jsonrpc: '2.0',


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Tenderly node block can fall behind RPC node block, hence node simulation failed with "not found".

- **What is the new behavior (if this is a feature change)?**
We pass in latest for tenderly node simulation.

- **Other information**:
