### PR TITLE
fix(subgraph): Move filtering to queries to get rid of timeouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.10",
+  "version": "4.22.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.22.10",
+      "version": "4.22.11",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.10",
+  "version": "4.22.11",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/v3/subgraph-provider.ts
+++ b/src/providers/v3/subgraph-provider.ts
@@ -101,33 +101,6 @@ export class V3SubgraphProvider
     );
   }
 
-  protected override subgraphQuery(blockNumber?: number): string {
-    return `
-    query getPools($pageSize: Int!, $id: String) {
-      pools(
-        first: $pageSize
-        ${blockNumber ? `block: { number: ${blockNumber} }` : ``}
-          where: { id_gt: $id }
-        ) {
-          id
-          token0 {
-            symbol
-            id
-          }
-          token1 {
-            symbol
-            id
-          }
-          feeTier
-          liquidity
-          totalValueLockedUSD
-          totalValueLockedETH
-          totalValueLockedUSDUntracked
-        }
-      }
-   `;
-  }
-
   protected override mapSubgraphPool(
     rawPool: V3RawSubgraphPool
   ): V3SubgraphPool {

--- a/src/providers/v4/subgraph-provider.ts
+++ b/src/providers/v4/subgraph-provider.ts
@@ -82,35 +82,6 @@ export class V4SubgraphProvider
     );
   }
 
-  protected override subgraphQuery(blockNumber?: number): string {
-    return `
-    query getPools($pageSize: Int!, $id: String) {
-      pools(
-        first: $pageSize
-        ${blockNumber ? `block: { number: ${blockNumber} }` : ``}
-          where: { id_gt: $id }
-        ) {
-          id
-          token0 {
-            symbol
-            id
-          }
-          token1 {
-            symbol
-            id
-          }
-          feeTier
-          tickSpacing
-          hooks
-          liquidity
-          totalValueLockedUSD
-          totalValueLockedETH
-          totalValueLockedUSDUntracked
-        }
-      }
-   `;
-  }
-
   protected override mapSubgraphPool(
     rawPool: V4RawSubgraphPool
   ): V4SubgraphPool {
@@ -129,5 +100,26 @@ export class V4SubgraphProvider
       tvlETH: parseFloat(rawPool.totalValueLockedETH),
       tvlUSD: parseFloat(rawPool.totalValueLockedUSD),
     };
+  }
+
+  // Override to include V4-specific fields
+  protected override getPoolFields(): string {
+    return `
+      id
+      token0 {
+        symbol
+        id
+      }
+      token1 {
+        symbol
+        id
+      }
+      feeTier
+      tickSpacing
+      hooks
+      liquidity
+      totalValueLockedUSD
+      totalValueLockedETH
+    `;
   }
 }

--- a/test/unit/providers/v2/subgraph-provider.test.ts
+++ b/test/unit/providers/v2/subgraph-provider.test.ts
@@ -9,6 +9,8 @@ dotenv.config();
 describe('SubgraphProvider V2', () => {
 
   const virtualTokenAddress = '0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b';
+  const FEI = '0x956f47f50a910163d8bf957cf5846d573e7f87ca';
+  
   function constructPool(withVirtualToken: boolean, trackedReservedEth: string) {
     return {
       id: '0xAddress1',
@@ -17,6 +19,24 @@ describe('SubgraphProvider V2', () => {
         symbol: withVirtualToken ? 'VIRTUAL' : 'TOKEN0'
       },
       token1: { id: '0xToken1', symbol: 'TOKEN1' },
+      totalSupply: '100000',
+      trackedReserveETH: trackedReservedEth,
+      reserveETH: trackedReservedEth,
+      reserveUSD: '0.001',
+    };
+  }
+
+  function constructFEIPool(isToken0: boolean, trackedReservedEth: string) {
+    return {
+      id: '0xAddress2',
+      token0: {
+        id: isToken0 ? FEI : '0xToken0',
+        symbol: isToken0 ? 'FEI' : 'TOKEN0'
+      },
+      token1: { 
+        id: isToken0 ? '0xToken1' : FEI, 
+        symbol: isToken0 ? 'TOKEN1' : 'FEI' 
+      },
       totalSupply: '100000',
       trackedReserveETH: trackedReservedEth,
       reserveETH: trackedReservedEth,
@@ -35,122 +55,167 @@ describe('SubgraphProvider V2', () => {
     sinon.restore();
   });
 
-  it('fetches subgraph pools if trackedReserveETH is above 0.025 threshold on Base', async () => {
+  it('fetches subgraph pools if trackedReserveETH is above threshold on Base', async () => {
     requestStubBase = sinon.stub(GraphQLClient.prototype, 'request');
     subgraphProviderBase = new V2SubgraphProvider(ChainId.BASE, 2, 30000, true, 1000, 0.01, Number.MAX_VALUE, 'test_url');
 
-    const firstCallResponse = {
-        pairs: [
-          constructPool(false, '1'),
-        ],
-      };
-    const subsequentCallsResponse = { pairs: [] };
+    const highTrackedReserveResponse = {
+      pairs: [constructPool(false, '1')],
+    };
+    const emptyResponse = { pairs: [] };
 
-    // Configure the stub: return mock data on the first call, empty array on subsequent calls
-    requestStubBase.onCall(0).resolves(firstCallResponse);
-    requestStubBase.onCall(1).resolves(subsequentCallsResponse);
+    // Stub all the different query types that will be made
+    // For BASE chain, we expect 6 queries: FEI (token0), FEI (token1), Virtual (token0), Virtual (token1), High tracked reserve, High USD
+    requestStubBase.resolves(emptyResponse); // Default response for most queries
+    requestStubBase.onCall(4).resolves(highTrackedReserveResponse); // High tracked reserve query
+    requestStubBase.onCall(5).resolves(emptyResponse); // High USD query
 
     const pools = await subgraphProviderBase.getPools();
     expect(pools.length).toEqual(1);
     expect(pools[0]!.token0.id).not.toEqual(virtualTokenAddress);
   });
 
-  it('fetches 0 subgraph pools if trackedReserveETH is below 0.025 threshold on Base', async () => {
+  it('fetches 0 subgraph pools if trackedReserveETH is below threshold on Base', async () => {
     requestStubBase = sinon.stub(GraphQLClient.prototype, 'request');
     subgraphProviderBase = new V2SubgraphProvider(ChainId.BASE, 2, 30000, true, 1000, 0.01, Number.MAX_VALUE, 'test_url');
 
-    const firstCallResponse = {
-      pairs: [
-        constructPool(false, '0.001'),
-      ],
+    const lowTrackedReserveResponse = {
+      pairs: [constructPool(false, '0.001')],
     };
-    const subsequentCallsResponse = { pairs: [] };
+    const emptyResponse = { pairs: [] };
 
-    // Configure the stub: return mock data on the first call, empty array on subsequent calls
-    requestStubBase.onCall(0).resolves(firstCallResponse);
-    requestStubBase.onCall(1).resolves(subsequentCallsResponse);
+    // All queries return empty except one that returns a pool with low tracked reserve
+    requestStubBase.resolves(emptyResponse);
+    requestStubBase.onCall(4).resolves(lowTrackedReserveResponse); // High tracked reserve query
 
     const pools = await subgraphProviderBase.getPools();
     expect(pools.length).toEqual(0);
   });
 
-  it('fetches 1 subgraph pools if trackedReserveETH is below 0.025 threshold but Virtual pair on Base', async () => {
+  it('fetches 1 subgraph pools if trackedReserveETH is below threshold but Virtual pair on Base', async () => {
     requestStubBase = sinon.stub(GraphQLClient.prototype, 'request');
     subgraphProviderBase = new V2SubgraphProvider(ChainId.BASE, 2, 30000, true, 1000, 0.01, Number.MAX_VALUE, 'test_url');
 
-    const firstCallResponse = {
-      pairs: [
-        constructPool(true, '0.001'),
-      ],
+    const virtualPoolResponse = {
+      pairs: [constructPool(true, '0.001')],
     };
-    const subsequentCallsResponse = { pairs: [] };
+    const emptyResponse = { pairs: [] };
 
-    // Configure the stub: return mock data on the first call, empty array on subsequent calls
-    requestStubBase.onCall(0).resolves(firstCallResponse);
-    requestStubBase.onCall(1).resolves(subsequentCallsResponse);
+    // Virtual token query returns the pool
+    requestStubBase.resolves(emptyResponse);
+    requestStubBase.onCall(2).resolves(virtualPoolResponse); // Virtual (token0) query
 
     const pools = await subgraphProviderBase.getPools();
     expect(pools.length).toEqual(1);
     expect(pools[0]!.token0.id).toEqual(virtualTokenAddress);
   });
 
-
-  it('fetches subgraph pools if trackedReserveETH is above 0.025 threshold on Mainnet', async () => {
+  it('fetches subgraph pools if trackedReserveETH is above threshold on Mainnet', async () => {
     requestStubMainnet = sinon.stub(GraphQLClient.prototype, 'request');
     subgraphProviderMainnet = new V2SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 1000, 0.01, Number.MAX_VALUE, 'test_url');
 
-    const firstCallResponse = {
-      pairs: [
-        constructPool(false, '1'),
-      ],
+    const highTrackedReserveResponse = {
+      pairs: [constructPool(false, '1')],
     };
-    const subsequentCallsResponse = { pairs: [] };
+    const emptyResponse = { pairs: [] };
 
-    // Configure the stub: return mock data on the first call, empty array on subsequent calls
-    requestStubMainnet.onCall(0).resolves(firstCallResponse);
-    requestStubMainnet.onCall(1).resolves(subsequentCallsResponse);
+    // For MAINNET chain, we expect 4 queries: FEI (token0), FEI (token1), High tracked reserve, High USD
+    requestStubMainnet.resolves(emptyResponse);
+    requestStubMainnet.onCall(2).resolves(highTrackedReserveResponse); // High tracked reserve query
+    requestStubMainnet.onCall(3).resolves(emptyResponse); // High USD query
 
     const pools = await subgraphProviderMainnet.getPools();
     expect(pools.length).toEqual(1);
     expect(pools[0]!.token0.id).not.toEqual(virtualTokenAddress);
   });
 
-  it('fetches 0 subgraph pools if trackedReserveETH is below 0.025 threshold on Mainnet', async () => {
+  it('fetches 0 subgraph pools if trackedReserveETH is below threshold on Mainnet', async () => {
     requestStubMainnet = sinon.stub(GraphQLClient.prototype, 'request');
     subgraphProviderMainnet = new V2SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 1000, 0.01, Number.MAX_VALUE, 'test_url');
 
-    const firstCallResponse = {
-      pairs: [
-        constructPool(false, '0.001'),
-      ],
+    const lowTrackedReserveResponse = {
+      pairs: [constructPool(false, '0.001')],
     };
-    const subsequentCallsResponse = { pairs: [] };
+    const emptyResponse = { pairs: [] };
 
-    // Configure the stub: return mock data on the first call, empty array on subsequent calls
-    requestStubMainnet.onCall(0).resolves(firstCallResponse);
-    requestStubMainnet.onCall(1).resolves(subsequentCallsResponse);
+    requestStubMainnet.resolves(emptyResponse);
+    requestStubMainnet.onCall(2).resolves(lowTrackedReserveResponse); // High tracked reserve query
 
     const pools = await subgraphProviderMainnet.getPools();
     expect(pools.length).toEqual(0);
   });
 
-  it('fetches 0 subgraph pools if trackedReserveETH is below 0.025 threshold but Virtual pair on Mainnet', async () => {
+  it('fetches 0 subgraph pools if trackedReserveETH is below threshold but Virtual pair on Mainnet', async () => {
     requestStubMainnet = sinon.stub(GraphQLClient.prototype, 'request');
     subgraphProviderMainnet = new V2SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 1000, 0.01, Number.MAX_VALUE, 'test_url');
 
-    const firstCallResponse = {
-      pairs: [
-        constructPool(true, '0.001'),
-      ],
-    };
-    const subsequentCallsResponse = { pairs: [] };
+    const emptyResponse = { pairs: [] };
 
-    // Configure the stub: return mock data on the first call, empty array on subsequent calls
-    requestStubMainnet.onCall(0).resolves(firstCallResponse);
-    requestStubMainnet.onCall(1).resolves(subsequentCallsResponse);
+    // Virtual token queries don't exist on Mainnet, so this should return 0
+    requestStubMainnet.resolves(emptyResponse);
 
     const pools = await subgraphProviderMainnet.getPools();
     expect(pools.length).toEqual(0);
+  });
+
+  it('fetches FEI token pools correctly', async () => {
+    requestStubMainnet = sinon.stub(GraphQLClient.prototype, 'request');
+    subgraphProviderMainnet = new V2SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 1000, 0.01, Number.MAX_VALUE, 'test_url');
+
+    const feiPoolResponse = {
+      pairs: [constructFEIPool(true, '0.001')], // FEI as token0
+    };
+    const emptyResponse = { pairs: [] };
+
+    requestStubMainnet.resolves(emptyResponse);
+    requestStubMainnet.onCall(0).resolves(feiPoolResponse); // FEI (token0) query
+
+    const pools = await subgraphProviderMainnet.getPools();
+    expect(pools.length).toEqual(1);
+    expect(pools[0]!.token0.id).toEqual(FEI.toLowerCase());
+  });
+
+  it('fetches high USD reserve pools correctly', async () => {
+    requestStubMainnet = sinon.stub(GraphQLClient.prototype, 'request');
+    subgraphProviderMainnet = new V2SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 1000, 0.01, 0.0001, 'test_url'); // Low USD threshold
+
+    const highUSDPoolResponse = {
+      pairs: [{
+        id: '0xAddress3',
+        token0: { id: '0xToken0', symbol: 'TOKEN0' },
+        token1: { id: '0xToken1', symbol: 'TOKEN1' },
+        totalSupply: '100000',
+        trackedReserveETH: '0.001',
+        reserveETH: '0.001',
+        reserveUSD: '1.0', // High USD value
+      }],
+    };
+    const emptyResponse = { pairs: [] };
+
+    requestStubMainnet.resolves(emptyResponse);
+    requestStubMainnet.onCall(3).resolves(highUSDPoolResponse); // High USD query
+
+    const pools = await subgraphProviderMainnet.getPools();
+    expect(pools.length).toEqual(1);
+    expect(pools[0]!.reserveUSD).toEqual(1.0);
+  });
+
+  it('deduplicates pools that match multiple criteria', async () => {
+    requestStubMainnet = sinon.stub(GraphQLClient.prototype, 'request');
+    subgraphProviderMainnet = new V2SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 1000, 0.01, Number.MAX_VALUE, 'test_url');
+
+    const samePool = constructFEIPool(true, '1.0'); // FEI pool with high tracked reserve
+    const feiPoolResponse = { pairs: [samePool] };
+    const highTrackedReserveResponse = { pairs: [samePool] }; // Same pool returned by different query
+    const emptyResponse = { pairs: [] };
+
+    requestStubMainnet.resolves(emptyResponse);
+    requestStubMainnet.onCall(0).resolves(feiPoolResponse); // FEI (token0) query
+    requestStubMainnet.onCall(2).resolves(highTrackedReserveResponse); // High tracked reserve query
+
+    const pools = await subgraphProviderMainnet.getPools();
+    expect(pools.length).toEqual(1); // Should be deduplicated
+    expect(pools[0]!.token0.id).toEqual(FEI.toLowerCase());
   });
 
   it('isVirtualPairBaseV2Pool tests', async () => {

--- a/test/unit/providers/v3/subgraph-provider.test.ts
+++ b/test/unit/providers/v3/subgraph-provider.test.ts
@@ -2,11 +2,11 @@ import { ChainId } from '@uniswap/sdk-core';
 import dotenv from 'dotenv';
 import { GraphQLClient } from 'graphql-request';
 import sinon from 'sinon';
-import { V4SubgraphProvider } from '../../../../src';
+import { V3SubgraphProvider } from '../../../../src';
 
 dotenv.config();
 
-describe('SubgraphProvider V4', () => {
+describe('SubgraphProvider V3', () => {
   function constructPool(id: string, liquidity: string, totalValueLockedETH: string) {
     return {
       id: id,
@@ -16,8 +16,6 @@ describe('SubgraphProvider V4', () => {
       },
       token1: { id: '0xToken1', symbol: 'TOKEN1' },
       feeTier: '3000',
-      tickSpacing: '60',
-      hooks: '0x0000000000000000000000000000000000000000',
       liquidity: liquidity,
       totalValueLockedUSD: '1000.0',
       totalValueLockedETH: totalValueLockedETH,
@@ -25,7 +23,7 @@ describe('SubgraphProvider V4', () => {
   }
 
   let requestStub: sinon.SinonStub;
-  let subgraphProvider: V4SubgraphProvider;
+  let subgraphProvider: V3SubgraphProvider;
 
   beforeEach(() => {});
 
@@ -35,17 +33,17 @@ describe('SubgraphProvider V4', () => {
 
   it('fetches subgraph pools if totalValueLockedETH is above threshold', async () => {
     requestStub = sinon.stub(GraphQLClient.prototype, 'request');
-    subgraphProvider = new V4SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
+    subgraphProvider = new V3SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
 
     const highTrackedETHResponse = {
       pools: [constructPool('0xAddress1', '1000000', '1.0')], // High tracked ETH
     };
     const emptyResponse = { pools: [] };
 
-    // For V4, we expect 2 queries: High tracked ETH, High liquidity
+    // For V3, we expect 2 queries: High tracked ETH, V3 zero ETH pools
     requestStub.resolves(emptyResponse); // Default response for most queries
     requestStub.onCall(0).resolves(highTrackedETHResponse); // High tracked ETH query
-    requestStub.onCall(1).resolves(emptyResponse); // High liquidity query
+    requestStub.onCall(1).resolves(emptyResponse); // V3 zero ETH pools query
 
     const pools = await subgraphProvider.getPools();
     expect(pools.length).toEqual(1);
@@ -54,7 +52,7 @@ describe('SubgraphProvider V4', () => {
 
   it('fetches 0 subgraph pools if totalValueLockedETH is below threshold and liquidity is 0', async () => {
     requestStub = sinon.stub(GraphQLClient.prototype, 'request');
-    subgraphProvider = new V4SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
+    subgraphProvider = new V3SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
 
     const lowTrackedETHResponse = {
       pools: [constructPool('0xAddress2', '0', '0.001')], // Low tracked ETH and zero liquidity
@@ -69,26 +67,27 @@ describe('SubgraphProvider V4', () => {
     expect(pools.length).toEqual(0);
   });
 
-  it('fetches subgraph pools if liquidity is above 0', async () => {
+  it('fetches subgraph pools with liquidity > 0 AND totalValueLockedETH = 0 (V3 specific)', async () => {
     requestStub = sinon.stub(GraphQLClient.prototype, 'request');
-    subgraphProvider = new V4SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
+    subgraphProvider = new V3SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
 
-    const highLiquidityResponse = {
-      pools: [constructPool('0xAddress3', '1000000', '0.001')], // High liquidity, low tracked ETH
+    const v3ZeroETHResponse = {
+      pools: [constructPool('0xAddress3', '1000000', '0')], // High liquidity, zero tracked ETH (V3 specific)
     };
     const emptyResponse = { pools: [] };
 
     requestStub.resolves(emptyResponse);
-    requestStub.onCall(1).resolves(highLiquidityResponse); // High liquidity query
+    requestStub.onCall(1).resolves(v3ZeroETHResponse); // V3 zero ETH pools query
 
     const pools = await subgraphProvider.getPools();
     expect(pools.length).toEqual(1);
     expect(pools[0]!.liquidity).toEqual('1000000');
+    expect(pools[0]!.tvlETH).toEqual(0);
   });
 
   it('fetches 0 subgraph pools if liquidity is 0', async () => {
     requestStub = sinon.stub(GraphQLClient.prototype, 'request');
-    subgraphProvider = new V4SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
+    subgraphProvider = new V3SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
 
     const zeroLiquidityResponse = {
       pools: [constructPool('0xAddress4', '0', '0.001')], // Zero liquidity
@@ -96,7 +95,23 @@ describe('SubgraphProvider V4', () => {
     const emptyResponse = { pools: [] };
 
     requestStub.resolves(emptyResponse);
-    requestStub.onCall(1).resolves(zeroLiquidityResponse); // High liquidity query
+    requestStub.onCall(1).resolves(zeroLiquidityResponse); // V3 zero ETH pools query
+
+    const pools = await subgraphProvider.getPools();
+    expect(pools.length).toEqual(0);
+  });
+
+  it('fetches 0 subgraph pools if liquidity > 0 but totalValueLockedETH > 0 (not V3 zero ETH condition)', async () => {
+    requestStub = sinon.stub(GraphQLClient.prototype, 'request');
+    subgraphProvider = new V3SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
+
+    const highLiquidityNonZeroETHResponse = {
+      pools: [constructPool('0xAddress5', '1000000', '0.001')], // High liquidity, non-zero tracked ETH
+    };
+    const emptyResponse = { pools: [] };
+
+    requestStub.resolves(emptyResponse);
+    requestStub.onCall(1).resolves(highLiquidityNonZeroETHResponse); // V3 zero ETH pools query
 
     const pools = await subgraphProvider.getPools();
     expect(pools.length).toEqual(0);
@@ -104,16 +119,16 @@ describe('SubgraphProvider V4', () => {
 
   it('deduplicates pools that match multiple criteria', async () => {
     requestStub = sinon.stub(GraphQLClient.prototype, 'request');
-    subgraphProvider = new V4SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
+    subgraphProvider = new V3SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
 
-    const samePool = constructPool('0xAddress5', '1000000', '1.0'); // Pool with high liquidity and high tracked ETH
+    const samePool = constructPool('0xAddress6', '1000000', '1.0'); // Pool with high liquidity and high tracked ETH
     const highTrackedETHResponse = { pools: [samePool] };
-    const highLiquidityResponse = { pools: [samePool] }; // Same pool returned by different query
+    const v3ZeroETHResponse = { pools: [samePool] }; // Same pool returned by different query
     const emptyResponse = { pools: [] };
 
     requestStub.resolves(emptyResponse);
     requestStub.onCall(0).resolves(highTrackedETHResponse); // High tracked ETH query
-    requestStub.onCall(1).resolves(highLiquidityResponse); // High liquidity query
+    requestStub.onCall(1).resolves(v3ZeroETHResponse); // V3 zero ETH pools query
 
     const pools = await subgraphProvider.getPools();
     expect(pools.length).toEqual(1); // Should be deduplicated
@@ -121,18 +136,16 @@ describe('SubgraphProvider V4', () => {
     expect(pools[0]!.liquidity).toEqual('1000000');
   });
 
-  it('correctly maps V4-specific fields', async () => {
+  it('correctly maps V3-specific fields', async () => {
     requestStub = sinon.stub(GraphQLClient.prototype, 'request');
-    subgraphProvider = new V4SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
+    subgraphProvider = new V3SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
 
-    const v4PoolResponse = {
+    const v3PoolResponse = {
       pools: [{
-        id: '0xAddress2',
+        id: '0xAddress7',
         token0: { id: '0xToken0', symbol: 'TOKEN0' },
         token1: { id: '0xToken1', symbol: 'TOKEN1' },
         feeTier: '500',
-        tickSpacing: '10',
-        hooks: '0x1234567890123456789012345678901234567890',
         liquidity: '500000',
         totalValueLockedUSD: '2000.0',
         totalValueLockedETH: '2.0',
@@ -141,14 +154,12 @@ describe('SubgraphProvider V4', () => {
     const emptyResponse = { pools: [] };
 
     requestStub.resolves(emptyResponse);
-    requestStub.onCall(0).resolves(v4PoolResponse); // High tracked ETH query
+    requestStub.onCall(0).resolves(v3PoolResponse); // High tracked ETH query
 
     const pools = await subgraphProvider.getPools();
     expect(pools.length).toEqual(1);
-    expect(pools[0]!.id).toEqual('0xAddress2');
+    expect(pools[0]!.id).toEqual('0xAddress7');
     expect(pools[0]!.feeTier).toEqual('500');
-    expect(pools[0]!.tickSpacing).toEqual('10');
-    expect(pools[0]!.hooks).toEqual('0x1234567890123456789012345678901234567890');
     expect(pools[0]!.liquidity).toEqual('500000');
     expect(pools[0]!.tvlUSD).toEqual(2000.0);
     expect(pools[0]!.tvlETH).toEqual(2.0);
@@ -156,7 +167,7 @@ describe('SubgraphProvider V4', () => {
 
   it('handles empty responses from all queries', async () => {
     requestStub = sinon.stub(GraphQLClient.prototype, 'request');
-    subgraphProvider = new V4SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
+    subgraphProvider = new V3SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
 
     const emptyResponse = { pools: [] };
 
@@ -169,25 +180,25 @@ describe('SubgraphProvider V4', () => {
 
   it('handles multiple pools from different queries', async () => {
     requestStub = sinon.stub(GraphQLClient.prototype, 'request');
-    subgraphProvider = new V4SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
+    subgraphProvider = new V3SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
 
     const highTrackedETHResponse = {
-      pools: [constructPool('0xAddress6', '1000000', '1.0')],
+      pools: [constructPool('0xAddress8', '1000000', '1.0')],
     };
-    const highLiquidityResponse = {
-      pools: [constructPool('0xAddress7', '2000000', '2.0')],
+    const v3ZeroETHResponse = {
+      pools: [constructPool('0xAddress9', '2000000', '0')], // V3 zero ETH pool
     };
     const emptyResponse = { pools: [] };
 
-    // Mock responses for the two V4 queries
+    // Mock responses for the two V3 queries
     let callCount = 0;
     requestStub.callsFake(() => {
       callCount++;
       // High tracked ETH query returns one pool
       if (callCount === 1) return Promise.resolve(highTrackedETHResponse);
       if (callCount === 2) return Promise.resolve(emptyResponse); // End pagination for first query
-      // High liquidity query returns another pool
-      if (callCount === 3) return Promise.resolve(highLiquidityResponse);
+      // V3 zero ETH pools query returns another pool
+      if (callCount === 3) return Promise.resolve(v3ZeroETHResponse);
       if (callCount === 4) return Promise.resolve(emptyResponse); // End pagination for second query
       // Default for any other calls
       return Promise.resolve(emptyResponse);
@@ -196,24 +207,55 @@ describe('SubgraphProvider V4', () => {
     const pools = await subgraphProvider.getPools();
     expect(pools.length).toEqual(2);
     expect(pools[0]!.tvlETH).toEqual(1.0);
-    expect(pools[1]!.tvlETH).toEqual(2.0);
+    expect(pools[1]!.tvlETH).toEqual(0);
+    expect(pools[1]!.liquidity).toEqual('2000000');
   });
 
-  // Keep the original test but unskip it and update it to work with the new structure
+  it('correctly filters V3 pools based on V3-specific logic', async () => {
+    requestStub = sinon.stub(GraphQLClient.prototype, 'request');
+    subgraphProvider = new V3SubgraphProvider(ChainId.MAINNET, 2, 30000, true, 0.01, Number.MAX_VALUE, 'test_url');
+
+    // Test the V3-specific filtering logic:
+    // - Include pools with liquidity > 0 AND totalValueLockedETH = 0
+    // - Include pools with totalValueLockedETH > threshold
+    const highTrackedETHResponse = {
+      pools: [constructPool('0xAddress10', '1000000', '1.0')], // High tracked ETH
+    };
+    const v3ZeroETHResponse = {
+      pools: [constructPool('0xAddress11', '500000', '0')], // V3 zero ETH pool
+    };
+    const emptyResponse = { pools: [] };
+
+    requestStub.resolves(emptyResponse);
+    requestStub.onCall(0).resolves(highTrackedETHResponse); // High tracked ETH query
+    requestStub.onCall(1).resolves(v3ZeroETHResponse); // V3 zero ETH pools query
+
+    const pools = await subgraphProvider.getPools();
+    expect(pools.length).toEqual(2);
+    
+    // First pool should have high tracked ETH
+    expect(pools[0]!.tvlETH).toEqual(1.0);
+    expect(pools[0]!.liquidity).toEqual('1000000');
+    
+    // Second pool should be V3 zero ETH pool
+    expect(pools[1]!.tvlETH).toEqual(0);
+    expect(pools[1]!.liquidity).toEqual('500000');
+  });
+
   it('can fetch subgraph pools from actual subgraph', async () => {
-    if (!process.env.SUBGRAPH_URL_SEPOLIA) {
-      console.log('Skipping actual subgraph test - no SUBGRAPH_URL_SEPOLIA provided');
+    if (!process.env.SUBGRAPH_URL_MAINNET) {
+      console.log('Skipping actual subgraph test - no SUBGRAPH_URL_MAINNET provided');
       return;
     }
 
-    const subgraphProvider = new V4SubgraphProvider(
+    const subgraphProvider = new V3SubgraphProvider(
       ChainId.MAINNET, 
       2, 
       30000, 
       true, 
       0.01, 
       Number.MAX_VALUE, 
-      process.env.SUBGRAPH_URL_SEPOLIA
+      process.env.SUBGRAPH_URL_MAINNET
     );
     
     const pools = await subgraphProvider.getPools();
@@ -224,11 +266,9 @@ describe('SubgraphProvider V4', () => {
       const pool = pools[0]!;
       expect(pool.id).toBeDefined();
       expect(pool.feeTier).toBeDefined();
-      expect(pool.tickSpacing).toBeDefined();
-      expect(pool.hooks).toBeDefined();
       expect(pool.liquidity).toBeDefined();
       expect(pool.tvlUSD).toBeDefined();
       expect(pool.tvlETH).toBeDefined();
     }
   });
-});
+}); 


### PR DESCRIPTION
This PR aims to address subgraph 15m timeouts once and for all.
By moving filtering in the query itself, instead of fetching all pools then filtering.
This should speed up the process significantly.

https://linear.app/uniswap/issue/ROUTE-551/long-term-fix-for-base-v3-subgraph-15m-timeouts

**Pending**: validation that we get same results/pools for v2/v3/v4