### PR TITLE
chore: bump sor to 4.21.2 - fix: bypass cache when HOOK_INCLUSIVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.1",
+  "version": "4.21.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.21.1",
+      "version": "4.21.2",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.1",
+  "version": "4.21.2",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -3287,6 +3287,8 @@ export class AlphaRouter
     // in case we have URv1.2 request during QUOTE intent, we assume cached routes correctly returns mixed route w/o v4, if mixed is best
     // or v2/v3 is the best.
     // implicitly it means hooksOptions no longer matters for URv1.2
+    // swapRouter has higher precedence than hooksOptions, because in case of URv1.2, we set hooksOptions = NO_HOOKS as default,
+    // but swapRouter does not have any v4 pool for routing, so swapRouter should always use caching during QUOTE intent.
     if (swapRouter) {
       return true;
     }

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -1461,12 +1461,12 @@ export class AlphaRouter
     // For legacy systems (SWAP_ROUTER_02) or missing swapConfig, follow UniversalRouterVersion.V1_2 logic.
     const availableProtocolsSet = new Set(Object.values(Protocol));
     const requestedProtocolsSet = new Set(protocols);
-    if (
+    const swapRouter =
       !swapConfig ||
       swapConfig.type === SwapType.SWAP_ROUTER_02 ||
       (swapConfig.type === SwapType.UNIVERSAL_ROUTER &&
-        swapConfig.version === UniversalRouterVersion.V1_2)
-    ) {
+        swapConfig.version === UniversalRouterVersion.V1_2);
+    if (swapRouter) {
       availableProtocolsSet.delete(Protocol.V4);
       if (requestedProtocolsSet.has(Protocol.V4)) {
         requestedProtocolsSet.delete(Protocol.V4);
@@ -1483,7 +1483,8 @@ export class AlphaRouter
       routingConfig.hooksOptions = HooksOptions.NO_HOOKS;
     }
 
-    // If hooksOptions not specified, we should also set it to HOOKS_INCLUSIVE, as this is default behavior even without hooksOptions.
+    // If hooksOptions not specified and it's not a swapRouter (i.e. Universal Router it is),
+    // we should also set it to HOOKS_INCLUSIVE, as this is default behavior even without hooksOptions.
     if (!routingConfig.hooksOptions) {
       routingConfig.hooksOptions = HooksOptions.HOOKS_INCLUSIVE;
     }
@@ -1504,7 +1505,8 @@ export class AlphaRouter
       cacheMode !== CacheMode.Darkmode &&
       AlphaRouter.isAllowedToEnterCachedRoutes(
         routingConfig.intent,
-        routingConfig.hooksOptions
+        routingConfig.hooksOptions,
+        swapRouter
       )
     ) {
       if (enabledAndRequestedProtocolsMatch) {
@@ -3269,20 +3271,34 @@ export class AlphaRouter
     );
   }
 
+  // If we are requesting URv1.2, we need to keep entering cache
   // We want to skip cached routes access whenever "intent === INTENT.CACHING" or "hooksOption !== HooksOption.HOOKS_INCLUSIVE"
   // We keep this method as we might want to add more conditions in the future.
   public static isAllowedToEnterCachedRoutes(
     intent?: INTENT,
-    hooksOptions?: HooksOptions
+    hooksOptions?: HooksOptions,
+    swapRouter?: boolean
   ): boolean {
-    if (intent !== INTENT.CACHING) {
+    // intent takes highest precedence, as we need to ensure during caching intent, we do not enter cache no matter what
+    if (intent !== undefined && intent === INTENT.CACHING) {
+      return false;
+    }
+
+    // in case we have URv1.2 request during QUOTE intent, we assume cached routes correctly returns mixed route w/o v4, if mixed is best
+    // or v2/v3 is the best.
+    // implicitly it means hooksOptions no longer matters for URv1.2
+    if (swapRouter) {
       return true;
     }
 
-    if (hooksOptions === HooksOptions.HOOKS_INCLUSIVE) {
-      return true;
+    // in case we have URv2.0, and we are in QUOTE intent, we only want to enter cache when hooksOptions is default, HOOKS_INCLUSIVE
+    if (
+      hooksOptions !== undefined &&
+      hooksOptions !== HooksOptions.HOOKS_INCLUSIVE
+    ) {
+      return false;
     }
 
-    return false;
+    return true;
   }
 }

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -3269,12 +3269,12 @@ export class AlphaRouter
     );
   }
 
-  // We want to skip cached routes access whenever "intent === INTENT.CACHING" or "hooksOption !== HooksOption.NO_HOOKS"
+  // We want to skip cached routes access whenever "intent === INTENT.CACHING" or "hooksOption !== HooksOption.HOOKS_INCLUSIVE"
   // We keep this method as we might want to add more conditions in the future.
   public static isAllowedToEnterCachedRoutes(
     intent?: INTENT,
     hooksOptions?: HooksOptions
   ): boolean {
-    return intent !== INTENT.CACHING || hooksOptions === HooksOptions.NO_HOOKS;
+    return intent !== INTENT.CACHING || hooksOptions === HooksOptions.HOOKS_INCLUSIVE;
   }
 }

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -95,6 +95,7 @@ import {
   getAddress,
   getAddressLowerCase,
   getApplicableV4FeesTickspacingsHooks,
+  HooksOptions,
   MIXED_SUPPORTED,
   shouldWipeoutCachedRoutes,
   SWAP_ROUTER_02_ADDRESSES,
@@ -150,7 +151,6 @@ import {
 
 import { UniversalRouterVersion } from '@uniswap/universal-router-sdk';
 import { DEFAULT_BLOCKS_TO_LIVE } from '../../util/defaultBlocksToLive';
-import { HooksOptions } from '../../util/hooksOptions';
 import { INTENT } from '../../util/intent';
 import { serializeRouteIds } from '../../util/serializeRouteIds';
 import {
@@ -3275,6 +3275,14 @@ export class AlphaRouter
     intent?: INTENT,
     hooksOptions?: HooksOptions
   ): boolean {
-    return intent !== INTENT.CACHING || hooksOptions === HooksOptions.HOOKS_INCLUSIVE;
+    if (intent !== INTENT.CACHING) {
+      return true;
+    }
+
+    if (hooksOptions === HooksOptions.HOOKS_INCLUSIVE) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/test/unit/routers/alpha-router/alpha-router.test.ts
+++ b/test/unit/routers/alpha-router/alpha-router.test.ts
@@ -3124,6 +3124,11 @@ describe('alpha router', () => {
       expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.QUOTE, undefined)).toBe(true);
       expect(AlphaRouter.isAllowedToEnterCachedRoutes(undefined, undefined)).toBe(true);
     });
+
+    test('returns correct values based on random percentage and swapRouter', () => {
+      expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.QUOTE, undefined, true)).toBe(true);
+      expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.QUOTE, undefined, false)).toBe(true);
+    })
   });
 });
 

--- a/test/unit/routers/alpha-router/alpha-router.test.ts
+++ b/test/unit/routers/alpha-router/alpha-router.test.ts
@@ -20,6 +20,8 @@ import {
   DEFAULT_TOKEN_PROPERTIES_RESULT,
   ETHGasStationInfoProvider,
   FallbackTenderlySimulator,
+  HooksOptions,
+  INTENT,
   MixedRouteWithValidQuote,
   OnChainQuoteProvider,
   parseAmount,
@@ -28,6 +30,7 @@ import {
   SupportedRoutes,
   SwapAndAddConfig,
   SwapAndAddOptions,
+  SwapOptions,
   SwapRouterProvider,
   SwapToRatioStatus,
   SwapType,
@@ -111,7 +114,6 @@ import {
 import {
   InMemoryRouteCachingProvider
 } from '../../providers/caching/route/test-util/inmemory-route-caching-provider';
-import { INTENT } from '../../../../src/util/intent';
 
 const helper = require('../../../../src/routers/alpha-router/functions/calculate-ratio-amount-in');
 
@@ -181,6 +183,12 @@ describe('alpha router', () => {
     distributionPercent: 25,
     forceCrossProtocol: false,
   };
+
+  const SWAP_CONFIG: SwapOptions = {
+    type: SwapType.UNIVERSAL_ROUTER,
+    version: UniversalRouterVersion.V2_0,
+    slippageTolerance: new Percent(5, 10_000),
+  }
 
   const SWAP_AND_ADD_CONFIG: SwapAndAddConfig = {
     ratioErrorTolerance: new Fraction(1, 100),
@@ -1481,7 +1489,7 @@ describe('alpha router', () => {
           CurrencyAmount.fromRawAmount(USDC, 10000),
           MOCK_ZERO_DEC_TOKEN,
           TradeType.EXACT_INPUT,
-          undefined,
+          SWAP_CONFIG,
           {
             ...ROUTING_CONFIG,
             protocols: allProtocols
@@ -1496,7 +1504,7 @@ describe('alpha router', () => {
           CurrencyAmount.fromRawAmount(USDC, 100000),
           MOCK_ZERO_DEC_TOKEN,
           TradeType.EXACT_INPUT,
-          undefined,
+          SWAP_CONFIG,
           {
             ...ROUTING_CONFIG,
             protocols: allProtocols
@@ -1527,7 +1535,7 @@ describe('alpha router', () => {
           CurrencyAmount.fromRawAmount(USDC, 10000),
           MOCK_ZERO_DEC_TOKEN,
           TradeType.EXACT_INPUT,
-          undefined,
+          SWAP_CONFIG,
           {
             ...ROUTING_CONFIG,
             protocols: allProtocols,
@@ -1544,7 +1552,7 @@ describe('alpha router', () => {
           CurrencyAmount.fromRawAmount(USDC, 100000),
           MOCK_ZERO_DEC_TOKEN,
           TradeType.EXACT_INPUT,
-          undefined,
+          SWAP_CONFIG,
           {
             ...ROUTING_CONFIG,
             protocols: allProtocols
@@ -1559,7 +1567,7 @@ describe('alpha router', () => {
           CurrencyAmount.fromRawAmount(USDC, 100000),
           MOCK_ZERO_DEC_TOKEN,
           TradeType.EXACT_INPUT,
-          undefined,
+          SWAP_CONFIG,
           {
             ...ROUTING_CONFIG,
             protocols: allProtocols
@@ -1593,6 +1601,7 @@ describe('alpha router', () => {
             v1_2Params,
             {
               ...ROUTING_CONFIG,
+              intent: INTENT.QUOTE,
               protocols: [Protocol.V2, Protocol.V3, Protocol.MIXED], // Excluding V4
             }
           );
@@ -3106,6 +3115,14 @@ describe('alpha router', () => {
       // Should return true for other intents
       expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.QUOTE)).toBe(true);
       expect(AlphaRouter.isAllowedToEnterCachedRoutes(undefined)).toBe(true);
+    });
+
+    test('returns correct values based on random percentage and hooksOptions', () => {
+      expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.QUOTE, HooksOptions.HOOKS_INCLUSIVE)).toBe(true);
+      expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.QUOTE, HooksOptions.NO_HOOKS)).toBe(false);
+      expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.QUOTE, HooksOptions.HOOKS_ONLY)).toBe(false);
+      expect(AlphaRouter.isAllowedToEnterCachedRoutes(INTENT.QUOTE, undefined)).toBe(true);
+      expect(AlphaRouter.isAllowedToEnterCachedRoutes(undefined, undefined)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We bypass cache when NO_HOOKS

- **What is the new behavior (if this is a feature change)?**
Desired is to bypass cache when HOOKS_INCLUSIVE

- **Other information**:
