### PR TITLE
chore: bump sor to 4.22.19 - fix: add per-chain feature flag to the mixed cross-liquidity v3 against v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.19",
+  "version": "4.22.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.21.19",
+      "version": "4.22.19",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.18",
+  "version": "4.21.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/smart-order-router",
-      "version": "4.22.18",
+      "version": "4.21.19",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.21.19",
+  "version": "4.22.19",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/smart-order-router",
-  "version": "4.22.18",
+  "version": "4.21.19",
   "description": "Uniswap Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -112,6 +112,7 @@ import {
   getAddressLowerCase,
   getApplicableV4FeesTickspacingsHooks,
   HooksOptions,
+  MIXED_CROSS_LIQUIDITY_V3_AGAINST_V4_SUPPORTED,
   MIXED_SUPPORTED,
   shouldWipeoutCachedRoutes,
   SWAP_ROUTER_02_ADDRESSES,
@@ -346,6 +347,11 @@ export type AlphaRouterParams = {
    * All the supported mixed chains configuration
    */
   mixedSupported?: ChainId[];
+
+  /**
+   * All the supported mixed cross-liquidity high v3 tvl pools against low-to-mid v4 pools chains configuration
+   */
+  mixedCrossLiquidityV3AgainstV4Supported?: ChainId[];
 
   /**
    * The v4 pool params to be used for the v4 pool provider.
@@ -604,6 +610,7 @@ export class AlphaRouter
   protected v2Supported?: ChainId[];
   protected v4Supported?: ChainId[];
   protected mixedSupported?: ChainId[];
+  protected mixedCrossLiquidityV3AgainstV4Supported?: ChainId[];
   protected v4PoolParams?: Array<[number, number, string]>;
   protected cachedRoutesCacheInvalidationFixRolloutPercentage?: number;
   protected shouldEnableMixedRouteEthWeth?: boolean;
@@ -638,6 +645,7 @@ export class AlphaRouter
     v2Supported,
     v4Supported,
     mixedSupported,
+    mixedCrossLiquidityV3AgainstV4Supported,
     v4PoolParams,
     cachedRoutesCacheInvalidationFixRolloutPercentage,
     deleteCacheEnabledChains,
@@ -1108,6 +1116,9 @@ export class AlphaRouter
     this.v2Supported = v2Supported ?? V2_SUPPORTED;
     this.v4Supported = v4Supported ?? V4_SUPPORTED;
     this.mixedSupported = mixedSupported ?? MIXED_SUPPORTED;
+    this.mixedCrossLiquidityV3AgainstV4Supported =
+      mixedCrossLiquidityV3AgainstV4Supported ??
+      MIXED_CROSS_LIQUIDITY_V3_AGAINST_V4_SUPPORTED;
 
     this.cachedRoutesCacheInvalidationFixRolloutPercentage =
       cachedRoutesCacheInvalidationFixRolloutPercentage;
@@ -3049,6 +3060,9 @@ export class AlphaRouter
                   v2Candidates: v2CandidatePools,
                   v3Candidates: v3CandidatePools,
                   v4Candidates: v4CandidatePools,
+                  mixedCrossLiquidityV3AgainstV4Supported:
+                    this.mixedCrossLiquidityV3AgainstV4Supported,
+                  chainId: this.chainId,
                 });
 
               return this.mixedQuoter

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -129,10 +129,12 @@ export type MixedCrossLiquidityCandidatePoolsParams = {
   v2SubgraphProvider: IV2SubgraphProvider;
   v3SubgraphProvider: IV3SubgraphProvider;
   v4SubgraphProvider: IV4SubgraphProvider;
+  chainId: ChainId;
   v2Candidates?: V2CandidatePools;
   v3Candidates?: V3CandidatePools;
   v4Candidates?: V4CandidatePools;
   blockNumber?: number | Promise<number>;
+  mixedCrossLiquidityV3AgainstV4Supported?: ChainId[];
 };
 
 export type V4GetCandidatePoolsParams = {
@@ -304,6 +306,8 @@ export async function getMixedCrossLiquidityCandidatePools({
   v2Candidates,
   v3Candidates,
   v4Candidates,
+  mixedCrossLiquidityV3AgainstV4Supported,
+  chainId,
 }: MixedCrossLiquidityCandidatePoolsParams): Promise<CrossLiquidityCandidatePools> {
   const v2Pools = (
     await v2SubgraphProvider.getPools(tokenIn, tokenOut, {
@@ -335,13 +339,16 @@ export async function getMixedCrossLiquidityCandidatePools({
     v2Candidates
   );
 
-  const v3AgainstV4SelectedPools = findCrossProtocolMissingPools(
-    tokenInAddress,
-    tokenOutAddress,
-    v3Pools,
-    v3Candidates,
-    v4Candidates
-  );
+  const v3AgainstV4SelectedPools =
+    mixedCrossLiquidityV3AgainstV4Supported?.includes(chainId)
+      ? findCrossProtocolMissingPools(
+          tokenInAddress,
+          tokenOutAddress,
+          v3Pools,
+          v3Candidates,
+          v4Candidates
+        )
+      : { forTokenIn: undefined, forTokenOut: undefined };
 
   // this is for deduplicate v3 pools, in case both v4 and v2 select the same v3 pools for tokenIn/tokenOut
   if (

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -129,7 +129,7 @@ export type MixedCrossLiquidityCandidatePoolsParams = {
   v2SubgraphProvider: IV2SubgraphProvider;
   v3SubgraphProvider: IV3SubgraphProvider;
   v4SubgraphProvider: IV4SubgraphProvider;
-  chainId: ChainId;
+  chainId?: ChainId;
   v2Candidates?: V2CandidatePools;
   v3Candidates?: V3CandidatePools;
   v4Candidates?: V4CandidatePools;
@@ -340,7 +340,7 @@ export async function getMixedCrossLiquidityCandidatePools({
   );
 
   const v3AgainstV4SelectedPools =
-    mixedCrossLiquidityV3AgainstV4Supported?.includes(chainId)
+    chainId && mixedCrossLiquidityV3AgainstV4Supported?.includes(chainId)
       ? findCrossProtocolMissingPools(
           tokenInAddress,
           tokenOutAddress,

--- a/src/util/chains.ts
+++ b/src/util/chains.ts
@@ -82,6 +82,8 @@ export const MIXED_SUPPORTED = [
   ChainId.SONEIUM,
 ];
 
+export const MIXED_CROSS_LIQUIDITY_V3_AGAINST_V4_SUPPORTED = [ChainId.BASE];
+
 export const HAS_L1_FEE = [
   ChainId.OPTIMISM,
   ChainId.OPTIMISM_GOERLI,

--- a/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
+++ b/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
@@ -1023,6 +1023,8 @@ describe('get candidate pools', () => {
           v2Candidates,
           v3Candidates,
           v4Candidates,
+          chainId: ChainId.BASE,
+          mixedCrossLiquidityV3AgainstV4Supported: [ChainId.BASE],
         });
 
         expect(crossLiquidityCandidatePools).toEqual({
@@ -1048,6 +1050,8 @@ describe('get candidate pools', () => {
             v2Candidates,
             v3Candidates,
             v4Candidates,
+            chainId: ChainId.BASE,
+            mixedCrossLiquidityV3AgainstV4Supported: [ChainId.BASE],
           });
 
           expect(crossLiquidityCandidatePools).toEqual({


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
cross liquidity v3 against v4 makes routing-api pipeline timing out on the mainnet

- **What is the new behavior (if this is a feature change)?**
we decided to limit cross liquidity v3 against v4 only on base

- **Other information**:
v3 agaainst v4 is really for base jacob/eth against zora creator pool