### PR TITLE
chore: bump sor to 4.20.9 - fix: UR v1.2 should have mixed route w/ v4 pool filtered out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.8",
+  "version": "4.20.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.20.8",
+      "version": "4.20.9",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.8",
+  "version": "4.20.9",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -13,14 +13,14 @@ import {
   IV3SubgraphProvider,
   IV4PoolProvider,
   IV4SubgraphProvider,
-  TokenValidationResult,
+  TokenValidationResult
 } from '../../../providers';
 import {
   CurrencyAmount,
   log,
   metric,
   MetricLoggerUnit,
-  routeToString,
+  routeToString
 } from '../../../util';
 import { MixedRoute } from '../../router';
 import { AlphaRouterConfig } from '../alpha-router';
@@ -32,12 +32,16 @@ import {
   getMixedRouteCandidatePools,
   V2CandidatePools,
   V3CandidatePools,
-  V4CandidatePools,
+  V4CandidatePools
 } from '../functions/get-candidate-pools';
 import { IGasModel } from '../gas-models';
 
 import { BaseQuoter } from './base-quoter';
 import { GetQuotesResult, GetRoutesResult } from './model';
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
+import {
+  mixedRouteFilterOutV4Pools
+} from '../../../util/mixedRouteFilterOutV4Pools';
 
 export class MixedQuoter extends BaseQuoter<
   [
@@ -179,13 +183,17 @@ export class MixedQuoter extends BaseQuoter<
 
     const { maxSwapsPerPath } = routingConfig;
 
-    const routes = computeAllMixedRoutes(
+    let routes = computeAllMixedRoutes(
       currencyIn,
       currencyOut,
       pools,
       maxSwapsPerPath,
-      routingConfig.shouldEnableMixedRouteEthWeth
+      routingConfig.shouldEnableMixedRouteEthWeth,
     );
+
+    if (routingConfig.universalRouterVersion === UniversalRouterVersion.V1_2 || !routingConfig.protocols?.includes(Protocol.V4)) {
+      routes = mixedRouteFilterOutV4Pools(routes);
+    }
 
     metric.putMetric(
       'MixedGetRoutesLoad',

--- a/src/util/mixedRouteFilterOutV4Pools.ts
+++ b/src/util/mixedRouteFilterOutV4Pools.ts
@@ -1,0 +1,14 @@
+import { MixedRoute } from '../routers';
+import { Pool as V4Pool } from '@uniswap/v4-sdk';
+
+export function mixedRouteContainsV4Pools(route: MixedRoute): boolean {
+  return route.pools.some((pool) => {
+    return (pool instanceof V4Pool);
+  });
+}
+
+export function mixedRouteFilterOutV4Pools(routes: MixedRoute[]): MixedRoute[] {
+  return routes.filter((route) => {
+    return !mixedRouteContainsV4Pools(route);
+  });
+}

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -16,6 +16,9 @@ import { V3_CORE_FACTORY_ADDRESSES } from './addresses';
 import { TPool } from '@uniswap/router-sdk';
 import { CurrencyAmount, V4_ETH_WETH_FAKE_POOL } from '.';
 import { CachedRoutes } from '../providers';
+import {
+  mixedRouteContainsV4Pools,
+} from './mixedRouteFilterOutV4Pools';
 
 export const routeToTokens = (route: SupportedRoutes): Currency[] => {
   switch (route.protocol) {
@@ -170,9 +173,9 @@ export function shouldWipeoutCachedRoutes(
             return poolIsInExcludedProtocols(
               pool,
               routingConfig?.excludedProtocolsFromMixed
-            );
+            )
           }).length > 0
-        );
+        ) || mixedRouteContainsV4Pools((route.route as MixedRoute));
       default:
         return false;
     }

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -16,9 +16,6 @@ import { V3_CORE_FACTORY_ADDRESSES } from './addresses';
 import { TPool } from '@uniswap/router-sdk';
 import { CurrencyAmount, V4_ETH_WETH_FAKE_POOL } from '.';
 import { CachedRoutes } from '../providers';
-import {
-  mixedRouteContainsV4Pools,
-} from './mixedRouteFilterOutV4Pools';
 
 export const routeToTokens = (route: SupportedRoutes): Currency[] => {
   switch (route.protocol) {

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -175,7 +175,7 @@ export function shouldWipeoutCachedRoutes(
               routingConfig?.excludedProtocolsFromMixed
             )
           }).length > 0
-        ) || mixedRouteContainsV4Pools((route.route as MixedRoute));
+        );
       default:
         return false;
     }

--- a/test/unit/util/mixedRouteFilterOutV4Pools.test.ts
+++ b/test/unit/util/mixedRouteFilterOutV4Pools.test.ts
@@ -1,0 +1,51 @@
+import {
+  DAI_USDT,
+  DAI_USDT_LOW,
+  DAI_USDT_V4_LOW,
+  USDC_DAI,
+  USDC_DAI_LOW,
+  USDC_DAI_MEDIUM, USDC_DAI_V4_LOW, USDC_DAI_V4_MEDIUM,
+  USDC_WETH,
+  USDC_WETH_LOW,
+  USDC_WETH_V4_LOW,
+  WBTC_WETH,
+  WETH9_USDT_LOW,
+  WETH9_USDT_V4_LOW,
+  WETH_USDT
+} from '../../test-util/mock-data';
+import {
+  computeAllMixedRoutes
+} from '../../../src/routers/alpha-router/functions/compute-all-routes';
+import { DAI_MAINNET as DAI, USDC_MAINNET as USDC } from '../../../src';
+import {
+  mixedRouteFilterOutV4Pools
+} from '../../../src/util/mixedRouteFilterOutV4Pools';
+import { Pool as V4Pool } from '@uniswap/v4-sdk';
+
+describe('mixedRouteFilterOutV4Pools', () => {
+  it('filter out v4 pool mixed route', async () => {
+    const pools = [
+      DAI_USDT,
+      USDC_WETH,
+      WETH_USDT,
+      USDC_DAI,
+      WBTC_WETH,
+      USDC_DAI_LOW,
+      USDC_DAI_MEDIUM,
+      USDC_WETH_LOW,
+      WETH9_USDT_LOW,
+      DAI_USDT_LOW,
+      DAI_USDT_V4_LOW,
+      WETH9_USDT_V4_LOW,
+      USDC_WETH_V4_LOW,
+      USDC_DAI_V4_LOW,
+      USDC_DAI_V4_MEDIUM,
+    ];
+    const routes = computeAllMixedRoutes(USDC, DAI, pools, 3);
+
+    expect(routes).toHaveLength(24);
+    const filteredRoutes = mixedRouteFilterOutV4Pools(routes);
+    expect(filteredRoutes).toHaveLength(6);
+    expect(filteredRoutes.every(route => !route.pools.some(pool => pool instanceof V4Pool))).toBeTruthy();
+  });
+});


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
we return the mixed route that contains the v4 pool, where UR v1.2 was requested with protocols v2,v3

- **What is the new behavior (if this is a feature change)?**
we need to make sure we filter out mixed route w/ v4 pool.

- **Other information**:
