### PR TITLE
chore: bump sor to 4.20.11 - fix: pass alphaRouterConfig to RouteCachingProvider for enableMixedRouteWithUR1_2Percent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.10",
+  "version": "4.20.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.20.10",
+      "version": "4.20.11",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.10",
+  "version": "4.20.11",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/caching/route/route-caching-provider.ts
+++ b/src/providers/caching/route/route-caching-provider.ts
@@ -14,6 +14,7 @@ import {
 
 import { CacheMode } from './model';
 import { CachedRoutes } from './model/cached-routes';
+import { AlphaRouterConfig } from '../../../routers';
 
 /**
  * Abstract class for a RouteCachingProvider.
@@ -40,7 +41,8 @@ export abstract class IRouteCachingProvider {
     tradeType: TradeType,
     protocols: Protocol[],
     blockNumber: number,
-    optimistic = false
+    optimistic = false,
+    alphaRouterConfig?: AlphaRouterConfig,
   ): Promise<CachedRoutes | undefined> => {
     if (
       (await this.getCacheMode(
@@ -61,7 +63,8 @@ export abstract class IRouteCachingProvider {
       tradeType,
       protocols,
       blockNumber,
-      optimistic
+      optimistic,
+      alphaRouterConfig,
     );
 
     return this.filterExpiredCachedRoutes(cachedRoute, blockNumber, optimistic);
@@ -165,7 +168,8 @@ export abstract class IRouteCachingProvider {
     tradeType: TradeType,
     protocols: Protocol[],
     currentBlockNumber: number,
-    optimistic: boolean
+    optimistic: boolean,
+    alphaRouterConfig?: AlphaRouterConfig,
   ): Promise<CachedRoutes | undefined>;
 
   /**

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -527,6 +527,10 @@ export type AlphaRouterConfig = {
    * hashed router ids of the cached route, if the online routing lambda uses the cached route to serve the quote
    */
   cachedRoutesRouteIds?: string;
+  /**
+   * enable mixed route with UR1_2 version backward compatibility issue
+   */
+  enableMixedRouteWithUR1_2Percent?: number;
 };
 
 export class AlphaRouter

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -153,7 +153,7 @@ export function shouldWipeoutCachedRoutes(
 ): boolean {
   // We want to roll out the mixed route with UR v1_2 with percent control,
   // along with the cached routes so that we can test the performance of the mixed route with UR v1_2ss
-  if (routingConfig?.enableMixedRouteWithUR1_2Percent
+  if ((routingConfig?.enableMixedRouteWithUR1_2Percent ?? 0) >= (Math.random() * 100)
     &&
     // In case of optimisticCachedRoutes, we don't want to wipe out the cache
     // This is because the upstream client will indicate that it's a perf sensitive (likely online) request,

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -151,6 +151,21 @@ export function shouldWipeoutCachedRoutes(
   cachedRoutes?: CachedRoutes,
   routingConfig?: AlphaRouterConfig
 ): boolean {
+  // We want to roll out the mixed route with UR v1_2 with percent control,
+  // along with the cached routes so that we can test the performance of the mixed route with UR v1_2ss
+  if (routingConfig?.enableMixedRouteWithUR1_2Percent
+    &&
+    // In case of optimisticCachedRoutes, we don't want to wipe out the cache
+    // This is because the upstream client will indicate that it's a perf sensitive (likely online) request,
+    // such that we should still use the cached routes.
+    // In case of routing-api,
+    // when intent=quote, optimisticCachedRoutes will be true, it means it's an online quote request, and we should use the cached routes.
+    // when intent=caching, optimisticCachedRoutes will be false, it means it's an async routing lambda invocation for the benefit of
+    // non-perf-sensitive, so that we can nullify the retrieved cached routes, if certain condition meets.
+    routingConfig?.optimisticCachedRoutes) {
+    return false;
+  }
+
   const containsExcludedProtocolPools = cachedRoutes?.routes.find((route) => {
     switch (route.protocol) {
       case Protocol.MIXED:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We dont have a way to control the percentage roll out w.r.t. wiping out cached routes during online routing lambda

- **What is the new behavior (if this is a feature change)?**
We pass in the mixed route with UR v1_2 percent flag so that we can roll out the fix gradually.

- **Other information**:
This needs to be together with routing-api https://github.com/Uniswap/routing-api/pull/1065