### PR TITLE
fix: don't use cachedRoutes if intent.caching (1% experiment)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.19.0",
+  "version": "4.19.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.19.0",
+      "version": "4.19.1",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.19.0",
+  "version": "4.19.1",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -3200,21 +3200,22 @@ export class AlphaRouter
     );
   }
 
-  // Percentage of time we allow using cached routes. We start with 99% to gradually roll out the change.
-  public static readonly CACHED_ROUTES_EXPERIMENT_FLAG_ENABLED_DEFAULT_PERCENTAGE = 0.99;
+  // Percentage of time we want to skip cached routes for the experiment.
+  // Starting with 1% to gradually roll out the change.
+  public static readonly CACHED_ROUTES_SKIP_EXPERIMENT_FLAG_PERCENTAGE = 0.01;
 
   // We want to skip cached routes access whenever "intent === INTENT.CACHING".
   // To verify this functionality though, we want to start by using a percentage of the time.
   public static isAllowedToEnterCachedRoutes(intent?: INTENT): boolean {
-    // By default, we allow the access to cached routes (original functionality - 99% of the time)
-    const shouldAllow =
-      Math.random() <
-      AlphaRouter.CACHED_ROUTES_EXPERIMENT_FLAG_ENABLED_DEFAULT_PERCENTAGE;
-    if (shouldAllow) {
-      return true;
+    // Check if we should run the experiment
+    const shouldRunExperiment =
+      Math.random() < AlphaRouter.CACHED_ROUTES_SKIP_EXPERIMENT_FLAG_PERCENTAGE;
+    if (shouldRunExperiment) {
+      // For the experiment group, we want to skip the cached routes access if the intent is caching
+      return intent !== INTENT.CACHING;
     }
 
-    // For the remaining percent of the time, we want to skip the cached routes access if the intent is caching.
-    return intent !== INTENT.CACHING;
+    // For the control group, we always allow access to cached routes.
+    return true;
   }
 }

--- a/test/unit/routers/alpha-router/alpha-router.test.ts
+++ b/test/unit/routers/alpha-router/alpha-router.test.ts
@@ -3101,14 +3101,14 @@ describe('alpha router', () => {
     });
 
     test('returns correct values based on random percentage and intent', () => {
-      // Test when random is below threshold (should always return true)
-      randomStub.returns(AlphaRouter.CACHED_ROUTES_EXPERIMENT_FLAG_ENABLED_DEFAULT_PERCENTAGE - 0.01);
+      // Test when random is above experiment threshold (control group - should always return true)
+      randomStub.returns(AlphaRouter.CACHED_ROUTES_SKIP_EXPERIMENT_FLAG_PERCENTAGE + 0.01);
       expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.CACHING)).toBe(true);
       expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.QUOTE)).toBe(true);
       expect(AlphaRouter.isAllowedToEnterCachedRoutes(undefined)).toBe(true);
 
-      // Test when random is above threshold
-      randomStub.returns(AlphaRouter.CACHED_ROUTES_EXPERIMENT_FLAG_ENABLED_DEFAULT_PERCENTAGE + 0.001);
+      // Test when random is below experiment threshold (experiment group)
+      randomStub.returns(AlphaRouter.CACHED_ROUTES_SKIP_EXPERIMENT_FLAG_PERCENTAGE - 0.001);
       // Should return false only for CACHING intent
       expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.CACHING)).toBe(false);
       // Should return true for other intents


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 
Bug fix

- **What is the current behavior?**
Cached routes are still used when intent.caching

- **What is the new behavior?**
Don't use cachedRoutes if intent.caching
Start with `1%` experiment to validate and measure rpc/latency increase

