### PR TITLE
chore: bump sor to 4.14.1 - add bytes32 non-null terminator logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.14.0",
+      "version": "4.14.1",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -898,12 +898,19 @@ export class TokenProvider implements ITokenProvider {
           continue;
         }
 
+        let symbol;
+
         try {
-          isBytes32
+          symbol = isBytes32
             ? parseBytes32String(symbolResult.result[0]!)
             : symbolResult.result[0]!;
         } catch (error) {
-          if (error instanceof Error && error.message.includes('invalid bytes32 string - no null terminator')) {
+          if (
+            error instanceof Error &&
+            error.message.includes(
+              'invalid bytes32 string - no null terminator'
+            )
+          ) {
             log.error(
               {
                 symbolResult,
@@ -911,13 +918,10 @@ export class TokenProvider implements ITokenProvider {
               },
               `invalid bytes32 string - no null terminator`
             );
-            continue;
           }
-        }
 
-        const symbol = isBytes32
-          ? parseBytes32String(symbolResult.result[0]!)
-          : symbolResult.result[0]!;
+          throw error;
+        }
         const decimal = decimalResult.result[0]!;
 
         addressToToken[address.toLowerCase()] = new Token(

--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -898,6 +898,23 @@ export class TokenProvider implements ITokenProvider {
           continue;
         }
 
+        try {
+          isBytes32
+            ? parseBytes32String(symbolResult.result[0]!)
+            : symbolResult.result[0]!;
+        } catch (error) {
+          if (error instanceof Error && error.message.includes('invalid bytes32 string - no null terminator')) {
+            log.error(
+              {
+                symbolResult,
+                error,
+              },
+              `invalid bytes32 string - no null terminator`
+            );
+            continue;
+          }
+        }
+
         const symbol = isBytes32
           ? parseBytes32String(symbolResult.result[0]!)
           : symbolResult.result[0]!;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
chore

- **What is the current behavior?** (You can also link to an open issue here)
we don't know which token had non-null terminator runtime error

- **What is the new behavior (if this is a feature change)?**
log it so that we know

- **Other information**:
