### PR TITLE
chore: bump sor to 4.22.13 - fix: support new gql endpoint for zora siyujiang/new-gql-endpointt

### DIFF
--- a/src/providers/subgraph-provider.ts
+++ b/src/providers/subgraph-provider.ts
@@ -66,13 +66,23 @@ export abstract class SubgraphProvider<
     private trackedEthThreshold = 0.01,
     // @ts-expect-error - kept for backward compatibility
     private untrackedUsdThreshold = Number.MAX_VALUE,
-    private subgraphUrl?: string
+    private subgraphUrl?: string,
+    private useNewEndpoint = false,
+    private bearerToken?: string
   ) {
     this.protocol = protocol;
     if (!this.subgraphUrl) {
       throw new Error(`No subgraph url for chain id: ${this.chainId}`);
     }
-    this.client = new GraphQLClient(this.subgraphUrl);
+    if (this.useNewEndpoint) {
+      this.client = new GraphQLClient(this.subgraphUrl, {
+        headers: {
+          authorization: `Bearer ${this.bearerToken}`
+        },
+      });
+    } else {
+      this.client = new GraphQLClient(this.subgraphUrl);
+    }
   }
 
   public async getPools(

--- a/src/providers/subgraph-provider.ts
+++ b/src/providers/subgraph-provider.ts
@@ -67,14 +67,13 @@ export abstract class SubgraphProvider<
     // @ts-expect-error - kept for backward compatibility
     private untrackedUsdThreshold = Number.MAX_VALUE,
     private subgraphUrl?: string,
-    private useNewEndpoint = false,
     private bearerToken?: string
   ) {
     this.protocol = protocol;
     if (!this.subgraphUrl) {
       throw new Error(`No subgraph url for chain id: ${this.chainId}`);
     }
-    if (this.useNewEndpoint) {
+    if (this.bearerToken) {
       this.client = new GraphQLClient(this.subgraphUrl, {
         headers: {
           authorization: `Bearer ${this.bearerToken}`


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
zora has many creator pools and post pools. current subgraph cannot sync to tip. we need to migrate to new subgraph endpoint.

- **What is the new behavior (if this is a feature change)?**
migrate to new subgraph endpoint. new endpoint needs bearer token, meanwhile old one doesn't

- **Other information**:
