### PR TITLE
chore: bump sor to 4.14.2 - add bytes32 non-null terminator token address logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.14.1",
+      "version": "4.14.2",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -915,6 +915,7 @@ export class TokenProvider implements ITokenProvider {
               {
                 symbolResult,
                 error,
+                address,
               },
               `invalid bytes32 string - no null terminator`
             );


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

- **What is the current behavior?** (You can also link to an open issue here)
we know token symbol 0x0000000000000000000000000000000000000000000000000000000000000020, but we don't know token address.

- **What is the new behavior (if this is a feature change)?**
log token address.

- **Other information**:
