### PR TITLE
fix: mixed quoter types/values length mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.5",
+  "version": "4.20.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.20.5",
+      "version": "4.20.6",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.5",
+  "version": "4.20.6",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -689,7 +689,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
                 },
               ] as QuoteExactParams[];
             case Protocol.MIXED:
-              if (mixedRouteContainsV4Pool) {
+              if (!MIXED_HAS_V1_QUOTER.includes(this.chainId) || mixedRouteContainsV4Pool) {
                 return [
                   encodedRoute as string,
                   {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
in beta pipeline, seeing

> [QuoteFetchError] Attempt 3. Unknown error from provider: types/values length mismatch (count={"types":3,"values":2}, value={"types":[{"name":"path","type":"bytes","indexed":null,"components":null,"arrayLength":null,"arrayChildren":null,"baseType":"bytes","_isParamType":true},{"name":"param","type":"tuple","indexed":null,"components":[{"name":"nonEncodableData","type":"tuple[]","indexed":null,"components":[{"name":"hookData","type":"bytes","indexed":null,"components":null,"arrayLength":null,"arrayChildren":null,"baseType":"bytes","_isParamType":true}],

this is because the mixed route doesn;t have v4 pool, but since it's on Base and OP, we still need to encode with V2 function ABIs

- **What is the new behavior (if this is a feature change)?**
encode with V2 function ABIs

- **Other information**:
