### PR TITLE
chore: bump sor to 4.22.2 - fix: dynamic fee pool id siyujiang/route-540-hook-aegis-debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.1",
+  "version": "4.22.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.22.1",
+      "version": "4.22.2",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.1",
+  "version": "4.22.2",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/v4/pool-provider.ts
+++ b/src/providers/v4/pool-provider.ts
@@ -66,7 +66,7 @@ export function isPoolFeeDynamic(
       DYNAMIC_FEE_FLAG,
       Number(subgraphPool.tickSpacing),
       subgraphPool.hooks
-    ) === subgraphPool.id
+    ).toLowerCase() === subgraphPool.id.toLowerCase()
   );
 }
 

--- a/src/providers/v4/pool-provider.ts
+++ b/src/providers/v4/pool-provider.ts
@@ -1,5 +1,5 @@
 import { ChainId, Currency } from '@uniswap/sdk-core';
-import { Pool } from '@uniswap/v4-sdk';
+import { DYNAMIC_FEE_FLAG, Pool } from '@uniswap/v4-sdk';
 import retry, { Options as RetryOptions } from 'async-retry';
 import { getAddress, log, STATE_VIEW_ADDRESSES } from '../../util';
 import { IMulticallProvider, Result } from '../multicall-provider';
@@ -7,6 +7,7 @@ import { ProviderConfig } from '../provider';
 
 import { StateView__factory } from '../../types/other/factories/StateView__factory';
 import { ILiquidity, ISlot0, PoolProvider } from '../pool-provider';
+import { V4SubgraphPool } from './subgraph-provider';
 
 type V4ISlot0 = ISlot0 & {
   poolId: string;
@@ -51,6 +52,10 @@ export function sortsBefore(currencyA: Currency, currencyB: Currency): boolean {
   if (currencyA.isNative) return true;
   if (currencyB.isNative) return false;
   return currencyA.wrapped.sortsBefore(currencyB.wrapped);
+}
+
+export function isPoolFeeDynamic(tokenA: Currency, tokenB: Currency, subgraphPool: V4SubgraphPool): boolean {
+  return Pool.getPoolId(tokenA!, tokenB!, DYNAMIC_FEE_FLAG, Number(subgraphPool.tickSpacing), subgraphPool.hooks) === subgraphPool.id
 }
 
 export class V4PoolProvider

--- a/src/providers/v4/pool-provider.ts
+++ b/src/providers/v4/pool-provider.ts
@@ -54,8 +54,20 @@ export function sortsBefore(currencyA: Currency, currencyB: Currency): boolean {
   return currencyA.wrapped.sortsBefore(currencyB.wrapped);
 }
 
-export function isPoolFeeDynamic(tokenA: Currency, tokenB: Currency, subgraphPool: V4SubgraphPool): boolean {
-  return Pool.getPoolId(tokenA!, tokenB!, DYNAMIC_FEE_FLAG, Number(subgraphPool.tickSpacing), subgraphPool.hooks) === subgraphPool.id
+export function isPoolFeeDynamic(
+  tokenA: Currency,
+  tokenB: Currency,
+  subgraphPool: V4SubgraphPool
+): boolean {
+  return (
+    Pool.getPoolId(
+      tokenA!,
+      tokenB!,
+      DYNAMIC_FEE_FLAG,
+      Number(subgraphPool.tickSpacing),
+      subgraphPool.hooks
+    ) === subgraphPool.id
+  );
 }
 
 export class V4PoolProvider

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -4,8 +4,10 @@ import { FeeAmount } from '@uniswap/v3-sdk';
 import _ from 'lodash';
 
 import { isNativeCurrency } from '@uniswap/universal-router-sdk';
+import { DYNAMIC_FEE_FLAG } from '@uniswap/v4-sdk';
 import {
-  DAI_OPTIMISM_SEPOLIA, isPoolFeeDynamic,
+  DAI_OPTIMISM_SEPOLIA,
+  isPoolFeeDynamic,
   ITokenListProvider,
   IV2SubgraphProvider,
   IV4PoolProvider,
@@ -16,7 +18,7 @@ import {
   V2SubgraphPool,
   V4PoolAccessor,
   V4SubgraphPool,
-  WBTC_OPTIMISM_SEPOLIA
+  WBTC_OPTIMISM_SEPOLIA,
 } from '../../../providers';
 import {
   CELO,
@@ -97,7 +99,6 @@ import { parseFeeAmount } from '../../../util/amounts';
 import { log } from '../../../util/log';
 import { metric, MetricLoggerUnit } from '../../../util/metric';
 import { AlphaRouterConfig } from '../alpha-router';
-import { DYNAMIC_FEE_FLAG, Pool } from '@uniswap/v4-sdk';
 
 export type SubgraphPool = V2SubgraphPool | V3SubgraphPool | V4SubgraphPool;
 export type CandidatePoolsBySelectionCriteria = {
@@ -896,9 +897,9 @@ export async function getV4CandidatePools({
     let fee: number;
     try {
       fee = Number(subgraphPool.feeTier);
-      fee = isPoolFeeDynamic(tokenA!, tokenB!, subgraphPool) ?
-        DYNAMIC_FEE_FLAG :
-        fee;
+      fee = isPoolFeeDynamic(tokenA!, tokenB!, subgraphPool)
+        ? DYNAMIC_FEE_FLAG
+        : fee;
     } catch (err) {
       log.info(
         { subgraphPool },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
We re-compute pool id for dynamic fee pool, but with changing fee tier, pool id stays constant. so when we re-compute pool id, we got it wrong

- **What is the new behavior (if this is a feature change)?**
we should always use the pool id from v4 subgraph.

- **Other information**:
aegis and renzo cannot route through