### PR TITLE
chore: bump sor to 4.22.1 - fix: euler subgraph query missing tickspacing siyujiang/route-539-support-euler-factory-hooks-routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.0",
+  "version": "4.22.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.22.0",
+      "version": "4.22.1",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.0",
+  "version": "4.22.0-euler-5",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.0-euler-5",
+  "version": "4.22.1",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/v4/euler-swap-hooks-subgraph-provider.ts
+++ b/src/providers/v4/euler-swap-hooks-subgraph-provider.ts
@@ -208,12 +208,14 @@ export class EulerSwapHooksSubgraphProvider implements ISubgraphProvider {
             id
           }
           feeTier
+          tick
           tickSpacing
-          hooks
           liquidity
+          hooks
           totalValueLockedUSD
           totalValueLockedETH
           totalValueLockedUSDUntracked
+          sqrtPrice
         }
       }
     `;

--- a/src/providers/v4/euler-swap-hooks-subgraph-provider.ts
+++ b/src/providers/v4/euler-swap-hooks-subgraph-provider.ts
@@ -202,10 +202,12 @@ export class EulerSwapHooksSubgraphProvider implements ISubgraphProvider {
           token0 {
             symbol
             id
+            derivedETH
           }
           token1 {
             symbol
             id
+            derivedETH
           }
           feeTier
           tick

--- a/src/providers/v4/euler-swap-hooks-subgraph-provider.ts
+++ b/src/providers/v4/euler-swap-hooks-subgraph-provider.ts
@@ -5,12 +5,11 @@ import Timeout from 'await-timeout';
 import { gql, GraphQLClient } from 'graphql-request';
 import _ from 'lodash';
 
-import { SubgraphPool } from '../../routers/alpha-router/functions/get-candidate-pools';
 import { log, metric } from '../../util';
 import { ProviderConfig } from '../provider';
 import { PAGE_SIZE } from '../subgraph-provider';
 
-import { SUBGRAPH_URL_BY_CHAIN } from './subgraph-provider';
+import { SUBGRAPH_URL_BY_CHAIN, V4SubgraphPool } from './subgraph-provider';
 
 export interface EulerSwapHooks {
   id: string; // euler id
@@ -25,7 +24,7 @@ export interface ISubgraphProvider {
   getPoolByHook(
     hook: string,
     providerConfig?: ProviderConfig
-  ): Promise<SubgraphPool | undefined>;
+  ): Promise<V4SubgraphPool | undefined>;
 }
 
 export class EulerSwapHooksSubgraphProvider implements ISubgraphProvider {
@@ -186,7 +185,7 @@ export class EulerSwapHooksSubgraphProvider implements ISubgraphProvider {
   async getPoolByHook(
     hook: string,
     providerConfig?: ProviderConfig
-  ): Promise<SubgraphPool | undefined> {
+  ): Promise<V4SubgraphPool | undefined> {
     const beforeAll = Date.now();
     const blockNumber = providerConfig?.blockNumber
       ? await providerConfig.blockNumber
@@ -203,26 +202,23 @@ export class EulerSwapHooksSubgraphProvider implements ISubgraphProvider {
           token0 {
             symbol
             id
-            derivedETH
           }
           token1 {
             symbol
             id
-            derivedETH
           }
           feeTier
-          tick
-          liquidity
+          tickSpacing
           hooks
+          liquidity
           totalValueLockedUSD
           totalValueLockedETH
           totalValueLockedUSDUntracked
-          sqrtPrice
         }
       }
     `;
 
-    let pool: SubgraphPool | undefined = undefined;
+    let pool: V4SubgraphPool | undefined = undefined;
 
     log.info(
       `Getting pool by hook from the subgraph with page size ${PAGE_SIZE}${
@@ -233,7 +229,7 @@ export class EulerSwapHooksSubgraphProvider implements ISubgraphProvider {
     );
 
     const poolResult = await this.client.request<{
-      pools: SubgraphPool[];
+      pools: V4SubgraphPool[];
     }>(query, {
       pageSize: PAGE_SIZE,
       hooks: hook.toLowerCase(),


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
euler subgraph missing tickspacing, causing runtime error `Error: invalid BigNumber string (argument=\"value\", value=\"NaN\", code=INVALID_ARGUMENT, version=bignumber/5.7.0)`

- **What is the new behavior (if this is a feature change)?**
in euler subgraph query, we need to query tickspacing as well

- **Other information**:
