### PR TITLE
fix: map virtual swap InsufficientToken as SlippageTooLow

### DIFF
--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -307,6 +307,8 @@ export class TenderlySimulator extends Simulator {
   ): Promise<SwapRoute> {
     const currencyIn = swapRoute.trade.inputAmount.currency;
     const tokenIn = currencyIn.wrapped;
+    const currencyOut = swapRoute.trade.outputAmount.currency;
+    const tokenOut = currencyOut.wrapped;
     const chainId = this.chainId;
 
     if (TENDERLY_NOT_SUPPORTED_CHAINS.includes(chainId)) {
@@ -492,6 +494,8 @@ export class TenderlySimulator extends Simulator {
             return {
               ...swapRoute,
               simulationStatus: breakDownTenderlySimulationError(
+                tokenIn,
+                tokenOut,
                 (resp.result[2] as JsonRpcError).error.data
               ),
             };

--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -601,6 +601,13 @@ export const USDC_NATIVE_BASE = new Token(
   'USDbC',
   'USD Base Coin'
 );
+export const VIRTUAL_BASE = new Token(
+  ChainId.BASE,
+  '0x0b3e328455c4059EEb9e3f84b5543F74E24e7E1b',
+  18,
+  'VIRTUAL',
+  'Virtual Protocol'
+);
 
 // Base Goerli Tokens
 export const USDC_BASE_GOERLI = new Token(

--- a/src/util/tenderlySimulationErrorBreakDown.ts
+++ b/src/util/tenderlySimulationErrorBreakDown.ts
@@ -1,6 +1,9 @@
-import { SimulationStatus } from '../providers';
+import { Token } from '@uniswap/sdk-core';
+import { SimulationStatus, VIRTUAL_BASE } from '../providers';
 
 export function breakDownTenderlySimulationError(
+  tokenIn: Token,
+  tokenOut: Token,
   data?: string
 ): SimulationStatus {
   if (data) {
@@ -12,6 +15,18 @@ export function breakDownTenderlySimulationError(
       case '0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000025556e697377617056323a20494e53554646494349454e545f4f55545055545f414d4f554e54000000000000000000000000000000000000000000000000000000': // INSUFFICIENT_OUTPUT_AMOUNT
       case '0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000034949410000000000000000000000000000000000000000000000000000000000': // IIA
         return SimulationStatus.SlippageTooLow;
+      case '0x675cae38': // InsufficientToken
+        if (
+          tokenIn.address.toLowerCase() ===
+            VIRTUAL_BASE.address.toLowerCase() ||
+          tokenOut.address.toLowerCase() === VIRTUAL_BASE.address.toLowerCase()
+        ) {
+          // if this is from virtual, we'd guess it's due to slippage too low, although it might be due to something else
+          return SimulationStatus.SlippageTooLow;
+        }
+
+        // Otherwise we don't wanna guess, just return generic failed.
+        return SimulationStatus.Failed;
       default: // we don't know why onchain execution reverted, just return generic failed.
         return SimulationStatus.Failed;
     }

--- a/test/unit/util/tenderlySimulationErrorBreakDown.test.ts
+++ b/test/unit/util/tenderlySimulationErrorBreakDown.test.ts
@@ -4,7 +4,8 @@ import {
 import {
   SimulationStatus,
   USDC_MAINNET,
-  USDT_MAINNET
+  USDT_MAINNET,
+  VIRTUAL_BASE
 } from '../../../build/main';
 
 describe('tenderly simulation error break down', () => {
@@ -41,6 +42,11 @@ describe('tenderly simulation error break down', () => {
   it('InsufficientToken', () => {
     const simulationStatus = breakDownTenderlySimulationError(USDC_MAINNET, USDT_MAINNET, '0x675cae38');
     expect(simulationStatus).toEqual(SimulationStatus.Failed);
+  });
+
+  it('InsufficientToken Virtual', () => {
+    const simulationStatus = breakDownTenderlySimulationError(USDC_MAINNET, VIRTUAL_BASE, '0x675cae38');
+    expect(simulationStatus).toEqual(SimulationStatus.SlippageTooLow);
   });
 
   it('unknown data', () => {

--- a/test/unit/util/tenderlySimulationErrorBreakDown.test.ts
+++ b/test/unit/util/tenderlySimulationErrorBreakDown.test.ts
@@ -1,46 +1,50 @@
 import {
   breakDownTenderlySimulationError
 } from '../../../src/util/tenderlySimulationErrorBreakDown';
-import { SimulationStatus } from '../../../build/main';
+import {
+  SimulationStatus,
+  USDC_MAINNET,
+  USDT_MAINNET
+} from '../../../build/main';
 
 describe('tenderly simulation error break down', () => {
   it('V3TooMuchRequested', async () => {
-    const simulationStatus = breakDownTenderlySimulationError('0x739dbe52')
+    const simulationStatus = breakDownTenderlySimulationError(USDC_MAINNET, USDT_MAINNET, '0x739dbe52')
     expect(simulationStatus).toEqual(SimulationStatus.SlippageTooLow)
   })
 
   it('V3TooLittleReceived', async () => {
-    const simulationStatus = breakDownTenderlySimulationError('0x39d35496')
+    const simulationStatus = breakDownTenderlySimulationError(USDC_MAINNET, USDT_MAINNET, '0x39d35496')
     expect(simulationStatus).toEqual(SimulationStatus.SlippageTooLow)
   })
 
   it('V2TooLittleReceived', async () => {
-    const simulationStatus = breakDownTenderlySimulationError('0x849eaf98')
+    const simulationStatus = breakDownTenderlySimulationError(USDC_MAINNET, USDT_MAINNET, '0x849eaf98')
     expect(simulationStatus).toEqual(SimulationStatus.SlippageTooLow)
   })
 
   it('V2TooMuchRequested', async () => {
-    const simulationStatus = breakDownTenderlySimulationError('0x8ab0bc16')
+    const simulationStatus = breakDownTenderlySimulationError(USDC_MAINNET, USDT_MAINNET, '0x8ab0bc16')
     expect(simulationStatus).toEqual(SimulationStatus.SlippageTooLow)
   })
 
   it('INSUFFICIENT_OUTPUT_AMOUNT', async () => {
-    const simulationStatus = breakDownTenderlySimulationError('0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000025556e697377617056323a20494e53554646494349454e545f4f55545055545f414d4f554e54000000000000000000000000000000000000000000000000000000');
+    const simulationStatus = breakDownTenderlySimulationError(USDC_MAINNET, USDT_MAINNET, '0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000025556e697377617056323a20494e53554646494349454e545f4f55545055545f414d4f554e54000000000000000000000000000000000000000000000000000000');
     expect(simulationStatus).toEqual(SimulationStatus.SlippageTooLow)
   })
 
   it('IIA', async () => {
-    const simulationStatus = breakDownTenderlySimulationError('0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000034949410000000000000000000000000000000000000000000000000000000000');
+    const simulationStatus = breakDownTenderlySimulationError(USDC_MAINNET, USDT_MAINNET, '0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000034949410000000000000000000000000000000000000000000000000000000000');
     expect(simulationStatus).toEqual(SimulationStatus.SlippageTooLow)
   })
 
   it('InsufficientToken', () => {
-    const simulationStatus = breakDownTenderlySimulationError('0x675cae38');
+    const simulationStatus = breakDownTenderlySimulationError(USDC_MAINNET, USDT_MAINNET, '0x675cae38');
     expect(simulationStatus).toEqual(SimulationStatus.Failed);
   });
 
   it('unknown data', () => {
-    const simulationStatus = breakDownTenderlySimulationError(undefined);
+    const simulationStatus = breakDownTenderlySimulationError(USDC_MAINNET, USDT_MAINNET, undefined);
     expect(simulationStatus).toEqual(SimulationStatus.Failed);
   });
 });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Sometimes slippage in virtual trading appears in the form in InsufficientToken in the universal router level

- **What is the new behavior (if this is a feature change)?**
If tokenIn or tokenOut is $VIRTUAL, map InsufficientToken to SlippageTooLow 

- **Other information**:
this might not be due to slippage too low in the exact out scenario