### PR TITLE
chore: bump sor to 4.20.10 - fix: remove optimisticCachedRoutes check in wiping cached routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.9",
+  "version": "4.20.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.20.9",
+      "version": "4.20.10",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.9",
+  "version": "4.20.10",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -151,17 +151,6 @@ export function shouldWipeoutCachedRoutes(
   cachedRoutes?: CachedRoutes,
   routingConfig?: AlphaRouterConfig
 ): boolean {
-  // In case of optimisticCachedRoutes, we don't want to wipe out the cache
-  // This is because the upstream client will indicate that it's a perf sensitive (likely online) request,
-  // such that we should still use the cached routes.
-  // In case of routing-api,
-  // when intent=quote, optimisticCachedRoutes will be true, it means it's an online quote request, and we should use the cached routes.
-  // when intent=caching, optimisticCachedRoutes will be false, it means it's an async routing lambda invocation for the benefit of
-  // non-perf-sensitive, so that we can nullify the retrieved cached routes, if certain condition meets.
-  if (routingConfig?.optimisticCachedRoutes) {
-    return false;
-  }
-
   const containsExcludedProtocolPools = cachedRoutes?.routes.find((route) => {
     switch (route.protocol) {
       case Protocol.MIXED:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We do not wipe out cached routes in online lambda path.

- **What is the new behavior (if this is a feature change)?**
We should wipe out cached routes in online lambda path.

- **Other information**:
i think its ok to have a perf hit in this case

because 1) theres not many mixed quote as best quote 2) for mixed route that contains v4 pool is even less 3) quote request with UR v1.2 header is even less

works on my local https://app.warp.dev/block/hiG5dT6jliXF7mOrzzwU0P