### PR TITLE
chore: bump sor to 4.20.12 - fix: enableMixedRouteWithUR1_2Percent to enableMixedRouteWithUR1_2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.11",
+  "version": "4.20.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.20.11",
+      "version": "4.20.12",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.20.11",
+  "version": "4.20.12",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/caching/route/route-caching-provider.ts
+++ b/src/providers/caching/route/route-caching-provider.ts
@@ -12,9 +12,9 @@ import {
   TradeType,
 } from '@uniswap/sdk-core';
 
+import { AlphaRouterConfig } from '../../../routers';
 import { CacheMode } from './model';
 import { CachedRoutes } from './model/cached-routes';
-import { AlphaRouterConfig } from '../../../routers';
 
 /**
  * Abstract class for a RouteCachingProvider.
@@ -42,7 +42,7 @@ export abstract class IRouteCachingProvider {
     protocols: Protocol[],
     blockNumber: number,
     optimistic = false,
-    alphaRouterConfig?: AlphaRouterConfig,
+    alphaRouterConfig?: AlphaRouterConfig
   ): Promise<CachedRoutes | undefined> => {
     if (
       (await this.getCacheMode(
@@ -64,7 +64,7 @@ export abstract class IRouteCachingProvider {
       protocols,
       blockNumber,
       optimistic,
-      alphaRouterConfig,
+      alphaRouterConfig
     );
 
     return this.filterExpiredCachedRoutes(cachedRoute, blockNumber, optimistic);
@@ -169,7 +169,7 @@ export abstract class IRouteCachingProvider {
     protocols: Protocol[],
     currentBlockNumber: number,
     optimistic: boolean,
-    alphaRouterConfig?: AlphaRouterConfig,
+    alphaRouterConfig?: AlphaRouterConfig
   ): Promise<CachedRoutes | undefined>;
 
   /**

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -530,7 +530,7 @@ export type AlphaRouterConfig = {
   /**
    * enable mixed route with UR1_2 version backward compatibility issue
    */
-  enableMixedRouteWithUR1_2Percent?: number;
+  enableMixedRouteWithUR1_2?: boolean;
 };
 
 export class AlphaRouter
@@ -2039,7 +2039,9 @@ export class AlphaRouter
         cachedRoutesRouteIds !== undefined &&
         // it's possible that top cached routes may be split routes,
         // so that we always serialize all the top 8 retrieved cached routes vs the top routes.
-        !cachedRoutesRouteIds.startsWith(serializeRouteIds(routesToCache.routes.map((r) => r.routeId)));
+        !cachedRoutesRouteIds.startsWith(
+          serializeRouteIds(routesToCache.routes.map((r) => r.routeId))
+        );
 
       if (cachedRoutesChanged) {
         metric.putMetric('cachedRoutesChanged', 1, MetricLoggerUnit.Count);

--- a/src/routers/alpha-router/quoters/mixed-quoter.ts
+++ b/src/routers/alpha-router/quoters/mixed-quoter.ts
@@ -13,14 +13,14 @@ import {
   IV3SubgraphProvider,
   IV4PoolProvider,
   IV4SubgraphProvider,
-  TokenValidationResult
+  TokenValidationResult,
 } from '../../../providers';
 import {
   CurrencyAmount,
   log,
   metric,
   MetricLoggerUnit,
-  routeToString
+  routeToString,
 } from '../../../util';
 import { MixedRoute } from '../../router';
 import { AlphaRouterConfig } from '../alpha-router';
@@ -32,16 +32,14 @@ import {
   getMixedRouteCandidatePools,
   V2CandidatePools,
   V3CandidatePools,
-  V4CandidatePools
+  V4CandidatePools,
 } from '../functions/get-candidate-pools';
 import { IGasModel } from '../gas-models';
 
+import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
+import { mixedRouteFilterOutV4Pools } from '../../../util/mixedRouteFilterOutV4Pools';
 import { BaseQuoter } from './base-quoter';
 import { GetQuotesResult, GetRoutesResult } from './model';
-import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
-import {
-  mixedRouteFilterOutV4Pools
-} from '../../../util/mixedRouteFilterOutV4Pools';
 
 export class MixedQuoter extends BaseQuoter<
   [
@@ -188,10 +186,13 @@ export class MixedQuoter extends BaseQuoter<
       currencyOut,
       pools,
       maxSwapsPerPath,
-      routingConfig.shouldEnableMixedRouteEthWeth,
+      routingConfig.shouldEnableMixedRouteEthWeth
     );
 
-    if (routingConfig.universalRouterVersion === UniversalRouterVersion.V1_2 || !routingConfig.protocols?.includes(Protocol.V4)) {
+    if (
+      routingConfig.universalRouterVersion === UniversalRouterVersion.V1_2 ||
+      !routingConfig.protocols?.includes(Protocol.V4)
+    ) {
       routes = mixedRouteFilterOutV4Pools(routes);
     }
 

--- a/src/util/mixedRouteFilterOutV4Pools.ts
+++ b/src/util/mixedRouteFilterOutV4Pools.ts
@@ -1,9 +1,9 @@
-import { MixedRoute } from '../routers';
 import { Pool as V4Pool } from '@uniswap/v4-sdk';
+import { MixedRoute } from '../routers';
 
 export function mixedRouteContainsV4Pools(route: MixedRoute): boolean {
   return route.pools.some((pool) => {
-    return (pool instanceof V4Pool);
+    return pool instanceof V4Pool;
   });
 }
 

--- a/src/util/routes.ts
+++ b/src/util/routes.ts
@@ -153,8 +153,8 @@ export function shouldWipeoutCachedRoutes(
 ): boolean {
   // We want to roll out the mixed route with UR v1_2 with percent control,
   // along with the cached routes so that we can test the performance of the mixed route with UR v1_2ss
-  if ((routingConfig?.enableMixedRouteWithUR1_2Percent ?? 0) >= (Math.random() * 100)
-    &&
+  if (
+    routingConfig?.enableMixedRouteWithUR1_2 &&
     // In case of optimisticCachedRoutes, we don't want to wipe out the cache
     // This is because the upstream client will indicate that it's a perf sensitive (likely online) request,
     // such that we should still use the cached routes.
@@ -162,7 +162,8 @@ export function shouldWipeoutCachedRoutes(
     // when intent=quote, optimisticCachedRoutes will be true, it means it's an online quote request, and we should use the cached routes.
     // when intent=caching, optimisticCachedRoutes will be false, it means it's an async routing lambda invocation for the benefit of
     // non-perf-sensitive, so that we can nullify the retrieved cached routes, if certain condition meets.
-    routingConfig?.optimisticCachedRoutes) {
+    routingConfig?.optimisticCachedRoutes
+  ) {
     return false;
   }
 
@@ -174,7 +175,7 @@ export function shouldWipeoutCachedRoutes(
             return poolIsInExcludedProtocols(
               pool,
               routingConfig?.excludedProtocolsFromMixed
-            )
+            );
           }).length > 0
         );
       default:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We are passing in `enableMixedRouteWithUR1_2Percent`

- **What is the new behavior (if this is a feature change)?**
We want to pass in `enableMixedRouteWithUR1_2` so that the percent is only computed once within routing-api

- **Other information**:
