### PR TITLE
fix: arb tenderly node endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.9.0",
+      "version": "4.9.1",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -141,7 +141,7 @@ const TENDERLY_NODE_API = (chainId: ChainId, tenderlyNodeApiKey: string) => {
     case ChainId.BASE:
       return `https://base.gateway.tenderly.co/${tenderlyNodeApiKey}`;
     case ChainId.ARBITRUM_ONE:
-      return `https://arbitrum-one.gateway.tenderly.co/${tenderlyNodeApiKey}`;
+      return `https://arbitrum.gateway.tenderly.co/${tenderlyNodeApiKey}`;
     case ChainId.OPTIMISM:
       return `https://optimism.gateway.tenderly.co/${tenderlyNodeApiKey}`;
     case ChainId.POLYGON:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
arbitrum had wrong tenderly node endpoint https://arbitrum-one.gateway.tenderly.co/${tenderlyNodeApiKey}


- **What is the new behavior (if this is a feature change)?**
fix to have right tenderly node endpoint https://arbitrum.gateway.tenderly.co/${tenderlyNodeApiKey}


- **Other information**:
Tenderly didn't spot https://arbitrum-one.gateway.tenderly.co/${tenderlyNodeApiKey} was wrong when I was confirming with them https://uniswapteam.slack.com/archives/C01KV681S5C/p1733976476351119