### PR TITLE
chore: bump sor to 4.22.3 - fix: mixed route quoter encoding should be consistent 06-27-fix_router-sdk_pass_in_usemixedrouterquotev2_boolean_flag_siyujiang_route-476-turn-mixed-routes-back-on-for-l2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/brotli": "^1.3.4",
         "@uniswap/default-token-list": "^11.13.0",
         "@uniswap/permit2-sdk": "^1.3.0",
-        "@uniswap/router-sdk": "^2.0.2",
+        "@uniswap/router-sdk": "^2.0.4",
         "@uniswap/sdk-core": "^7.7.1",
         "@uniswap/swap-router-contracts": "^1.3.1",
         "@uniswap/token-lists": "^1.0.0-beta.31",
@@ -3262,9 +3262,9 @@
       }
     },
     "node_modules/@uniswap/router-sdk": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/router-sdk/-/router-sdk-2.0.3.tgz",
-      "integrity": "sha512-LWDdkpg8qS3wGtLetNojQPdGvBDb9ZSJ9XePmFQhqy2VR/YcERcAsLEjVAKhObPxkazjULIIlmf2yIsCAYzX/w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/router-sdk/-/router-sdk-2.0.4.tgz",
+      "integrity": "sha512-MxCtD+g+2pzzd9rZ6HKTdv1ZK2mLjREoDRNAp9+F961zCCVhgJr9L1/6Hour27/xxCyljwmG83Zn1cSS054giw==",
       "dependencies": {
         "@ethersproject/abi": "^5.5.0",
         "@uniswap/sdk-core": "^7.7.2",
@@ -14328,9 +14328,9 @@
       }
     },
     "@uniswap/router-sdk": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uniswap/router-sdk/-/router-sdk-2.0.3.tgz",
-      "integrity": "sha512-LWDdkpg8qS3wGtLetNojQPdGvBDb9ZSJ9XePmFQhqy2VR/YcERcAsLEjVAKhObPxkazjULIIlmf2yIsCAYzX/w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/router-sdk/-/router-sdk-2.0.4.tgz",
+      "integrity": "sha512-MxCtD+g+2pzzd9rZ6HKTdv1ZK2mLjREoDRNAp9+F961zCCVhgJr9L1/6Hour27/xxCyljwmG83Zn1cSS054giw==",
       "requires": {
         "@ethersproject/abi": "^5.5.0",
         "@uniswap/sdk-core": "^7.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.2",
+  "version": "4.22.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.22.2",
+      "version": "4.22.3",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.2",
+  "version": "4.22.3",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/brotli": "^1.3.4",
     "@uniswap/default-token-list": "^11.13.0",
     "@uniswap/permit2-sdk": "^1.3.0",
-    "@uniswap/router-sdk": "^2.0.2",
+    "@uniswap/router-sdk": "^2.0.4",
     "@uniswap/sdk-core": "^7.7.1",
     "@uniswap/swap-router-contracts": "^1.3.1",
     "@uniswap/token-lists": "^1.0.0-beta.31",

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -467,7 +467,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
   private encodeRouteToPath<
     TRoute extends SupportedRoutes,
     TPath extends SupportedPath
-  >(route: TRoute, functionName: string): TPath {
+  >(route: TRoute, functionName: string, mixedRouteContainsV4Pool: boolean): TPath {
     switch (route.protocol) {
       case Protocol.V3:
         return encodeV3RouteToPath(
@@ -487,7 +487,8 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
         return encodeMixedRouteToPath(
           route instanceof V2Route
             ? new MixedRouteSDK(route.pairs, route.input, route.output, true)
-            : route
+            : route,
+          mixedRouteContainsV4Pool
         ) as TPath;
       default:
         throw new Error(
@@ -666,7 +667,7 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
 
     const inputs: QuoteInputType[] = _(routes)
       .flatMap((route) => {
-        const encodedRoute = this.encodeRouteToPath(route, functionName);
+        const encodedRoute = this.encodeRouteToPath(route, functionName, mixedRouteContainsV4Pool);
 
         const routeInputs: QuoteInputType[] = amounts.map((amount) => {
           switch (route.protocol) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
When mixed routes contain some with v4 pools, but others without v4 pools, we need to be consistent in hitting mixed quoter v2. The reason is because mixed quoter v1 and mixed quoter v2 have different mixed routes encoding, so that we cannot mix and match mixed routes encoding. This has resulted in some weird quotes, where amountIn equals amountOut https://uniswapteam.slack.com/archives/C057EDW9M88/p1745858710285609.

- **What is the new behavior (if this is a feature change)?**
New behavior is to have consistent mixed routes encoding, let SOR pass in whether encoding should use mixed quoter v1 or mixed quoter v2. In case some routes out of all the mixed routes contain v4 pools, then we consistently use the mixed quoter v2 encoding.

- **Other information**:
