### PR TITLE
chore: bump sor to 4.9.0 - feat: migrate all other L2s tenderly sim from API to node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.8.8",
+  "version": "4.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.8.8",
+      "version": "4.9.0",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.8.8",
+  "version": "4.9.0",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -140,6 +140,18 @@ const TENDERLY_NODE_API = (chainId: ChainId, tenderlyNodeApiKey: string) => {
       return `https://mainnet.gateway.tenderly.co/${tenderlyNodeApiKey}`;
     case ChainId.BASE:
       return `https://base.gateway.tenderly.co/${tenderlyNodeApiKey}`;
+    case ChainId.ARBITRUM_ONE:
+      return `https://arbitrum-one.gateway.tenderly.co/${tenderlyNodeApiKey}`;
+    case ChainId.OPTIMISM:
+      return `https://optimism.gateway.tenderly.co/${tenderlyNodeApiKey}`;
+    case ChainId.POLYGON:
+      return `https://polygon.gateway.tenderly.co/${tenderlyNodeApiKey}`;
+    case ChainId.AVALANCHE:
+      return `https://avalanche.gateway.tenderly.co/${tenderlyNodeApiKey}`;
+    case ChainId.BLAST:
+      return `https://blast.gateway.tenderly.co/${tenderlyNodeApiKey}`;
+    case ChainId.WORLDCHAIN:
+      return `https://worldchain-mainnet.gateway.tenderly.co/${tenderlyNodeApiKey}`;
     default:
       throw new Error(
         `ChainId ${chainId} does not correspond to a tenderly node endpoint`
@@ -151,6 +163,9 @@ export const TENDERLY_NOT_SUPPORTED_CHAINS = [
   ChainId.CELO,
   ChainId.CELO_ALFAJORES,
   ChainId.ZKSYNC,
+  // tenderly node RPC supports BNB and ZORA upon request, we will make them available
+  ChainId.BNB,
+  ChainId.ZORA,
 ];
 
 // We multiply tenderly gas limit by this to overestimate gas limit

--- a/test/integ/routers/alpha-router/alpha-router.integration.test.ts
+++ b/test/integ/routers/alpha-router/alpha-router.integration.test.ts
@@ -746,7 +746,7 @@ describe('alpha router integration', () => {
       // we will start using the new tenderly node endpoint in SOR integ-test suite at 100%
       3000,
       100,
-      [ChainId.MAINNET, ChainId.BASE]
+      [ChainId.MAINNET, ChainId.BASE, ChainId.ARBITRUM_ONE, ChainId.OPTIMISM, ChainId.POLYGON, ChainId.AVALANCHE, ChainId.BLAST, ChainId.WORLDCHAIN]
     );
 
     const simulator = new FallbackTenderlySimulator(
@@ -3653,7 +3653,7 @@ describe('quote for other networks', () => {
             // we will start using the new tenderly node endpoint in SOR integ-test suite at 100%
             3000,
             100,
-            [ChainId.MAINNET, ChainId.BASE]
+            [ChainId.MAINNET, ChainId.BASE, ChainId.ARBITRUM_ONE, ChainId.OPTIMISM, ChainId.POLYGON, ChainId.AVALANCHE, ChainId.BLAST, ChainId.WORLDCHAIN]
           );
 
           const simulator = new FallbackTenderlySimulator(


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

- **What is the current behavior?** (You can also link to an open issue here)
tenderly still on API for many L2s

- **What is the new behavior (if this is a feature change)?**
migrate them to tenderly

- **Other information**:
