### PR TITLE
chore: bump sor to 4.22.15 - fix: query more v4 subgraph token fields for dynamic fee hook pool detemrination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.14",
+  "version": "4.22.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.22.14",
+      "version": "4.22.15",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.14",
+  "version": "4.22.15",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/providers/v4/subgraph-provider.ts
+++ b/src/providers/v4/subgraph-provider.ts
@@ -11,10 +11,16 @@ export interface V4SubgraphPool {
   hooks: string;
   liquidity: string;
   token0: {
+    symbol: string;
     id: string;
+    name: string;
+    decimals: number;
   };
   token1: {
+    symbol: string;
     id: string;
+    name: string;
+    decimals: number;
   };
   tvlETH: number;
   tvlUSD: number;
@@ -29,10 +35,14 @@ export type V4RawSubgraphPool = {
   token0: {
     symbol: string;
     id: string;
+    name: string;
+    decimals: number;
   };
   token1: {
     symbol: string;
     id: string;
+    name: string;
+    decimals: number;
   };
   totalValueLockedUSD: string;
   totalValueLockedETH: string;
@@ -94,10 +104,16 @@ export class V4SubgraphProvider
       hooks: rawPool.hooks,
       liquidity: rawPool.liquidity,
       token0: {
+        symbol: rawPool.token0.symbol,
         id: rawPool.token0.id,
+        name: rawPool.token0.name,
+        decimals: rawPool.token0.decimals,
       },
       token1: {
+        symbol: rawPool.token1.symbol,
         id: rawPool.token1.id,
+        name: rawPool.token1.name,
+        decimals: rawPool.token1.decimals,
       },
       tvlETH: parseFloat(rawPool.totalValueLockedETH),
       tvlUSD: parseFloat(rawPool.totalValueLockedUSD),
@@ -111,10 +127,14 @@ export class V4SubgraphProvider
       token0 {
         symbol
         id
+        name
+        decimals
       }
       token1 {
         symbol
         id
+        name
+        decimals
       }
       feeTier
       tickSpacing


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
