### PR TITLE
feat: Add Abstract mainnet and testnet chain support

### DIFF
--- a/src/providers/caching-token-provider.ts
+++ b/src/providers/caching-token-provider.ts
@@ -29,6 +29,8 @@ import {
   ITokenProvider,
   TokenAccessor,
   USDB_BLAST,
+  USDC_ABSTRACT,
+  USDC_ABSTRACT_TESTNET,
   USDC_ARBITRUM,
   USDC_ARBITRUM_GOERLI,
   USDC_ARBITRUM_SEPOLIA,
@@ -47,6 +49,7 @@ import {
   USDC_SONEIUM,
   USDC_UNICHAIN,
   USDC_WORLDCHAIN,
+  USDT_ABSTRACT,
   USDT_ARBITRUM,
   USDT_BNB,
   USDT_MAINNET,
@@ -61,6 +64,8 @@ import {
   WBTC_OPTIMISM_GOERLI,
   WBTC_OPTIMISM_SEPOLIA,
   WBTC_WORLDCHAIN,
+  WETH_ABSTRACT,
+  WETH_ABSTRACT_TESTNET,
   WLD_WORLDCHAIN,
   WMATIC_POLYGON,
   WMATIC_POLYGON_MUMBAI,
@@ -69,7 +74,7 @@ import {
 // These tokens will added to the Token cache on initialization.
 export const CACHE_SEED_TOKENS: {
   [chainId in ChainId]?: { [symbol: string]: Token };
-} = {
+} & { [key: number]: { [symbol: string]: Token } } = {
   [ChainId.MAINNET]: {
     WETH: WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET]!,
     USDC: USDC_MAINNET,
@@ -205,6 +210,15 @@ export const CACHE_SEED_TOKENS: {
   [ChainId.SONEIUM]: {
     USDC: USDC_SONEIUM,
     WETH: WRAPPED_NATIVE_CURRENCY[ChainId.SONEIUM],
+  },
+  [2741]: {
+    USDC: USDC_ABSTRACT,
+    USDT: USDT_ABSTRACT,
+    WETH: WETH_ABSTRACT,
+  },
+  [11124]: {
+    USDC: USDC_ABSTRACT_TESTNET,
+    WETH: WETH_ABSTRACT_TESTNET,
   },
   // Currently we do not have providers for Moonbeam mainnet or Gnosis testnet
 };

--- a/src/providers/token-provider.ts
+++ b/src/providers/token-provider.ts
@@ -691,6 +691,48 @@ export const WBTC_MOONBEAM = new Token(
   'Wrapped BTC bridged using Multichain'
 );
 
+// Abstract Mainnet Tokens
+export const WETH_ABSTRACT = new Token(
+  2741,
+  '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
+  18,
+  'WETH',
+  'Wrapped Ether'
+);
+
+export const USDC_ABSTRACT = new Token(
+  2741,
+  '0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1',
+  6,
+  'USDC',
+  'USD Coin'
+);
+
+export const USDT_ABSTRACT = new Token(
+  2741,
+  '0x0709F39376dEEe2A2dfC94A58EdEb2Eb9DF012bD',
+  6,
+  'USDT',
+  'Tether USD'
+);
+
+// Abstract Testnet Tokens
+export const WETH_ABSTRACT_TESTNET = new Token(
+  11124,
+  '0x9EDCde0257F2386Ce177C3a7FCdd97787F0D841d',
+  18,
+  'WETH',
+  'Wrapped Ether'
+);
+
+export const USDC_ABSTRACT_TESTNET = new Token(
+  11124,
+  '0xe4C7fBB0a626ed208021ccabA6Be1566905E2dFc',
+  6,
+  'USDC',
+  'USD Coin'
+);
+
 // Blast Tokens
 export const USDB_BLAST = new Token(
   ChainId.BLAST,
@@ -1116,13 +1158,17 @@ export const USDC_ON = (chainId: ChainId): Token => {
       return USDC_UNICHAIN;
     case ChainId.SONEIUM:
       return USDC_SONEIUM;
+    case 2741 as ChainId:
+      return USDC_ABSTRACT;
+    case 11124 as ChainId:
+      return USDC_ABSTRACT_TESTNET;
     default:
       throw new Error(`Chain id: ${chainId} not supported`);
   }
 };
 
 export const WNATIVE_ON = (chainId: ChainId): Token => {
-  return WRAPPED_NATIVE_CURRENCY[chainId];
+  return WRAPPED_NATIVE_CURRENCY[chainId]!;
 };
 
 export const V4_SEPOLIA_TEST_A = new Token(

--- a/src/routers/alpha-router/config.ts
+++ b/src/routers/alpha-router/config.ts
@@ -58,6 +58,8 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (
     case ChainId.ARBITRUM_SEPOLIA:
     case ChainId.CELO:
     case ChainId.CELO_ALFAJORES:
+    case 2741 as ChainId: // Abstract mainnet
+    case 11124 as ChainId: // Abstract testnet
       return {
         v2PoolSelection: {
           topN: 3,

--- a/src/routers/alpha-router/gas-models/gas-costs.ts
+++ b/src/routers/alpha-router/gas-models/gas-costs.ts
@@ -50,6 +50,11 @@ export const BASE_SWAP_COST = (id: ChainId): BigNumber => {
       return BigNumber.from(2000);
     case ChainId.MOONBEAM:
       return BigNumber.from(2000);
+    case 2741 as ChainId: // Abstract mainnet
+    case 11124 as ChainId: // Abstract testnet
+      return BigNumber.from(2000);
+    default:
+      return BigNumber.from(2000);
   }
 };
 export const COST_PER_INIT_TICK = (id: ChainId): BigNumber => {
@@ -91,6 +96,11 @@ export const COST_PER_INIT_TICK = (id: ChainId): BigNumber => {
       return BigNumber.from(31000);
     case ChainId.MOONBEAM:
       return BigNumber.from(31000);
+    case 2741 as ChainId: // Abstract mainnet
+    case 11124 as ChainId: // Abstract testnet
+      return BigNumber.from(31000);
+    default:
+      return BigNumber.from(31000);
   }
 };
 
@@ -131,6 +141,11 @@ export const COST_PER_HOP = (id: ChainId): BigNumber => {
     case ChainId.GNOSIS:
       return BigNumber.from(80000);
     case ChainId.MOONBEAM:
+      return BigNumber.from(80000);
+    case 2741 as ChainId: // Abstract mainnet
+    case 11124 as ChainId: // Abstract testnet
+      return BigNumber.from(80000);
+    default:
       return BigNumber.from(80000);
   }
 };

--- a/src/util/addresses.ts
+++ b/src/util/addresses.ts
@@ -57,6 +57,8 @@ export const V3_CORE_FACTORY_ADDRESSES: AddressMap = {
     CHAIN_TO_ADDRESSES_MAP[ChainId.UNICHAIN].v3CoreFactoryAddress,
   [ChainId.SONEIUM]:
     CHAIN_TO_ADDRESSES_MAP[ChainId.SONEIUM].v3CoreFactoryAddress,
+  [2741]: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1', // Abstract mainnet
+  [11124]: '0x2E17FF9b877661bDFEF8879a4B31665157a960F0', // Abstract testnet
 };
 
 export const QUOTER_V2_ADDRESSES: AddressMap = {
@@ -92,6 +94,8 @@ export const QUOTER_V2_ADDRESSES: AddressMap = {
   // TODO: Gnosis + Moonbeam contracts to be deployed
   [ChainId.UNICHAIN]: CHAIN_TO_ADDRESSES_MAP[ChainId.UNICHAIN].quoterAddress,
   [ChainId.SONEIUM]: CHAIN_TO_ADDRESSES_MAP[ChainId.SONEIUM].quoterAddress,
+  [2741]: '0x728BD3eC25D5EDBafebB84F3d67367Cd9EBC7693', // Abstract mainnet
+  [11124]: '0xdE41045eb15C8352413199f35d6d1A32803DaaE2', // Abstract testnet
 };
 
 export const NEW_QUOTER_V2_ADDRESSES: AddressMap = {
@@ -198,6 +202,8 @@ export const UNISWAP_MULTICALL_ADDRESSES: AddressMap = {
   [ChainId.BLAST]: CHAIN_TO_ADDRESSES_MAP[ChainId.BLAST].multicallAddress,
   [ChainId.ZORA]: CHAIN_TO_ADDRESSES_MAP[ChainId.ZORA].multicallAddress,
   [ChainId.ZKSYNC]: CHAIN_TO_ADDRESSES_MAP[ChainId.ZKSYNC].multicallAddress,
+  [2741]: '0x9CA4dcb2505fbf536F6c54AA0a77C79f4fBC35C0', // Abstract mainnet
+  [11124]: '0x84B11838e53f53DBc1fca7a6413cDd2c7Ab15DB8', // Abstract testnet
   [ChainId.WORLDCHAIN]:
     CHAIN_TO_ADDRESSES_MAP[ChainId.WORLDCHAIN].multicallAddress,
   [ChainId.UNICHAIN_SEPOLIA]:

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -32,6 +32,8 @@ export const SUPPORTED_CHAINS: ChainId[] = [
   ChainId.MONAD_TESTNET,
   ChainId.BASE_SEPOLIA,
   ChainId.SONEIUM,
+  2741 as ChainId, // Abstract mainnet
+  11124 as ChainId, // Abstract testnet
   // Gnosis and Moonbeam don't yet have contracts deployed yet
 ];
 
@@ -167,6 +169,10 @@ export const ID_TO_CHAIN_ID = (id: number): ChainId => {
       return ChainId.UNICHAIN;
     case 1868:
       return ChainId.SONEIUM;
+    case 2741:
+      return 2741 as ChainId; // Abstract mainnet
+    case 11124:
+      return 11124 as ChainId; // Abstract testnet
     default:
       throw new Error(`Unknown chain id: ${id}`);
   }
@@ -196,6 +202,8 @@ export enum ChainName {
   BLAST = 'blast-mainnet',
   ZORA = 'zora-mainnet',
   ZKSYNC = 'zksync-mainnet',
+  ABSTRACT = 'abstract-mainnet',
+  ABSTRACT_TESTNET = 'abstract-testnet',
   WORLDCHAIN = 'worldchain-mainnet',
   UNICHAIN_SEPOLIA = 'unichain-sepolia',
   UNICHAIN = 'unichain-mainnet',
@@ -213,6 +221,7 @@ export enum NativeCurrencyName {
   BNB = 'BNB',
   AVALANCHE = 'AVAX',
   MONAD = 'MON',
+  ABSTRACT = 'ETH',
 }
 
 export const NATIVE_NAMES_BY_ID: { [chainId: number]: string[] } = {
@@ -326,6 +335,8 @@ export const NATIVE_NAMES_BY_ID: { [chainId: number]: string[] } = {
     'ETHER',
     '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
   ],
+  [2741]: ['ETH', 'ETHER', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'],
+  [11124]: ['ETH', 'ETHER', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'],
 };
 
 export const NATIVE_CURRENCY: { [chainId: number]: NativeCurrencyName } = {
@@ -356,6 +367,8 @@ export const NATIVE_CURRENCY: { [chainId: number]: NativeCurrencyName } = {
   [ChainId.BASE_SEPOLIA]: NativeCurrencyName.ETHER,
   [ChainId.UNICHAIN]: NativeCurrencyName.ETHER,
   [ChainId.SONEIUM]: NativeCurrencyName.ETHER,
+  [2741]: NativeCurrencyName.ABSTRACT,
+  [11124]: NativeCurrencyName.ABSTRACT,
 };
 
 export const ID_TO_NETWORK_NAME = (id: number): ChainName => {
@@ -416,6 +429,10 @@ export const ID_TO_NETWORK_NAME = (id: number): ChainName => {
       return ChainName.MONAD_TESTNET;
     case 1868:
       return ChainName.SONEIUM;
+    case 2741:
+      return ChainName.ABSTRACT;
+    case 11124:
+      return ChainName.ABSTRACT_TESTNET;
     default:
       throw new Error(`Unknown chain id: ${id}`);
   }
@@ -482,7 +499,9 @@ export const ID_TO_PROVIDER = (id: ChainId): string => {
   }
 };
 
-export const WRAPPED_NATIVE_CURRENCY: { [chainId in ChainId]: Token } = {
+export const WRAPPED_NATIVE_CURRENCY: { [chainId in ChainId]: Token } & {
+  [key: number]: Token;
+} = {
   [ChainId.MAINNET]: new Token(
     1,
     '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
@@ -691,6 +710,20 @@ export const WRAPPED_NATIVE_CURRENCY: { [chainId in ChainId]: Token } = {
   [ChainId.SONEIUM]: new Token(
     ChainId.SONEIUM,
     '0x4200000000000000000000000000000000000006',
+    18,
+    'WETH',
+    'Wrapped Ether'
+  ),
+  [2741]: new Token(
+    2741,
+    '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
+    18,
+    'WETH',
+    'Wrapped Ether'
+  ),
+  [11124]: new Token(
+    11124,
+    '0x9EDCde0257F2386Ce177C3a7FCdd97787F0D841d',
     18,
     'WETH',
     'Wrapped Ether'


### PR DESCRIPTION
Added abstract mainnet and testnet support:

- Add Abstract mainnet (2741) and testnet (11124) to supported chains
- Add chain configuration with native ETH currency support
- Add WETH, USDC, and USDT token definitions for both chains
- Add Uniswap V3 contract addresses (Quoter V2, Multicall)
- Add gas cost configurations for optimal routing
- Add routing and token caching configuration
- Update type definitions to support new chains

Chain details:
- Mainnet: 2741, RPC: https://api.mainnet.abs.xyz
- Testnet: 11124, RPC: https://api.testnet.abs.xyz

Contract addresses:
- Quoter V2: 0x728BD3eC25D5EDBafebB84F3d67367Cd9EBC7693 (mainnet)
- Quoter V2: 0xdE41045eb15C8352413199f35d6d1A32803DaaE2 (testnet)
- Multicall: 0x9CA4dcb2505fbf536F6c54AA0a77C79f4fBC35C0 (mainnet)
- Multicall: 0x84B11838e53f53DBc1fca7a6413cDd2c7Ab15DB8 (testnet)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
