### PR TITLE
chore: bump sor to 4.10.1 - fix: ID_TO_NETWORK_NAME add unichain and monad testnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.10.0",
+      "version": "4.10.1",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -154,6 +154,8 @@ export enum ChainName {
   ZKSYNC = 'zksync-mainnet',
   WORLDCHAIN = 'worldchain-mainnet',
   UNICHAIN_SEPOLIA = 'unichain-sepolia',
+  UNICHAIN = 'unichain-mainnet',
+  MONAD_TESTNET = 'monad-testnet',
 }
 
 export enum NativeCurrencyName {
@@ -336,6 +338,10 @@ export const ID_TO_NETWORK_NAME = (id: number): ChainName => {
       return ChainName.WORLDCHAIN;
     case 1301:
       return ChainName.UNICHAIN_SEPOLIA;
+    case 130:
+      return ChainName.UNICHAIN;
+    case 41454:
+      return ChainName.MONAD_TESTNET;
     default:
       throw new Error(`Unknown chain id: ${id}`);
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
routing-api release pipeline failed:

> Error: Unknown chain id: 41454
    at ID_TO_NETWORK_NAME (/codebuild/output/src1403594110/src/node_modules/@uniswap/smart-order-router/src/util/chains.ts:340:13)
    at /codebuild/output/src1403594110/src/bin/stacks/routing-dashboard-stack.ts:113:78
    at Array.map (<anonymous>)
    at /codebuild/output/src1403594110/src/bin/stacks/routing-dashboard-stack.ts:108:27
    at arrayMap (/codebuild/output/src1403594110/src/node_modules/lodash/lodash.js:653:23)
    at map (/codebuild/output/src1403594110/src/node_modules/lodash/lodash.js:9622:14)
    at Function.flatMap (/codebuild/output/src1403594110/src/node_modules/lodash/lodash.js:9325:26)
    at new RoutingDashboardStack (/codebuild/output/src1403594110/src/bin/stacks/routing-dashboard-stack.ts:102:57)
    at new RoutingAPIStack (/codebuild/output/src1403594110/src/bin/stacks/routing-api-stack.ts:245:5)
    at Object.<anonymous> (/codebuild/output/src1403594110/src/bin/app.ts:420:1)


- **What is the new behavior (if this is a feature change)?**
we should add unichain and monad testnet into ID_TO_NETWORK_NAME

- **Other information**:
