### PR TITLE
fix: pin npm to specific version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           scope: '@uniswap'
 
       - name: Install npm
-        run: npm install -g npm@latest --ignore-scripts
+        run: npm install -g npm@11.7.0 --ignore-scripts
 
       - name: Setup CI
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           scope: '@uniswap'
 
       - name: Install npm
-        run: npm install -g npm@11.7.0 --ignore-scripts
+        run: npm install -g github:npm/cli#6d1db8724b1d0e5457a87bb31e62e43d566348ce --ignore-scripts # npm@11.7.0
 
       - name: Setup CI
         run: npm ci


### PR DESCRIPTION
## Summary
Pin `npm@latest` to `npm@11.7.0` in the release workflow to prevent automatically pulling compromised versions of npm or its dependencies.

## What changed
- `.github/workflows/release.yml`: Changed `npm install -g npm@latest --ignore-scripts` to `npm install -g npm@11.7.0 --ignore-scripts`

## Motivation
The [axios npm supply chain compromise (2026-03-30)](https://github.com/nicedayzhu/axios) demonstrated the risk of using unpinned `@latest` tags in CI pipelines. An attacker who publishes a malicious version to npm can immediately compromise any workflow that installs `@latest`. Pinning to a known-good version eliminates this attack vector.

## Test plan
- [ ] Verify the release workflow still runs successfully with the pinned npm version
- [ ] Confirm `npm@11.7.0` is a valid, uncompromised release

🤖 Generated with [Claude Code](https://claude.com/claude-code)