### PR TITLE
chore: bump sor to 4.20.4 - log cached routes change metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.3",
+  "version": "4.20.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.20.3",
+      "version": "4.20.4",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.3",
+  "version": "4.20.4",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -151,10 +151,7 @@ import {
 import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
 import { DEFAULT_BLOCKS_TO_LIVE } from '../../util/defaultBlocksToLive';
 import { INTENT } from '../../util/intent';
-import {
-  deserializeRouteIds,
-  serializeRouteIds
-} from '../../util/serializeRouteIds';
+import { serializeRouteIds } from '../../util/serializeRouteIds';
 import {
   DEFAULT_ROUTING_CONFIG_BY_CHAIN,
   ETH_GAS_STATION_API_URL,
@@ -2036,10 +2033,10 @@ export class AlphaRouter
     if (routesToCache) {
       const cachedRoutesChanged =
         cachedRoutesRouteIds !== undefined &&
-        // it's the first cached route out of all retrieved cached routes,
-        // that might change when we try to re-calculate from onchain
-        deserializeRouteIds(cachedRoutesRouteIds)[0] !== routesToCache?.routes[0]?.routeId;
-      
+        // it's possible that top cached routes may be split routes,
+        // so that we always serialize all the top 8 retrieved cached routes vs the top routes.
+        !cachedRoutesRouteIds.startsWith(serializeRouteIds(routesToCache.routes.map((r) => r.routeId)));
+
       if (cachedRoutesChanged) {
         metric.putMetric('cachedRoutesChanged', 1, MetricLoggerUnit.Count);
         metric.putMetric(

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -2057,6 +2057,7 @@ export class AlphaRouter
           `cachedRoutesNotChanged_chainId${currencyOut.chainId}_pair${currencyIn.symbol}${currencyOut.symbol}`,
           1,
           MetricLoggerUnit.Count
+        );
       }
 
       await this.routeCachingProvider

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -2046,6 +2046,17 @@ export class AlphaRouter
           1,
           MetricLoggerUnit.Count
         );
+      } else {
+        metric.putMetric('cachedRoutesNotChanged', 1, MetricLoggerUnit.Count);
+        metric.putMetric(
+          `cachedRoutesNotChanged_chainId${currencyIn.chainId}`,
+          1,
+          MetricLoggerUnit.Count
+        );
+        metric.putMetric(
+          `cachedRoutesNotChanged_chainId${currencyOut.chainId}_pair${currencyIn.symbol}${currencyOut.symbol}`,
+          1,
+          MetricLoggerUnit.Count
       }
 
       await this.routeCachingProvider

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -151,6 +151,7 @@ import {
 import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
 import { DEFAULT_BLOCKS_TO_LIVE } from '../../util/defaultBlocksToLive';
 import { INTENT } from '../../util/intent';
+import { serializeRouteIds } from '../../util/serializeRouteIds';
 import {
   DEFAULT_ROUTING_CONFIG_BY_CHAIN,
   ETH_GAS_STATION_API_URL,
@@ -523,9 +524,9 @@ export type AlphaRouterConfig = {
    */
   shouldEnableMixedRouteEthWeth?: boolean;
   /**
-   * hashed router id of the cached route, if the online routing lambda uses the cached route to serve the quote
+   * hashed router ids of the cached route, if the online routing lambda uses the cached route to serve the quote
    */
-  cachedRouteRouteId?: number;
+  cachedRouteRouteIds?: string;
 };
 
 export class AlphaRouter
@@ -1833,7 +1834,7 @@ export class AlphaRouter
               tradeType,
               'SetCachedRoute_NewPath',
               routesToCache,
-              routingConfig.cachedRouteRouteId
+              routingConfig.cachedRouteRouteIds
             );
           }
         }
@@ -1896,7 +1897,7 @@ export class AlphaRouter
         tradeType,
         'SetCachedRoute_OldPath',
         routesToCache,
-        routingConfig.cachedRouteRouteId
+        routingConfig.cachedRouteRouteIds
       );
     }
 
@@ -2027,12 +2028,13 @@ export class AlphaRouter
     tradeType: TradeType,
     metricsPrefix: string,
     routesToCache?: CachedRoutes,
-    cachedRouteRouteId?: number
+    cachedRouteRouteIds?: string
   ): Promise<void> {
     if (routesToCache) {
       const cachedRoutesChanged =
-        cachedRouteRouteId !== undefined &&
-        cachedRouteRouteId !== routesToCache.routes[0]?.routeId;
+        cachedRouteRouteIds !== undefined &&
+        cachedRouteRouteIds !==
+          serializeRouteIds(routesToCache.routes.map((r) => r.routeId));
 
       if (cachedRoutesChanged) {
         metric.putMetric('cachedRoutesChanged', 1, MetricLoggerUnit.Count);

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -257,10 +257,7 @@ const baseTokensByChain: { [chainId in ChainId]?: Token[] } = {
     DAI_UNICHAIN,
     USDC_UNICHAIN,
   ],
-  [ChainId.SONEIUM]: [
-    USDC_SONEIUM,
-    WRAPPED_NATIVE_CURRENCY[ChainId.SONEIUM]!,
-  ],
+  [ChainId.SONEIUM]: [USDC_SONEIUM, WRAPPED_NATIVE_CURRENCY[ChainId.SONEIUM]!],
 };
 
 class SubcategorySelectionPools<SubgraphPool> {

--- a/src/util/pool.ts
+++ b/src/util/pool.ts
@@ -306,5 +306,5 @@ export const V4_ETH_WETH_FAKE_POOL: { [chainId in ChainId]: V4Pool } = {
     79228162514264337593543950336,
     0,
     0
-  )
+  ),
 };

--- a/src/util/serializeRouteIds.ts
+++ b/src/util/serializeRouteIds.ts
@@ -1,0 +1,3 @@
+export function serializeRouteIds(routeIds: number[]): string {
+  return routeIds.join(':');
+}

--- a/src/util/serializeRouteIds.ts
+++ b/src/util/serializeRouteIds.ts
@@ -1,3 +1,7 @@
 export function serializeRouteIds(routeIds: number[]): string {
   return routeIds.join(':');
 }
+
+export function deserializeRouteIds(routeIds: string): number[] {
+  return routeIds.split(':').map(Number);
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
chore

- **What is the current behavior?** (You can also link to an open issue here)
we dont know how often cached routes change

- **What is the new behavior (if this is a feature change)?**
we log metrics to know how often cached routes change

- **Other information**:
we also log the chainId, as well as pair. we dont have the trading amount yet, because theres way too many fanouts.

Tested in routing-api, I can see:
- query string param cachedRoutesRouteIds
![Screenshot 2025-03-10 at 5.11.17 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/729b653a-19f1-4d46-9e82-56c509ebffb9.png)

- cachedRoutesNotChanged metrics
![Screenshot 2025-03-10 at 5.12.34 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BB54fKe6Y10GvrrdKXQN/0f1e88b3-dbd5-4fc8-95aa-fed2d736b5e0.png)

