### PR TITLE
fix: use v2 mixed quoter ABI for most chains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.4",
+  "version": "4.20.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.20.4",
+      "version": "4.20.5",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.4-debug-cachedroutes-protocols-1",
+  "version": "4.20.5",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.4",
+  "version": "4.20.4-debug-cachedroutes-protocols-1",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -32,11 +32,11 @@ import {
   getAddress,
   ID_TO_NETWORK_NAME,
   metric,
-  MetricLoggerUnit,
+  MetricLoggerUnit, MIXED_HAS_V1_QUOTER,
   MIXED_ROUTE_QUOTER_V1_ADDRESSES,
   MIXED_ROUTE_QUOTER_V2_ADDRESSES,
   NEW_QUOTER_V2_ADDRESSES,
-  PROTOCOL_V4_QUOTER_ADDRESSES,
+  PROTOCOL_V4_QUOTER_ADDRESSES
 } from '../util';
 import { CurrencyAmount } from '../util/amounts';
 import { log } from '../util/log';
@@ -502,10 +502,16 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
     protocol: Protocol
   ): Interface {
     if (useMixedRouteQuoter) {
-      if (mixedRouteContainsV4Pool) {
+      // If the mixed quoter does not have v1, which is most of the chains except for L1,
+      // then we know we need to use mixed quoter v2 ABI
+      if (!MIXED_HAS_V1_QUOTER.includes(this.chainId)) {
         return MixedRouteQuoterV2__factory.createInterface();
       } else {
-        return IMixedRouteQuoterV1__factory.createInterface();
+        if (mixedRouteContainsV4Pool) {
+          return MixedRouteQuoterV2__factory.createInterface();
+        } else {
+          return IMixedRouteQuoterV1__factory.createInterface();
+        }
       }
     }
 

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -32,11 +32,12 @@ import {
   getAddress,
   ID_TO_NETWORK_NAME,
   metric,
-  MetricLoggerUnit, MIXED_HAS_V1_QUOTER,
+  MetricLoggerUnit,
+  MIXED_HAS_V1_QUOTER,
   MIXED_ROUTE_QUOTER_V1_ADDRESSES,
   MIXED_ROUTE_QUOTER_V2_ADDRESSES,
   NEW_QUOTER_V2_ADDRESSES,
-  PROTOCOL_V4_QUOTER_ADDRESSES
+  PROTOCOL_V4_QUOTER_ADDRESSES,
 } from '../util';
 import { CurrencyAmount } from '../util/amounts';
 import { log } from '../util/log';
@@ -422,8 +423,11 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
       }
       return quoterAddress;
     }
+
     const quoterAddress = useMixedRouteQuoter
-      ? mixedRouteContainsV4Pool
+      ? !MIXED_HAS_V1_QUOTER.includes(this.chainId)
+        ? MIXED_ROUTE_QUOTER_V2_ADDRESSES[this.chainId]
+        : mixedRouteContainsV4Pool
         ? MIXED_ROUTE_QUOTER_V2_ADDRESSES[this.chainId]
         : MIXED_ROUTE_QUOTER_V1_ADDRESSES[this.chainId]
       : protocol === Protocol.V3

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1378,6 +1378,8 @@ export class AlphaRouter
       { blockNumber }
     );
 
+    log.error(`routingConfig ${JSON.stringify(routingConfig)}`);
+
     if (routingConfig.debugRouting) {
       log.warn(`Finalized routing config is ${JSON.stringify(routingConfig)}`);
     }

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1377,9 +1377,7 @@ export class AlphaRouter
       partialRoutingConfig,
       { blockNumber }
     );
-
-    log.error(`routingConfig ${JSON.stringify(routingConfig)}`);
-
+    
     if (routingConfig.debugRouting) {
       log.warn(`Finalized routing config is ${JSON.stringify(routingConfig)}`);
     }

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1377,7 +1377,7 @@ export class AlphaRouter
       partialRoutingConfig,
       { blockNumber }
     );
-    
+
     if (routingConfig.debugRouting) {
       log.warn(`Finalized routing config is ${JSON.stringify(routingConfig)}`);
     }
@@ -2035,7 +2035,9 @@ export class AlphaRouter
         cachedRoutesRouteIds !== undefined &&
         // it's possible that top cached routes may be split routes,
         // so that we always serialize all the top 8 retrieved cached routes vs the top routes.
-        !cachedRoutesRouteIds.startsWith(serializeRouteIds(routesToCache.routes.map((r) => r.routeId)));
+        !cachedRoutesRouteIds.startsWith(
+          serializeRouteIds(routesToCache.routes.map((r) => r.routeId))
+        );
 
       if (cachedRoutesChanged) {
         metric.putMetric('cachedRoutesChanged', 1, MetricLoggerUnit.Count);

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -82,10 +82,7 @@ export const MIXED_SUPPORTED = [
   ChainId.SONEIUM,
 ];
 
-export const MIXED_HAS_V1_QUOTER = [
-  ChainId.MAINNET,
-  ChainId.GOERLI,
-];
+export const MIXED_HAS_V1_QUOTER = [ChainId.MAINNET, ChainId.GOERLI];
 
 export const HAS_L1_FEE = [
   ChainId.OPTIMISM,

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -82,6 +82,11 @@ export const MIXED_SUPPORTED = [
   ChainId.SONEIUM,
 ];
 
+export const MIXED_HAS_V1_QUOTER = [
+  ChainId.MAINNET,
+  ChainId.GOERLI,
+];
+
 export const HAS_L1_FEE = [
   ChainId.OPTIMISM,
   ChainId.OPTIMISM_GOERLI,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We use wrong mixed quoter ABI on most chains, except for L1

- **What is the new behavior (if this is a feature change)?**
We need to use mixed quoter V2 ABI on most chains, because we never deployed mixed quoter V1 on most chains.

- **Other information**:
