### PR TITLE
chore: bump sor to 4.22.17 - fix: cross liquidity between v3 and v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.16",
+  "version": "4.22.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.22.16",
+      "version": "4.22.17",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.16",
+  "version": "4.22.17",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -3045,6 +3045,7 @@ export class AlphaRouter
                   blockNumber: routingConfig.blockNumber,
                   v2SubgraphProvider: this.v2SubgraphProvider,
                   v3SubgraphProvider: this.v3SubgraphProvider,
+                  v4SubgraphProvider: this.v4SubgraphProvider,
                   v2Candidates: v2CandidatePools,
                   v3Candidates: v3CandidatePools,
                   v4Candidates: v4CandidatePools,

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -301,7 +301,6 @@ export async function getMixedCrossLiquidityCandidatePools({
   blockNumber,
   v2SubgraphProvider,
   v3SubgraphProvider,
-  v4SubgraphProvider,
   v2Candidates,
   v3Candidates,
   v4Candidates,
@@ -316,11 +315,6 @@ export async function getMixedCrossLiquidityCandidatePools({
       blockNumber,
     })
   ).sort((a, b) => b.tvlUSD - a.tvlUSD);
-  const v4Pools = (
-    await v4SubgraphProvider.getPools(tokenIn, tokenOut, {
-      blockNumber,
-    })
-  ).sort((a, b) => b.tvlUSD - a.tvlUSD);
 
   const tokenInAddress = tokenIn.address.toLowerCase();
   const tokenOutAddress = tokenOut.address.toLowerCase();
@@ -332,31 +326,6 @@ export async function getMixedCrossLiquidityCandidatePools({
     v2Candidates,
     v3Candidates
   );
-  const v2AgainstV4SelectedPools = findCrossProtocolMissingPools(
-    tokenInAddress,
-    tokenOutAddress,
-    v2Pools,
-    v2Candidates,
-    v4Candidates
-  );
-
-  // this is for deduplicate v2 pools, in case both v4 and v3 select the same v2 pools for tokenIn/tokenOut
-  if (
-    v2AgainstV4SelectedPools.forTokenIn?.id ===
-      v2AgainstV3SelectedPools.forTokenIn?.id ||
-    v2AgainstV4SelectedPools.forTokenIn?.id ===
-      v2AgainstV3SelectedPools.forTokenOut?.id
-  ) {
-    v2AgainstV4SelectedPools.forTokenIn = undefined;
-  }
-  if (
-    v2AgainstV4SelectedPools.forTokenOut?.id ===
-      v2AgainstV3SelectedPools.forTokenIn?.id ||
-    v2AgainstV4SelectedPools.forTokenOut?.id ===
-      v2AgainstV3SelectedPools.forTokenOut?.id
-  ) {
-    v2AgainstV4SelectedPools.forTokenOut = undefined;
-  }
 
   const v3AgainstV2SelectedPools = findCrossProtocolMissingPools(
     tokenInAddress,
@@ -365,6 +334,7 @@ export async function getMixedCrossLiquidityCandidatePools({
     v3Candidates,
     v2Candidates
   );
+
   const v3AgainstV4SelectedPools = findCrossProtocolMissingPools(
     tokenInAddress,
     tokenOutAddress,
@@ -391,44 +361,9 @@ export async function getMixedCrossLiquidityCandidatePools({
     v3AgainstV4SelectedPools.forTokenOut = undefined;
   }
 
-  const v4AgainstV2SelectedPools = findCrossProtocolMissingPools(
-    tokenInAddress,
-    tokenOutAddress,
-    v4Pools,
-    v4Candidates,
-    v2Candidates
-  );
-  const v4AgainstV3SelectedPools = findCrossProtocolMissingPools(
-    tokenInAddress,
-    tokenOutAddress,
-    v4Pools,
-    v4Candidates,
-    v3Candidates
-  );
-
-  // this is for deduplicate v4 pools, in case both v2 and v3 select the same v4 pools for tokenIn/tokenOut
-  if (
-    v4AgainstV2SelectedPools.forTokenIn?.id ===
-      v4AgainstV3SelectedPools.forTokenIn?.id ||
-    v4AgainstV2SelectedPools.forTokenIn?.id ===
-      v4AgainstV3SelectedPools.forTokenOut?.id
-  ) {
-    v4AgainstV2SelectedPools.forTokenIn = undefined;
-  }
-  if (
-    v4AgainstV2SelectedPools.forTokenOut?.id ===
-      v4AgainstV3SelectedPools.forTokenIn?.id ||
-    v4AgainstV2SelectedPools.forTokenOut?.id ===
-      v4AgainstV3SelectedPools.forTokenOut?.id
-  ) {
-    v4AgainstV2SelectedPools.forTokenOut = undefined;
-  }
-
   const selectedV2Pools = [
     v2AgainstV3SelectedPools.forTokenIn,
     v2AgainstV3SelectedPools.forTokenOut,
-    v2AgainstV4SelectedPools.forTokenIn,
-    v2AgainstV4SelectedPools.forTokenOut,
   ].filter((pool) => pool !== undefined) as V2SubgraphPool[];
   const selectedV3Pools = [
     v3AgainstV2SelectedPools.forTokenIn,
@@ -436,17 +371,11 @@ export async function getMixedCrossLiquidityCandidatePools({
     v3AgainstV4SelectedPools.forTokenIn,
     v3AgainstV4SelectedPools.forTokenOut,
   ].filter((pool) => pool !== undefined) as V3SubgraphPool[];
-  const selectedV4Pools = [
-    v4AgainstV2SelectedPools.forTokenIn,
-    v4AgainstV2SelectedPools.forTokenOut,
-    v4AgainstV3SelectedPools.forTokenIn,
-    v4AgainstV3SelectedPools.forTokenOut,
-  ].filter((pool) => pool !== undefined) as V4SubgraphPool[];
 
   return {
     v2Pools: selectedV2Pools,
     v3Pools: selectedV3Pools,
-    v4Pools: selectedV4Pools,
+    v4Pools: [],
   };
 }
 

--- a/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
+++ b/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
@@ -1160,5 +1160,148 @@ describe('get candidate pools', () => {
         }
       );
     });
+    describe('fetching cross protocol missing v4', () => {
+      test('Obtains the highest liquidity pools missing from the cross protocol selection', async () => {
+        const v4Candidates = mockV4CandidatePools([WETH9_USDT_V4_LOW], [USDC_DAI_V4_LOW]);
+        const v3Candidates = mockV3CandidatePools([WETH9_USDT_LOW], [USDC_DAI_LOW]);
+        const v2Candidates = mockV2CandidatePools([WETH_USDT], [USDC_DAI]);
+
+        const crossLiquidityCandidatePools = await getMixedCrossLiquidityCandidatePools({
+          tokenIn: WRAPPED_NATIVE_CURRENCY[1]!,
+          tokenOut: DAI,
+          v2SubgraphProvider: mockV2SubgraphProvider,
+          v3SubgraphProvider: mockV3SubgraphProvider,
+          v4SubgraphProvider: mockV4SubgraphProvider,
+          v2Candidates,
+          v3Candidates,
+          v4Candidates,
+        });
+
+        expect(crossLiquidityCandidatePools).toEqual({
+          v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
+          v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
+          v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW), poolToV4Subgraph(USDC_WETH_V4_LOW)],
+        });
+      });
+
+      test('Ignores already selected pools when finding highest liquidity pools', async () => {
+        const v4Candidates = mockV4CandidatePools([WETH9_USDT_V4_LOW], [USDC_DAI_V4_LOW], [DAI_USDT_V4_LOW]);
+        const v3Candidates = mockV3CandidatePools([WETH9_USDT_LOW], [USDC_DAI_LOW]);
+        const v2Candidates = mockV2CandidatePools([WETH_USDT], [USDC_DAI]);
+
+        const crossLiquidityCandidatePools = await getMixedCrossLiquidityCandidatePools({
+          tokenIn: WRAPPED_NATIVE_CURRENCY[1]!,
+          tokenOut: DAI,
+          v2SubgraphProvider: mockV2SubgraphProvider,
+          v3SubgraphProvider: mockV3SubgraphProvider,
+          v4SubgraphProvider: mockV4SubgraphProvider,
+          v2Candidates,
+          v3Candidates,
+          v4Candidates,
+        });
+
+        expect(crossLiquidityCandidatePools).toEqual({
+          v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
+          v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
+          v4Pools: [poolToV4Subgraph(USDC_WETH_V4_LOW)],
+        });
+      });
+    });
+
+    describe('fetching cross protocol missing v4 and v2', () => {
+      test('Obtains the highest liquidity pools missing from the cross protocol selection', async () => {
+        const v4Candidates = mockV4CandidatePools([WETH9_USDT_V4_LOW], [USDC_DAI_V4_LOW]);
+        const v3Candidates = mockV3CandidatePools([WETH9_USDT_LOW], [USDC_DAI_LOW]);
+        const v2Candidates = mockV2CandidatePools([WETH_USDT], [USDC_DAI]);
+
+        const crossLiquidityCandidatePools = await getMixedCrossLiquidityCandidatePools({
+          tokenIn: WRAPPED_NATIVE_CURRENCY[1]!,
+          tokenOut: DAI,
+          v2SubgraphProvider: mockV2SubgraphProvider,
+          v3SubgraphProvider: mockV3SubgraphProvider,
+          v4SubgraphProvider: mockV4SubgraphProvider,
+          v2Candidates,
+          v3Candidates,
+          v4Candidates,
+        });
+
+        expect(crossLiquidityCandidatePools).toEqual({
+          v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
+          v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
+          v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW), poolToV4Subgraph(USDC_WETH_V4_LOW)],
+        });
+      });
+
+      test('Ignores already selected pools when finding highest liquidity pools', async () => {
+        const v4Candidates = mockV4CandidatePools([WETH9_USDT_V4_LOW], [USDC_DAI_V4_LOW], [DAI_USDT_V4_LOW]);
+        const v3Candidates = mockV3CandidatePools([WETH9_USDT_LOW], [USDC_DAI_LOW]);
+        const v2Candidates = mockV2CandidatePools([WETH_USDT], [USDC_DAI], [USDC_WETH]);
+
+        const crossLiquidityCandidatePools = await getMixedCrossLiquidityCandidatePools({
+          tokenIn: WRAPPED_NATIVE_CURRENCY[1]!,
+          tokenOut: DAI,
+          v2SubgraphProvider: mockV2SubgraphProvider,
+          v3SubgraphProvider: mockV3SubgraphProvider,
+          v4SubgraphProvider: mockV4SubgraphProvider,
+          v2Candidates,
+          v3Candidates,
+          v4Candidates,
+        });
+
+        expect(crossLiquidityCandidatePools).toEqual({
+          v2Pools: [pairToV2Subgraph(DAI_USDT)],
+          v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
+          v4Pools: [poolToV4Subgraph(USDC_WETH_V4_LOW)],
+        });
+      });
+    });
+
+    describe('fetching cross protocol missing v4 and v3', () => {
+      test('Obtains the highest liquidity pools missing from the cross protocol selection', async () => {
+        const v4Candidates = mockV4CandidatePools([WETH9_USDT_V4_LOW], [USDC_DAI_V4_LOW]);
+        const v3Candidates = mockV3CandidatePools([WETH9_USDT_LOW], [USDC_DAI_LOW]);
+        const v2Candidates = mockV2CandidatePools([WETH_USDT], [USDC_DAI]);
+
+        const crossLiquidityCandidatePools = await getMixedCrossLiquidityCandidatePools({
+          tokenIn: WRAPPED_NATIVE_CURRENCY[1]!,
+          tokenOut: DAI,
+          v2SubgraphProvider: mockV2SubgraphProvider,
+          v3SubgraphProvider: mockV3SubgraphProvider,
+          v4SubgraphProvider: mockV4SubgraphProvider,
+          v2Candidates,
+          v3Candidates,
+          v4Candidates,
+        });
+
+        expect(crossLiquidityCandidatePools).toEqual({
+          v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
+          v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
+          v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW), poolToV4Subgraph(USDC_WETH_V4_LOW)],
+        });
+      });
+
+      test('Ignores already selected pools when finding highest liquidity pools', async () => {
+        const v4Candidates = mockV4CandidatePools([WETH9_USDT_V4_LOW], [USDC_DAI_V4_LOW], [DAI_USDT_V4_LOW]);
+        const v3Candidates = mockV3CandidatePools([WETH9_USDT_LOW], [USDC_DAI_LOW], [USDC_WETH_LOW]);
+        const v2Candidates = mockV2CandidatePools([WETH_USDT], [USDC_DAI]);
+
+        const crossLiquidityCandidatePools = await getMixedCrossLiquidityCandidatePools({
+          tokenIn: WRAPPED_NATIVE_CURRENCY[1]!,
+          tokenOut: DAI,
+          v2SubgraphProvider: mockV2SubgraphProvider,
+          v3SubgraphProvider: mockV3SubgraphProvider,
+          v4SubgraphProvider: mockV4SubgraphProvider,
+          v2Candidates,
+          v3Candidates,
+          v4Candidates,
+        });
+
+        expect(crossLiquidityCandidatePools).toEqual({
+          v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
+          v3Pools: [poolToV3Subgraph(DAI_USDT_LOW)],
+          v4Pools: [poolToV4Subgraph(USDC_WETH_V4_LOW)],
+        });
+      });
+    });
   });
 });

--- a/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
+++ b/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
@@ -1028,7 +1028,7 @@ describe('get candidate pools', () => {
         expect(crossLiquidityCandidatePools).toEqual({
           v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
           v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
-          v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW), poolToV4Subgraph(USDC_WETH_V4_LOW)],
+          v4Pools: [],
         });
       });
 
@@ -1053,7 +1053,7 @@ describe('get candidate pools', () => {
           expect(crossLiquidityCandidatePools).toEqual({
             v2Pools: [pairToV2Subgraph(USDC_WETH)],
             v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
-            v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW), poolToV4Subgraph(USDC_WETH_V4_LOW)],
+            v4Pools: [],
           });
         }
       );
@@ -1079,7 +1079,7 @@ describe('get candidate pools', () => {
         expect(crossLiquidityCandidatePools).toEqual({
           v2Pools: [],
           v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
-          v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW), poolToV4Subgraph(USDC_WETH_V4_LOW)],
+          v4Pools: [],
         });
       });
 
@@ -1104,7 +1104,7 @@ describe('get candidate pools', () => {
           expect(crossLiquidityCandidatePools).toEqual({
             v2Pools: [],
             v3Pools: [poolToV3Subgraph(DAI_USDT_LOW)],
-            v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW)],
+            v4Pools: [],
           });
         }
       );
@@ -1130,7 +1130,7 @@ describe('get candidate pools', () => {
         expect(crossLiquidityCandidatePools).toEqual({
           v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
           v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
-          v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW), poolToV4Subgraph(USDC_WETH_V4_LOW)],
+          v4Pools: [],
         });
       });
 
@@ -1155,7 +1155,7 @@ describe('get candidate pools', () => {
           expect(crossLiquidityCandidatePools).toEqual({
             v2Pools: [pairToV2Subgraph(USDC_WETH)],
             v3Pools: [poolToV3Subgraph(DAI_USDT_LOW)],
-            v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW)],
+            v4Pools: [],
           });
         }
       );
@@ -1180,7 +1180,7 @@ describe('get candidate pools', () => {
         expect(crossLiquidityCandidatePools).toEqual({
           v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
           v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
-          v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW), poolToV4Subgraph(USDC_WETH_V4_LOW)],
+          v4Pools: [],
         });
       });
 
@@ -1203,7 +1203,7 @@ describe('get candidate pools', () => {
         expect(crossLiquidityCandidatePools).toEqual({
           v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
           v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
-          v4Pools: [poolToV4Subgraph(USDC_WETH_V4_LOW)],
+          v4Pools: [],
         });
       });
     });
@@ -1228,7 +1228,7 @@ describe('get candidate pools', () => {
         expect(crossLiquidityCandidatePools).toEqual({
           v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
           v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
-          v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW), poolToV4Subgraph(USDC_WETH_V4_LOW)],
+          v4Pools: [],
         });
       });
 
@@ -1251,7 +1251,7 @@ describe('get candidate pools', () => {
         expect(crossLiquidityCandidatePools).toEqual({
           v2Pools: [pairToV2Subgraph(DAI_USDT)],
           v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
-          v4Pools: [poolToV4Subgraph(USDC_WETH_V4_LOW)],
+          v4Pools: [],
         });
       });
     });
@@ -1276,7 +1276,7 @@ describe('get candidate pools', () => {
         expect(crossLiquidityCandidatePools).toEqual({
           v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
           v3Pools: [poolToV3Subgraph(DAI_USDT_LOW), poolToV3Subgraph(USDC_WETH_LOW)],
-          v4Pools: [poolToV4Subgraph(DAI_USDT_V4_LOW), poolToV4Subgraph(USDC_WETH_V4_LOW)],
+          v4Pools: [],
         });
       });
 
@@ -1299,7 +1299,7 @@ describe('get candidate pools', () => {
         expect(crossLiquidityCandidatePools).toEqual({
           v2Pools: [pairToV2Subgraph(DAI_USDT), pairToV2Subgraph(USDC_WETH)],
           v3Pools: [poolToV3Subgraph(DAI_USDT_LOW)],
-          v4Pools: [poolToV4Subgraph(USDC_WETH_V4_LOW)],
+          v4Pools: [],
         });
       });
     });


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
we don't have cross liquidity between v3 and v4. v3 zora/eth has 1.7mil tvl, needs to be used for connecting v4 zora creator pools.

- **What is the new behavior (if this is a feature change)?**
we will have v3 and v4 cross liquidity

- **Other information**:
