### PR TITLE
ROUTE-467 update the input parameter

### DIFF
--- a/src/providers/caching/route/route-caching-provider.ts
+++ b/src/providers/caching/route/route-caching-provider.ts
@@ -111,30 +111,12 @@ export abstract class IRouteCachingProvider {
    *
    * @public
    * @readonly
-   * @param chainId the chain id
-   * @param amount the amount of the currency
-   * @param quoteCurrency the quote currency
-   * @param tradeType the trade type
-   * @param protocols the protocols
-   * @param blockNumber the block number
-   * @returns true if the route was deleted, false otherwise
+   * @param cachedRoutes the cached routes to delete
    */
   public readonly deleteCachedRoute = async (
-    chainId: ChainId,
-    amount: CurrencyAmount<Currency>,
-    quoteCurrency: Currency,
-    tradeType: TradeType,
-    protocols: Protocol[],
-    blockNumber: number
+    cachedRoutes: CachedRoutes
   ): Promise<boolean> => {
-    return this._deleteCachedRoute(
-      chainId,
-      amount,
-      quoteCurrency,
-      tradeType,
-      protocols,
-      blockNumber
-    );
+    return this._deleteCachedRoute(cachedRoutes);
   };
 
   /**
@@ -247,13 +229,6 @@ export abstract class IRouteCachingProvider {
    * Must be implemented by subclasses.
    */
   protected abstract _deleteCachedRoute(
-    chainId: ChainId,
-    amount: CurrencyAmount<Currency>,
-    quoteCurrency: Currency,
-    tradeType: TradeType,
-    protocols: Protocol[],
-    blockNumber: number,
-    alphaRouterConfig?: AlphaRouterConfig,
-    swapOptions?: SwapOptions
+    cachedRoutes: CachedRoutes
   ): Promise<boolean>;
 }

--- a/src/providers/on-chain-quote-provider.ts
+++ b/src/providers/on-chain-quote-provider.ts
@@ -467,7 +467,11 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
   private encodeRouteToPath<
     TRoute extends SupportedRoutes,
     TPath extends SupportedPath
-  >(route: TRoute, functionName: string, mixedRouteContainsV4Pool: boolean): TPath {
+  >(
+    route: TRoute,
+    functionName: string,
+    mixedRouteContainsV4Pool: boolean
+  ): TPath {
     switch (route.protocol) {
       case Protocol.V3:
         return encodeV3RouteToPath(
@@ -667,7 +671,11 @@ export class OnChainQuoteProvider implements IOnChainQuoteProvider {
 
     const inputs: QuoteInputType[] = _(routes)
       .flatMap((route) => {
-        const encodedRoute = this.encodeRouteToPath(route, functionName, mixedRouteContainsV4Pool);
+        const encodedRoute = this.encodeRouteToPath(
+          route,
+          functionName,
+          mixedRouteContainsV4Pool
+        );
 
         const routeInputs: QuoteInputType[] = amounts.map((amount) => {
           switch (route.protocol) {

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -2111,14 +2111,33 @@ export class AlphaRouter
           MetricLoggerUnit.Count
         );
 
-        await this.routeCachingProvider?.deleteCachedRoute(
+        // Generate the object to be cached
+        const routesToCache = CachedRoutes.fromRoutesWithValidQuotes(
+          swapRouteWithSimulation.route,
           this.chainId,
-          amount,
-          quoteCurrency,
+          currencyIn,
+          currencyOut,
+          protocols.sort(),
+          await blockNumber,
           tradeType,
-          protocols,
-          await blockNumber
+          amount.toExact()
         );
+
+        if (!routesToCache) {
+          log.error(
+            { swapRouteWithSimulation },
+            'Failed to generate cached routes after simulation failure'
+          );
+        } else {
+          try {
+            await this.routeCachingProvider?.deleteCachedRoute(routesToCache);
+          } catch (err) {
+            log.error(
+              { err, routesToCache },
+              'Failed to delete cached route after simulation failure'
+            );
+          }
+        }
       }
 
       metric.putMetric(

--- a/test/unit/providers/caching/route/route-caching-provider.test.ts
+++ b/test/unit/providers/caching/route/route-caching-provider.test.ts
@@ -170,12 +170,7 @@ describe('RouteCachingProvider', () => {
 
         // Delete the route
         const deleted = await routeCachingProvider.deleteCachedRoute(
-          cachedRoute.chainId,
-          CurrencyAmount.fromRawAmount(USDC, 100),
-          DAI,
-          TradeType.EXACT_INPUT,
-          [Protocol.V2, Protocol.MIXED, Protocol.V3],
-          blockNumber
+          cachedRoute
         );
         expect(deleted).toBe(true);
         expect(routeCachingProvider.internalDeleteCacheRouteCalls).toEqual(1);

--- a/test/unit/providers/caching/route/test-util/inmemory-route-caching-provider.ts
+++ b/test/unit/providers/caching/route/test-util/inmemory-route-caching-provider.ts
@@ -51,15 +51,11 @@ export class InMemoryRouteCachingProvider extends IRouteCachingProvider {
   }
 
   protected async _deleteCachedRoute(
-    chainId: ChainId,
-    amount: CurrencyAmount<Currency>,
-    quoteCurrency: Currency,
-    tradeType: TradeType,
-    protocols: Protocol[]
+    cachedRoutes: CachedRoutes
   ): Promise<boolean> {
     this.internalDeleteCacheRouteCalls += 1;
 
-    const cacheKey = `${amount.currency.wrapped.symbol}/${quoteCurrency.symbol}/${chainId}/${tradeType}/${protocols.sort()}`;
+    const cacheKey = `${cachedRoutes.currencyIn.symbol}/${cachedRoutes.currencyOut.symbol}/${cachedRoutes.chainId}/${cachedRoutes.tradeType}/${cachedRoutes.protocolsCovered.sort()}`;
     return this.routesCache.delete(cacheKey);
   }
 


### PR DESCRIPTION


- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix:
update the input parameter to a cachedRoute where the _delete method should only delete the specific route which failed the simulation
- **What is the current behavior?** (You can also link to an open issue here)
https://github.com/Uniswap/smart-order-router/pull/894/files#diff-affaa5a649d44ca728a6a71fc9f7fb5baa1c6379a60a9ce1a4b2b2f9ebdc4a3b
- **What is the new behavior (if this is a feature change)?**
a CachedRoute is required
- **Other information**:
