### PR TITLE
fix: filter out direct v3 pool with rebase token breaking routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.16",
+  "version": "4.21.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.21.16",
+      "version": "4.21.17",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.16",
+  "version": "4.21.17",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -65,6 +65,13 @@ export const DAI_MAINNET = new Token(
   'DAI',
   'Dai Stablecoin'
 );
+export const EGGS_MAINNET = new Token(
+  ChainId.MAINNET,
+  '0x2e516BA5Bf3b7eE47fb99B09eaDb60BDE80a82e0',
+  18,
+  'EGGS',
+  'EGGS'
+);
 export const AMPL_MAINNET = new Token(
   ChainId.MAINNET,
   '0xD46bA6D942050d489DBd938a2C909A5d5039A161',

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -261,6 +261,11 @@ const baseTokensByChain: { [chainId in ChainId]?: Token[] } = {
   [ChainId.SONEIUM]: [USDC_SONEIUM, WRAPPED_NATIVE_CURRENCY[ChainId.SONEIUM]!],
 };
 
+const excludedV3PoolIds = new Set([
+  // https://linear.app/uniswap/issue/CX-1005
+  '0x0f681f10ab1aa1cde04232a199fe3c6f2652a80c'.toLowerCase(),
+]);
+
 class SubcategorySelectionPools<SubgraphPool> {
   constructor(
     public pools: SubgraphPool[],
@@ -1139,6 +1144,10 @@ export async function getV3CandidatePools({
             tvlUSD: 10000,
           };
         }
+      );
+
+      top2DirectSwapPool = top2DirectSwapPool.filter(
+        (pool) => !excludedV3PoolIds.has(pool.id.toLowerCase())
       );
     }
   }


### PR DESCRIPTION
Follow up on https://github.com/Uniswap/routing-api/pull/1109
Exclude direct v3 pool for EGGS

https://linear.app/uniswap/issue/CX-1005
