### PR TITLE
chore: bump sor to 4.21.13 - fix: bypass v3 pool FOT check for  token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.12",
+  "version": "4.21.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.21.12",
+      "version": "4.21.13",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.12",
+  "version": "4.21.13",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/quoters/v3-quoter.ts
+++ b/src/routers/alpha-router/quoters/v3-quoter.ts
@@ -96,6 +96,15 @@ export class V3Quoter extends BaseQuoter<V3CandidatePools, V3Route, Token> {
           return false;
         }
 
+        // ROUTE-495 - bypass v3 pool FOT check for $ELMO token
+        if (
+          tokenValidation == TokenValidationResult.FOT &&
+          token.wrapped.address.toLowerCase() === '0x335f4e66b9b61cee5ceade4e727fcec20156b2f0' &&
+          (token.equals(tokenIn) || token.equals(tokenOut))
+        ) {
+          return false;
+        }
+
         return (
           tokenValidation == TokenValidationResult.FOT ||
           tokenValidation == TokenValidationResult.STF


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
we blocked ELMO v3 pool because ELMO is FOT, but ELMO v3 pool is coded to not take FOT tax.

- **What is the new behavior (if this is a feature change)?**
allowlist ELMO v3 pool for quoting

- **Other information**:
