### PR TITLE
perf: extract previousTokenOut calculation outside loop

### DIFF
--- a/src/routers/alpha-router/functions/compute-all-routes.ts
+++ b/src/routers/alpha-router/functions/compute-all-routes.ts
@@ -214,13 +214,14 @@ export function computeAllRoutes<
       return;
     }
 
+    const previousTokenOut = _previousTokenOut ? _previousTokenOut : tokenIn;
+
     for (let i = 0; i < pools.length; i++) {
       if (poolsUsed[i]) {
         continue;
       }
 
       const curPool = pools[i]!;
-      const previousTokenOut = _previousTokenOut ? _previousTokenOut : tokenIn;
 
       if (!involvesToken(curPool, previousTokenOut)) {
         continue;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

performance optimization

- **What is the current behavior?** (You can also link to an open issue here)

`previousTokenOut` is calculated inside the loop on each iteration, causing redundant computation.

- **Changes**
Move `previousTokenOut` initialization before the `for` loop    
Reduce unnecessary ternary operation in recursive route computation