### PR TITLE
Revert "chore: bump sor to 4.21.18 - fix: invariant token because of revisited v4 native pool eth/weth"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.18",
+  "version": "4.21.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.21.18",
+      "version": "4.21.17",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.17",
+  "version": "4.21.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.21.17",
+      "version": "4.21.19",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.17",
+  "version": "4.21.19",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.18",
+  "version": "4.21.17",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/functions/compute-all-routes.ts
+++ b/src/routers/alpha-router/functions/compute-all-routes.ts
@@ -1,4 +1,4 @@
-import { ADDRESS_ZERO, Protocol, TPool } from '@uniswap/router-sdk';
+import { ADDRESS_ZERO, TPool } from '@uniswap/router-sdk';
 import { ChainId, Currency, Token } from '@uniswap/sdk-core';
 import { Pair } from '@uniswap/v2-sdk';
 import { Pool as V3Pool } from '@uniswap/v3-sdk';
@@ -7,7 +7,7 @@ import { Pool as V4Pool } from '@uniswap/v4-sdk';
 import {
   getAddressLowerCase,
   nativeOnChain,
-  V4_ETH_WETH_FAKE_POOL
+  V4_ETH_WETH_FAKE_POOL,
 } from '../../../util';
 import { HooksOptions } from '../../../util/hooksOptions';
 import { log } from '../../../util/log';
@@ -17,7 +17,7 @@ import {
   SupportedRoutes,
   V2Route,
   V3Route,
-  V4Route
+  V4Route,
 } from '../../router';
 
 export function computeAllV4Routes(
@@ -45,8 +45,7 @@ export function computeAllV4Routes(
     },
     (pool: V4Pool, currency: Currency) => pool.involvesToken(currency),
     filteredPools,
-    maxHops,
-    Protocol.V4
+    maxHops
   );
 }
 
@@ -64,8 +63,7 @@ export function computeAllV3Routes(
     },
     (pool: V3Pool, token: Token) => pool.involvesToken(token),
     pools,
-    maxHops,
-    Protocol.V3
+    maxHops
   );
 }
 
@@ -83,8 +81,7 @@ export function computeAllV2Routes(
     },
     (pool: Pair, token: Token) => pool.involvesToken(token),
     pools,
-    maxHops,
-    Protocol.V2
+    maxHops
   );
 }
 
@@ -149,8 +146,7 @@ export function computeAllMixedRoutes(
         ? (pool as V4Pool).involvesToken(currency)
         : pool.involvesToken(currency),
     amendedPools,
-    maxHops,
-    Protocol.MIXED
+    maxHops
   );
   /// filter out pure v4 and v3 and v2 routes
   return routesRaw.filter((route) => {
@@ -176,8 +172,7 @@ export function computeAllRoutes<
   ) => TRoute,
   involvesToken: (pool: TypePool, token: TCurrency) => boolean,
   pools: TypePool[],
-  maxHops: number,
-  protocol: Protocol
+  maxHops: number
 ): TRoute[] {
   const poolsUsed = Array<boolean>(pools.length).fill(false);
   const routes: TRoute[] = [];
@@ -235,22 +230,11 @@ export function computeAllRoutes<
         ? curPool.token1
         : curPool.token0;
 
-      // In case of protocol mixed, we need to ensure we distinguish between native and wrapped native
-      // because we inject ETH-WETH fake pool to connect mixed routes
-      // Otherwise, in v2,v3,v4, we can just use the wrapped address
-      // we have existing unit test 'handles ETH/WETH wrapping in mixed routes' coverage
-      // in case someone changes the logic to remove MIXED special case
-      const currentTokenVisited = protocol === Protocol.MIXED ? getAddressLowerCase(currentTokenOut) : currentTokenOut.wrapped.address;
-
-      // Here we need to keep track of the visited wrapped token,
-      // because in v4, it's possible to go through both native pool and wrapped native pool,
-      // causing invariant token error.
-      // see https://linear.app/uniswap/issue/ROUTE-437/invariant-token-error#comment-b1a1cb1e for more details
-      if (tokensVisited.has(currentTokenVisited)) {
+      if (tokensVisited.has(getAddressLowerCase(currentTokenOut))) {
         continue;
       }
 
-      tokensVisited.add(currentTokenVisited);
+      tokensVisited.add(getAddressLowerCase(currentTokenOut));
       currentRoute.push(curPool);
       poolsUsed[i] = true;
       computeRoutes(
@@ -263,18 +247,16 @@ export function computeAllRoutes<
       );
       poolsUsed[i] = false;
       currentRoute.pop();
-      tokensVisited.delete(currentTokenVisited);
+      tokensVisited.delete(getAddressLowerCase(currentTokenOut));
     }
   };
-
-  const firstTokenVisited = protocol === Protocol.MIXED ? getAddressLowerCase(tokenIn) : tokenIn.wrapped.address;
 
   computeRoutes(
     tokenIn,
     tokenOut,
     [],
     poolsUsed,
-    new Set([firstTokenVisited])
+    new Set([getAddressLowerCase(tokenIn)])
   );
 
   log.info(

--- a/test/unit/routers/alpha-router/functions/compute-all-routes.test.ts
+++ b/test/unit/routers/alpha-router/functions/compute-all-routes.test.ts
@@ -160,40 +160,6 @@ describe('compute all v4 routes', () => {
 
     expect(routes).toHaveLength(1);
   })
-
-  test('succeeds to compute routes avoiding duplicate wrapped tokens', async () => {
-    const pools = [
-      // Create a pool with native ETH and USDC
-      new V4Pool(
-        nativeOnChain(ChainId.MAINNET),
-        USDC,
-        FeeAmount.LOW,
-        10,
-        ADDRESS_ZERO,
-        encodeSqrtRatioX96(1, 1),
-        500,
-        0
-      ),
-      // Create a pool with wrapped ETH (WETH) and USDC
-      new V4Pool(
-        WRAPPED_NATIVE_CURRENCY[1]!,
-        USDC,
-        FeeAmount.LOW,
-        10,
-        ADDRESS_ZERO,
-        encodeSqrtRatioX96(1, 1),
-        500,
-        0
-      ),
-      USDC_DAI_V4_LOW
-    ];
-
-    const routes = computeAllV4Routes(DAI, WRAPPED_NATIVE_CURRENCY[1]!, pools, 2);
-
-    // Should only find 1 route since native ETH and WETH pools should not both be used
-    expect(routes).toHaveLength(1);
-    expect(routes[0]?.pools).toHaveLength(2);
-  })
 })
 
 describe('compute all v3 routes', () => {


### PR DESCRIPTION
Reverts Uniswap/smart-order-router#884 to support WETH hook natively: https://github.com/Uniswap/routing-api/pull/1130