### PR TITLE
fix: bump sor to 4.14.3 - fix: tenderly doesn't support monad testnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.14.2",
+  "version": "4.14.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.14.2",
+      "version": "4.14.3",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.14.2",
+  "version": "4.14.3",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/tenderly-simulation-provider.ts
+++ b/src/providers/tenderly-simulation-provider.ts
@@ -166,6 +166,7 @@ export const TENDERLY_NOT_SUPPORTED_CHAINS = [
   // tenderly node RPC supports BNB and ZORA upon request, we will make them available
   ChainId.BNB,
   ChainId.ZORA,
+  ChainId.MONAD_TESTNET,
 ];
 
 // We multiply tenderly gas limit by this to overestimate gas limit


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
tenderly doesn't support monad testnet

- **What is the new behavior (if this is a feature change)?**
bypass tenderly for monad testnt

- **Other information**:
