### PR TITLE
chore: Increased pageSize for Base (all protocols)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.6",
+  "version": "4.22.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.22.6",
+      "version": "4.22.7",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.6",
+  "version": "4.22.7",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/subgraph-provider.ts
+++ b/src/providers/subgraph-provider.ts
@@ -91,13 +91,10 @@ export abstract class SubgraphProvider<
 
     let pools: TRawSubgraphPool[] = [];
 
-    // For Base, we need to fetch more pools at once as V3 pools size is >1.6m as of 6/19/2025.
+    // For Base, we need to fetch more pools at once as V3 pools size is >1.6m as of 6/19/2025 (similar for V2/V4)
     // TODO: This is temporary to unblock timeouts. Come up with a long term fix: https://linear.app/uniswap/issue/ROUTE-551
     const finalPageSize =
-      this.chainId === ChainId.BASE &&
-      (this.protocol === Protocol.V3 || this.protocol === Protocol.V4)
-        ? MAX_PAGE_SIZE
-        : PAGE_SIZE;
+      this.chainId === ChainId.BASE ? MAX_PAGE_SIZE : PAGE_SIZE;
 
     log.info(
       `Getting ${


### PR DESCRIPTION
V2 cron subgraph started timing out as well due to lots of pools.
Increasing pagesize similarly to v3/v4.