### PR TITLE
chore: bump sor to 4.21.18 - fix: invariant token because of revisited v4 native pool eth/weth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.17",
+  "version": "4.21.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.21.17",
+      "version": "4.21.18",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.17",
+  "version": "4.21.18",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/test/unit/routers/alpha-router/functions/compute-all-routes.test.ts
+++ b/test/unit/routers/alpha-router/functions/compute-all-routes.test.ts
@@ -160,6 +160,40 @@ describe('compute all v4 routes', () => {
 
     expect(routes).toHaveLength(1);
   })
+
+  test('succeeds to compute routes avoiding duplicate wrapped tokens', async () => {
+    const pools = [
+      // Create a pool with native ETH and USDC
+      new V4Pool(
+        nativeOnChain(ChainId.MAINNET),
+        USDC,
+        FeeAmount.LOW,
+        10,
+        ADDRESS_ZERO,
+        encodeSqrtRatioX96(1, 1),
+        500,
+        0
+      ),
+      // Create a pool with wrapped ETH (WETH) and USDC
+      new V4Pool(
+        WRAPPED_NATIVE_CURRENCY[1]!,
+        USDC,
+        FeeAmount.LOW,
+        10,
+        ADDRESS_ZERO,
+        encodeSqrtRatioX96(1, 1),
+        500,
+        0
+      ),
+      USDC_DAI_V4_LOW
+    ];
+
+    const routes = computeAllV4Routes(DAI, WRAPPED_NATIVE_CURRENCY[1]!, pools, 2);
+
+    // Should only find 1 route since native ETH and WETH pools should not both be used
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.pools).toHaveLength(2);
+  })
 })
 
 describe('compute all v3 routes', () => {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We have invariant token error, because in v4, we can have circular route because of native & wrapped. e.g. ETH/OP -> ETH/OP-> ETH/opXEN

- **What is the new behavior (if this is a feature change)?**
We make sure in case of v4, we track both native and wrapped as the same token being visited.

- **Other information**:
in case of mixed, we need to make sure we don't track both native and wrapped as the same token being visited.